### PR TITLE
Refactor entity response helper for flexible statuses

### DIFF
--- a/internal/handlers/singleton.go
+++ b/internal/handlers/singleton.go
@@ -55,7 +55,7 @@ func (h *EntityHandler) handleGetSingleton(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Write the singleton entity response
-	h.writeEntityResponseWithETag(w, r, entityInstance, "")
+	h.writeEntityResponseWithETag(w, r, entityInstance, "", http.StatusOK)
 }
 
 // handlePatchSingleton handles PATCH requests for singleton entities (partial update)


### PR DESCRIPTION
## Summary
- allow `writeEntityResponseWithETag` to accept a status code while keeping metadata and ETag handling centralized
- reuse the helper for POST and update responses so success payloads share content negotiation and header logic
- adjust singleton responses to call the updated helper for consistency

## Testing
- go test ./internal/handlers
- golangci-lint run ./...
- go build ./...
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f7d0a52bac8328aa24163821c8f951