### PR TITLE
Implement OData query options parsing and application

### DIFF
--- a/internal/query/applier.go
+++ b/internal/query/applier.go
@@ -1,0 +1,174 @@
+package query
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"gorm.io/gorm"
+)
+
+// ApplyQueryOptions applies parsed query options to a GORM database query
+func ApplyQueryOptions(db *gorm.DB, options *QueryOptions, entityMetadata *metadata.EntityMetadata) *gorm.DB {
+	if options == nil {
+		return db
+	}
+
+	// Apply filter
+	if options.Filter != nil {
+		db = applyFilter(db, options.Filter, entityMetadata)
+	}
+
+	// Apply orderby
+	if len(options.OrderBy) > 0 {
+		db = applyOrderBy(db, options.OrderBy, entityMetadata)
+	}
+
+	// Apply top and skip (for pagination)
+	if options.Skip != nil {
+		db = db.Offset(*options.Skip)
+	}
+
+	if options.Top != nil {
+		db = db.Limit(*options.Top)
+	}
+
+	return db
+}
+
+// applyFilter applies filter expressions to the GORM query
+func applyFilter(db *gorm.DB, filter *FilterExpression, entityMetadata *metadata.EntityMetadata) *gorm.DB {
+	if filter == nil {
+		return db
+	}
+
+	// Handle logical operators (and, or)
+	if filter.Logical != "" {
+		leftDB := applyFilter(db, filter.Left, entityMetadata)
+		rightDB := applyFilter(db, filter.Right, entityMetadata)
+
+		if filter.Logical == LogicalAnd {
+			// For AND, we can chain the conditions
+			return leftDB.Where(rightDB)
+		} else if filter.Logical == LogicalOr {
+			// For OR, we need to build a more complex query
+			// This is simplified and may need enhancement for complex cases
+			leftQuery, leftArgs := buildFilterCondition(filter.Left, entityMetadata)
+			rightQuery, rightArgs := buildFilterCondition(filter.Right, entityMetadata)
+
+			combinedQuery := fmt.Sprintf("(%s) OR (%s)", leftQuery, rightQuery)
+			combinedArgs := append(leftArgs, rightArgs...)
+
+			return db.Where(combinedQuery, combinedArgs...)
+		}
+	}
+
+	// Handle simple comparison operators
+	query, args := buildFilterCondition(filter, entityMetadata)
+	return db.Where(query, args...)
+}
+
+// buildFilterCondition builds a WHERE condition string and arguments for a filter expression
+func buildFilterCondition(filter *FilterExpression, entityMetadata *metadata.EntityMetadata) (string, []interface{}) {
+	if filter == nil {
+		return "", nil
+	}
+
+	// Handle logical operators recursively
+	if filter.Logical != "" {
+		leftQuery, leftArgs := buildFilterCondition(filter.Left, entityMetadata)
+		rightQuery, rightArgs := buildFilterCondition(filter.Right, entityMetadata)
+
+		if filter.Logical == LogicalAnd {
+			query := fmt.Sprintf("(%s) AND (%s)", leftQuery, rightQuery)
+			args := append(leftArgs, rightArgs...)
+			return query, args
+		} else if filter.Logical == LogicalOr {
+			query := fmt.Sprintf("(%s) OR (%s)", leftQuery, rightQuery)
+			args := append(leftArgs, rightArgs...)
+			return query, args
+		}
+	}
+
+	fieldName := GetPropertyFieldName(filter.Property, entityMetadata)
+
+	switch filter.Operator {
+	case OpEqual:
+		return fmt.Sprintf("%s = ?", fieldName), []interface{}{filter.Value}
+	case OpNotEqual:
+		return fmt.Sprintf("%s != ?", fieldName), []interface{}{filter.Value}
+	case OpGreaterThan:
+		return fmt.Sprintf("%s > ?", fieldName), []interface{}{filter.Value}
+	case OpGreaterThanOrEqual:
+		return fmt.Sprintf("%s >= ?", fieldName), []interface{}{filter.Value}
+	case OpLessThan:
+		return fmt.Sprintf("%s < ?", fieldName), []interface{}{filter.Value}
+	case OpLessThanOrEqual:
+		return fmt.Sprintf("%s <= ?", fieldName), []interface{}{filter.Value}
+	case OpContains:
+		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{"%" + fmt.Sprint(filter.Value) + "%"}
+	case OpStartsWith:
+		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{fmt.Sprint(filter.Value) + "%"}
+	case OpEndsWith:
+		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{"%" + fmt.Sprint(filter.Value)}
+	default:
+		return "", nil
+	}
+}
+
+// applyOrderBy applies order by clauses to the GORM query
+func applyOrderBy(db *gorm.DB, orderBy []OrderByItem, entityMetadata *metadata.EntityMetadata) *gorm.DB {
+	for _, item := range orderBy {
+		fieldName := GetPropertyFieldName(item.Property, entityMetadata)
+		direction := "ASC"
+		if item.Descending {
+			direction = "DESC"
+		}
+		db = db.Order(fmt.Sprintf("%s %s", fieldName, direction))
+	}
+	return db
+}
+
+// ApplySelect filters the result to only include selected properties
+// This is done after the query by modifying the result slice
+func ApplySelect(results interface{}, selectedProperties []string, entityMetadata *metadata.EntityMetadata) interface{} {
+	if len(selectedProperties) == 0 {
+		return results
+	}
+
+	// Get the slice value
+	sliceValue := reflect.ValueOf(results)
+	if sliceValue.Kind() != reflect.Slice {
+		return results
+	}
+
+	// Create a new slice of maps to hold the filtered results
+	filteredResults := make([]map[string]interface{}, sliceValue.Len())
+
+	for i := 0; i < sliceValue.Len(); i++ {
+		item := sliceValue.Index(i)
+		filteredItem := make(map[string]interface{})
+
+		// Extract only the selected properties
+		for _, propName := range selectedProperties {
+			propName = strings.TrimSpace(propName)
+
+			// Find the property in metadata
+			for _, prop := range entityMetadata.Properties {
+				if prop.JsonName == propName || prop.Name == propName {
+					// Get the field value
+					fieldValue := item.FieldByName(prop.Name)
+					if fieldValue.IsValid() && fieldValue.CanInterface() {
+						filteredItem[prop.JsonName] = fieldValue.Interface()
+					}
+					break
+				}
+			}
+		}
+
+		filteredResults[i] = filteredItem
+	}
+
+	return filteredResults
+}

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -1,0 +1,354 @@
+package query
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+// QueryOptions represents parsed OData query options
+type QueryOptions struct {
+	Filter  *FilterExpression
+	Select  []string
+	OrderBy []OrderByItem
+	Top     *int
+	Skip    *int
+}
+
+// OrderByItem represents a single orderby clause
+type OrderByItem struct {
+	Property   string
+	Descending bool
+}
+
+// FilterExpression represents a parsed filter expression
+type FilterExpression struct {
+	Property string
+	Operator FilterOperator
+	Value    interface{}
+	Left     *FilterExpression
+	Right    *FilterExpression
+	Logical  LogicalOperator
+}
+
+// FilterOperator represents filter comparison operators
+type FilterOperator string
+
+const (
+	OpEqual              FilterOperator = "eq"
+	OpNotEqual           FilterOperator = "ne"
+	OpGreaterThan        FilterOperator = "gt"
+	OpGreaterThanOrEqual FilterOperator = "ge"
+	OpLessThan           FilterOperator = "lt"
+	OpLessThanOrEqual    FilterOperator = "le"
+	OpContains           FilterOperator = "contains"
+	OpStartsWith         FilterOperator = "startswith"
+	OpEndsWith           FilterOperator = "endswith"
+)
+
+// LogicalOperator represents logical operators for combining filters
+type LogicalOperator string
+
+const (
+	LogicalAnd LogicalOperator = "and"
+	LogicalOr  LogicalOperator = "or"
+)
+
+// ParseQueryOptions parses OData query options from the URL
+func ParseQueryOptions(queryParams url.Values, entityMetadata *metadata.EntityMetadata) (*QueryOptions, error) {
+	options := &QueryOptions{}
+
+	// Parse $filter
+	if filterStr := queryParams.Get("$filter"); filterStr != "" {
+		filter, err := parseFilter(filterStr, entityMetadata)
+		if err != nil {
+			return nil, fmt.Errorf("invalid $filter: %w", err)
+		}
+		options.Filter = filter
+	}
+
+	// Parse $select
+	if selectStr := queryParams.Get("$select"); selectStr != "" {
+		options.Select = parseSelect(selectStr)
+	}
+
+	// Parse $orderby
+	if orderByStr := queryParams.Get("$orderby"); orderByStr != "" {
+		orderBy, err := parseOrderBy(orderByStr, entityMetadata)
+		if err != nil {
+			return nil, fmt.Errorf("invalid $orderby: %w", err)
+		}
+		options.OrderBy = orderBy
+	}
+
+	return options, nil
+}
+
+// parseSelect parses the $select query option
+func parseSelect(selectStr string) []string {
+	parts := strings.Split(selectStr, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// parseOrderBy parses the $orderby query option
+func parseOrderBy(orderByStr string, entityMetadata *metadata.EntityMetadata) ([]OrderByItem, error) {
+	parts := strings.Split(orderByStr, ",")
+	result := make([]OrderByItem, 0, len(parts))
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+
+		// Check for "desc" or "asc" suffix
+		tokens := strings.Fields(trimmed)
+		item := OrderByItem{
+			Property:   tokens[0],
+			Descending: false,
+		}
+
+		if len(tokens) > 1 {
+			direction := strings.ToLower(tokens[1])
+			if direction == "desc" {
+				item.Descending = true
+			} else if direction != "asc" {
+				return nil, fmt.Errorf("invalid direction '%s', expected 'asc' or 'desc'", tokens[1])
+			}
+		}
+
+		// Validate property exists
+		if !propertyExists(item.Property, entityMetadata) {
+			return nil, fmt.Errorf("property '%s' does not exist", item.Property)
+		}
+
+		result = append(result, item)
+	}
+
+	return result, nil
+}
+
+// parseFilter parses a filter expression
+// This is a simplified parser that handles basic filter expressions
+func parseFilter(filterStr string, entityMetadata *metadata.EntityMetadata) (*FilterExpression, error) {
+	filterStr = strings.TrimSpace(filterStr)
+
+	// Check for logical operators (and, or)
+	if idx := findLogicalOperator(filterStr); idx != -1 {
+		operator := getLogicalOperatorAt(filterStr, idx)
+		left := strings.TrimSpace(filterStr[:idx])
+		right := strings.TrimSpace(filterStr[idx+len(operator):])
+
+		leftExpr, err := parseFilter(left, entityMetadata)
+		if err != nil {
+			return nil, err
+		}
+
+		rightExpr, err := parseFilter(right, entityMetadata)
+		if err != nil {
+			return nil, err
+		}
+
+		return &FilterExpression{
+			Left:    leftExpr,
+			Right:   rightExpr,
+			Logical: LogicalOperator(operator),
+		}, nil
+	}
+
+	// Check for function calls (contains, startswith, endswith)
+	if strings.Contains(filterStr, "(") && strings.Contains(filterStr, ")") {
+		return parseFunctionFilter(filterStr, entityMetadata)
+	}
+
+	// Parse comparison expression (property operator value)
+	return parseComparisonFilter(filterStr, entityMetadata)
+}
+
+// findLogicalOperator finds the position of a logical operator (and/or) in the filter string
+// This is a simple implementation that doesn't handle nested parentheses properly
+func findLogicalOperator(filterStr string) int {
+	// Look for " and " or " or " (with spaces to avoid matching parts of property names)
+	andIdx := strings.Index(strings.ToLower(filterStr), " and ")
+	orIdx := strings.Index(strings.ToLower(filterStr), " or ")
+
+	if andIdx == -1 {
+		return orIdx
+	}
+	if orIdx == -1 {
+		return andIdx
+	}
+
+	// Return the first occurrence
+	if andIdx < orIdx {
+		return andIdx
+	}
+	return orIdx
+}
+
+// getLogicalOperatorAt returns the logical operator at the given position
+func getLogicalOperatorAt(filterStr string, idx int) string {
+	lower := strings.ToLower(filterStr)
+	if strings.HasPrefix(lower[idx:], " and ") {
+		return " and "
+	}
+	if strings.HasPrefix(lower[idx:], " or ") {
+		return " or "
+	}
+	return ""
+}
+
+// parseFunctionFilter parses function-based filters like contains(Name,'laptop')
+func parseFunctionFilter(filterStr string, entityMetadata *metadata.EntityMetadata) (*FilterExpression, error) {
+	// Extract function name
+	openParen := strings.Index(filterStr, "(")
+	if openParen == -1 {
+		return nil, fmt.Errorf("invalid function filter: %s", filterStr)
+	}
+
+	functionName := strings.ToLower(strings.TrimSpace(filterStr[:openParen]))
+	closeParen := strings.LastIndex(filterStr, ")")
+	if closeParen == -1 {
+		return nil, fmt.Errorf("invalid function filter: missing closing parenthesis")
+	}
+
+	args := filterStr[openParen+1 : closeParen]
+	parts := splitFunctionArgs(args)
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("function %s requires 2 arguments", functionName)
+	}
+
+	property := strings.TrimSpace(parts[0])
+	value := strings.Trim(strings.TrimSpace(parts[1]), "'\"")
+
+	// Validate property exists
+	if !propertyExists(property, entityMetadata) {
+		return nil, fmt.Errorf("property '%s' does not exist", property)
+	}
+
+	var operator FilterOperator
+	switch functionName {
+	case "contains":
+		operator = OpContains
+	case "startswith":
+		operator = OpStartsWith
+	case "endswith":
+		operator = OpEndsWith
+	default:
+		return nil, fmt.Errorf("unsupported function: %s", functionName)
+	}
+
+	return &FilterExpression{
+		Property: property,
+		Operator: operator,
+		Value:    value,
+	}, nil
+}
+
+// splitFunctionArgs splits function arguments by comma
+func splitFunctionArgs(args string) []string {
+	result := make([]string, 0)
+	current := ""
+	inQuotes := false
+	quoteChar := rune(0)
+
+	for _, ch := range args {
+		if ch == '\'' || ch == '"' {
+			if !inQuotes {
+				inQuotes = true
+				quoteChar = ch
+			} else if ch == quoteChar {
+				inQuotes = false
+				quoteChar = 0
+			}
+			current += string(ch)
+		} else if ch == ',' && !inQuotes {
+			result = append(result, current)
+			current = ""
+		} else {
+			current += string(ch)
+		}
+	}
+
+	if current != "" {
+		result = append(result, current)
+	}
+
+	return result
+}
+
+// parseComparisonFilter parses comparison filters like "Price gt 100"
+func parseComparisonFilter(filterStr string, entityMetadata *metadata.EntityMetadata) (*FilterExpression, error) {
+	// Split by spaces to find operator
+	tokens := strings.Fields(filterStr)
+	if len(tokens) < 3 {
+		return nil, fmt.Errorf("invalid filter expression: %s", filterStr)
+	}
+
+	property := tokens[0]
+	operator := strings.ToLower(tokens[1])
+	value := strings.Join(tokens[2:], " ")
+
+	// Validate property exists
+	if !propertyExists(property, entityMetadata) {
+		return nil, fmt.Errorf("property '%s' does not exist", property)
+	}
+
+	// Remove quotes from string values
+	value = strings.Trim(value, "'\"")
+
+	// Validate operator
+	var op FilterOperator
+	switch operator {
+	case "eq":
+		op = OpEqual
+	case "ne":
+		op = OpNotEqual
+	case "gt":
+		op = OpGreaterThan
+	case "ge":
+		op = OpGreaterThanOrEqual
+	case "lt":
+		op = OpLessThan
+	case "le":
+		op = OpLessThanOrEqual
+	default:
+		return nil, fmt.Errorf("unsupported operator: %s", operator)
+	}
+
+	return &FilterExpression{
+		Property: property,
+		Operator: op,
+		Value:    value,
+	}, nil
+}
+
+// propertyExists checks if a property exists in the entity metadata
+func propertyExists(propertyName string, entityMetadata *metadata.EntityMetadata) bool {
+	for _, prop := range entityMetadata.Properties {
+		if prop.JsonName == propertyName || prop.Name == propertyName {
+			return true
+		}
+	}
+	return false
+}
+
+// GetPropertyFieldName returns the struct field name for a given JSON property name
+func GetPropertyFieldName(propertyName string, entityMetadata *metadata.EntityMetadata) string {
+	for _, prop := range entityMetadata.Properties {
+		if prop.JsonName == propertyName || prop.Name == propertyName {
+			return prop.JsonName
+		}
+	}
+	return propertyName
+}

--- a/internal/query/parser_test.go
+++ b/internal/query/parser_test.go
@@ -1,0 +1,441 @@
+package query
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+type TestEntity struct {
+	ID          int     `json:"ID" odata:"key"`
+	Name        string  `json:"Name"`
+	Description string  `json:"Description"`
+	Price       float64 `json:"Price"`
+	Category    string  `json:"Category"`
+}
+
+func getTestMetadata(t *testing.T) *metadata.EntityMetadata {
+	meta, err := metadata.AnalyzeEntity(TestEntity{})
+	if err != nil {
+		t.Fatalf("Failed to analyze entity: %v", err)
+	}
+	return meta
+}
+
+func TestParseSelect(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectStr string
+		expected  []string
+	}{
+		{
+			name:      "Single property",
+			selectStr: "Name",
+			expected:  []string{"Name"},
+		},
+		{
+			name:      "Multiple properties",
+			selectStr: "Name,Price,Category",
+			expected:  []string{"Name", "Price", "Category"},
+		},
+		{
+			name:      "Properties with spaces",
+			selectStr: "Name, Price, Category",
+			expected:  []string{"Name", "Price", "Category"},
+		},
+		{
+			name:      "Empty string",
+			selectStr: "",
+			expected:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSelect(tt.selectStr)
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d properties, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, prop := range result {
+				if prop != tt.expected[i] {
+					t.Errorf("Expected property %s at index %d, got %s", tt.expected[i], i, prop)
+				}
+			}
+		})
+	}
+}
+
+func TestParseOrderBy(t *testing.T) {
+	meta := getTestMetadata(t)
+
+	tests := []struct {
+		name       string
+		orderByStr string
+		expected   []OrderByItem
+		expectErr  bool
+	}{
+		{
+			name:       "Single property ascending",
+			orderByStr: "Name asc",
+			expected:   []OrderByItem{{Property: "Name", Descending: false}},
+			expectErr:  false,
+		},
+		{
+			name:       "Single property descending",
+			orderByStr: "Price desc",
+			expected:   []OrderByItem{{Property: "Price", Descending: true}},
+			expectErr:  false,
+		},
+		{
+			name:       "Single property no direction",
+			orderByStr: "Name",
+			expected:   []OrderByItem{{Property: "Name", Descending: false}},
+			expectErr:  false,
+		},
+		{
+			name:       "Multiple properties",
+			orderByStr: "Category asc, Price desc",
+			expected: []OrderByItem{
+				{Property: "Category", Descending: false},
+				{Property: "Price", Descending: true},
+			},
+			expectErr: false,
+		},
+		{
+			name:       "Invalid property",
+			orderByStr: "InvalidProperty asc",
+			expected:   nil,
+			expectErr:  true,
+		},
+		{
+			name:       "Invalid direction",
+			orderByStr: "Name invalid",
+			expected:   nil,
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseOrderBy(tt.orderByStr, meta)
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d items, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, item := range result {
+				if item.Property != tt.expected[i].Property {
+					t.Errorf("Expected property %s at index %d, got %s", tt.expected[i].Property, i, item.Property)
+				}
+				if item.Descending != tt.expected[i].Descending {
+					t.Errorf("Expected descending=%v at index %d, got %v", tt.expected[i].Descending, i, item.Descending)
+				}
+			}
+		})
+	}
+}
+
+func TestParseComparisonFilter(t *testing.T) {
+	meta := getTestMetadata(t)
+
+	tests := []struct {
+		name      string
+		filterStr string
+		expectErr bool
+		operator  FilterOperator
+		property  string
+		value     string
+	}{
+		{
+			name:      "Equal operator",
+			filterStr: "Name eq 'Laptop'",
+			expectErr: false,
+			operator:  OpEqual,
+			property:  "Name",
+			value:     "Laptop",
+		},
+		{
+			name:      "Greater than operator",
+			filterStr: "Price gt 100",
+			expectErr: false,
+			operator:  OpGreaterThan,
+			property:  "Price",
+			value:     "100",
+		},
+		{
+			name:      "Less than or equal operator",
+			filterStr: "Price le 999.99",
+			expectErr: false,
+			operator:  OpLessThanOrEqual,
+			property:  "Price",
+			value:     "999.99",
+		},
+		{
+			name:      "Not equal operator",
+			filterStr: "Category ne 'Electronics'",
+			expectErr: false,
+			operator:  OpNotEqual,
+			property:  "Category",
+			value:     "Electronics",
+		},
+		{
+			name:      "Invalid property",
+			filterStr: "InvalidProp eq 'value'",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid operator",
+			filterStr: "Name invalid 'value'",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseComparisonFilter(tt.filterStr, meta)
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if result.Operator != tt.operator {
+				t.Errorf("Expected operator %s, got %s", tt.operator, result.Operator)
+			}
+			if result.Property != tt.property {
+				t.Errorf("Expected property %s, got %s", tt.property, result.Property)
+			}
+			if result.Value != tt.value {
+				t.Errorf("Expected value %s, got %v", tt.value, result.Value)
+			}
+		})
+	}
+}
+
+func TestParseFunctionFilter(t *testing.T) {
+	meta := getTestMetadata(t)
+
+	tests := []struct {
+		name      string
+		filterStr string
+		expectErr bool
+		operator  FilterOperator
+		property  string
+		value     string
+	}{
+		{
+			name:      "Contains function",
+			filterStr: "contains(Name,'laptop')",
+			expectErr: false,
+			operator:  OpContains,
+			property:  "Name",
+			value:     "laptop",
+		},
+		{
+			name:      "StartsWith function",
+			filterStr: "startswith(Category,'Elec')",
+			expectErr: false,
+			operator:  OpStartsWith,
+			property:  "Category",
+			value:     "Elec",
+		},
+		{
+			name:      "EndsWith function",
+			filterStr: "endswith(Description,'technology')",
+			expectErr: false,
+			operator:  OpEndsWith,
+			property:  "Description",
+			value:     "technology",
+		},
+		{
+			name:      "Contains with spaces",
+			filterStr: "contains(Name, 'test value')",
+			expectErr: false,
+			operator:  OpContains,
+			property:  "Name",
+			value:     "test value",
+		},
+		{
+			name:      "Invalid property",
+			filterStr: "contains(InvalidProp,'value')",
+			expectErr: true,
+		},
+		{
+			name:      "Unsupported function",
+			filterStr: "unsupported(Name,'value')",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseFunctionFilter(tt.filterStr, meta)
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if result.Operator != tt.operator {
+				t.Errorf("Expected operator %s, got %s", tt.operator, result.Operator)
+			}
+			if result.Property != tt.property {
+				t.Errorf("Expected property %s, got %s", tt.property, result.Property)
+			}
+			if result.Value != tt.value {
+				t.Errorf("Expected value %s, got %v", tt.value, result.Value)
+			}
+		})
+	}
+}
+
+func TestParseQueryOptions(t *testing.T) {
+	meta := getTestMetadata(t)
+
+	tests := []struct {
+		name      string
+		query     string
+		expectErr bool
+		validate  func(*testing.T, *QueryOptions)
+	}{
+		{
+			name:      "Filter only",
+			query:     "$filter=Price gt 100",
+			expectErr: false,
+			validate: func(t *testing.T, opts *QueryOptions) {
+				if opts.Filter == nil {
+					t.Error("Expected filter to be set")
+				}
+			},
+		},
+		{
+			name:      "Select only",
+			query:     "$select=Name,Price",
+			expectErr: false,
+			validate: func(t *testing.T, opts *QueryOptions) {
+				if len(opts.Select) != 2 {
+					t.Errorf("Expected 2 selected properties, got %d", len(opts.Select))
+				}
+			},
+		},
+		{
+			name:      "OrderBy only",
+			query:     "$orderby=Price desc",
+			expectErr: false,
+			validate: func(t *testing.T, opts *QueryOptions) {
+				if len(opts.OrderBy) != 1 {
+					t.Errorf("Expected 1 orderby item, got %d", len(opts.OrderBy))
+				}
+			},
+		},
+		{
+			name:      "All options combined",
+			query:     "$filter=Price gt 100&$select=Name,Price&$orderby=Name asc",
+			expectErr: false,
+			validate: func(t *testing.T, opts *QueryOptions) {
+				if opts.Filter == nil {
+					t.Error("Expected filter to be set")
+				}
+				if len(opts.Select) != 2 {
+					t.Errorf("Expected 2 selected properties, got %d", len(opts.Select))
+				}
+				if len(opts.OrderBy) != 1 {
+					t.Errorf("Expected 1 orderby item, got %d", len(opts.OrderBy))
+				}
+			},
+		},
+		{
+			name:      "Invalid filter",
+			query:     "$filter=InvalidProperty eq 'value'",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid orderby",
+			query:     "$orderby=InvalidProperty desc",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queryValues, _ := url.ParseQuery(tt.query)
+			result, err := ParseQueryOptions(queryValues, meta)
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}
+
+func TestSplitFunctionArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		expected []string
+	}{
+		{
+			name:     "Two simple args",
+			args:     "Name,'value'",
+			expected: []string{"Name", "'value'"},
+		},
+		{
+			name:     "Args with spaces",
+			args:     "Name, 'value with spaces'",
+			expected: []string{"Name", " 'value with spaces'"},
+		},
+		{
+			name:     "Args with comma in quotes",
+			args:     "Name,'value, with, commas'",
+			expected: []string{"Name", "'value, with, commas'"},
+		},
+		{
+			name:     "Single arg",
+			args:     "Name",
+			expected: []string{"Name"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitFunctionArgs(tt.args)
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d args, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, arg := range result {
+				if arg != tt.expected[i] {
+					t.Errorf("Expected arg %s at index %d, got %s", tt.expected[i], i, arg)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Added query options parsing in the `parser.go` file to handle $filter, $select, and $orderby parameters.
- Introduced `ApplyQueryOptions` function in `applier.go` to apply parsed query options to GORM database queries.
- Enhanced `HandleCollection` method in `entity.go` to utilize query options for filtering, selecting, and ordering results.
- Created comprehensive unit tests for query options parsing and application in `parser_test.go` and `handlers_test.go`.
- Added support for filtering, selecting specific fields, and ordering results in the OData response.