### PR TITLE
Improve batch boundary generation

### DIFF
--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"bufio"
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"mime"
@@ -10,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 
 	"github.com/nlstn/go-odata/internal/response"
 	"gorm.io/gorm"
@@ -407,6 +410,13 @@ func (h *BatchHandler) writeBatchResponse(w http.ResponseWriter, responses []bat
 
 // generateBoundary generates a random boundary string
 func generateBoundary() string {
-	// Simple boundary generation - in production, use crypto/rand
-	return "36d5c8c6-3e8a-4b3e-9b5f-7c8d9e0f1a2b"
+	const boundaryBytes = 18
+
+	buf := make([]byte, boundaryBytes)
+	if _, err := rand.Read(buf); err != nil {
+		// Fallback to time-based boundary if the crypto reader fails
+		return fmt.Sprintf("fallback-%d", time.Now().UnixNano())
+	}
+
+	return hex.EncodeToString(buf)
 }

--- a/internal/handlers/batch_test.go
+++ b/internal/handlers/batch_test.go
@@ -227,6 +227,22 @@ Accept: application/json
 	}
 }
 
+func TestGenerateBoundaryProducesUniqueValues(t *testing.T) {
+	boundaries := make(map[string]struct{})
+
+	for i := 0; i < 10; i++ {
+		boundary := generateBoundary()
+		if boundary == "" {
+			t.Fatalf("expected boundary to be non-empty")
+		}
+
+		if _, exists := boundaries[boundary]; exists {
+			t.Fatalf("duplicate boundary generated: %s", boundary)
+		}
+		boundaries[boundary] = struct{}{}
+	}
+}
+
 func TestBatchHandler_Changeset(t *testing.T) {
 	handler, db, _ := setupBatchTestHandler(t)
 


### PR DESCRIPTION
## Summary
- replace the hard-coded batch multipart boundary with a randomly generated value and safe fallback
- add a unit test that ensures batch boundary values are non-empty and unique within a run

## Testing
- go test ./...
- go build ./...
- golangci-lint run ./...


------
https://chatgpt.com/codex/tasks/task_e_68f8c4cf70cc83289bf8e44012c61e95