### PR TITLE
Add read hook metadata detection

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -55,3 +55,22 @@ type EntityHooks interface {
 	// Any error returned will be logged but won't affect the response to the client.
 	AfterDelete(ctx context.Context, r *http.Request) error
 }
+
+// Additional optional read hooks can be implemented on entity types with the following signatures:
+//
+//  // BeforeReadCollection lets you add GORM scopes to the underlying query before it is executed.
+//  func (Product) BeforeReadCollection(ctx context.Context, r *http.Request, opts *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error)
+//
+//  // AfterReadCollection lets you replace or mutate the collection returned to the client.
+//  func (Product) AfterReadCollection(ctx context.Context, r *http.Request, opts *query.QueryOptions, results interface{}) (interface{}, error)
+//
+//  // BeforeReadEntity lets you add GORM scopes before reading a single entity.
+//  func (Product) BeforeReadEntity(ctx context.Context, r *http.Request, opts *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error)
+//
+//  // AfterReadEntity lets you replace or mutate the entity returned to the client.
+//  func (Product) AfterReadEntity(ctx context.Context, r *http.Request, opts *query.QueryOptions, entity interface{}) (interface{}, error)
+//
+// All read hooks receive the same context, HTTP request, and parsed OData query options that the handler uses.
+// Before* hooks return additional GORM scopes to apply (`nil` means no extra scopes), while After* hooks
+// receive the fetched data and can return a replacement value. In every case, returning a non-nil error aborts
+// the request processing with that error.

--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -19,12 +19,16 @@ type EntityMetadata struct {
 	SingletonName string             // Name of the singleton (if IsSingleton is true)
 	// Hooks defines which lifecycle hooks are available on this entity
 	Hooks struct {
-		HasBeforeCreate bool
-		HasAfterCreate  bool
-		HasBeforeUpdate bool
-		HasAfterUpdate  bool
-		HasBeforeDelete bool
-		HasAfterDelete  bool
+		HasBeforeCreate         bool
+		HasAfterCreate          bool
+		HasBeforeUpdate         bool
+		HasAfterUpdate          bool
+		HasBeforeDelete         bool
+		HasAfterDelete          bool
+		HasBeforeReadCollection bool
+		HasAfterReadCollection  bool
+		HasBeforeReadEntity     bool
+		HasAfterReadEntity      bool
 	}
 }
 
@@ -468,6 +472,26 @@ func detectHooks(metadata *EntityMetadata) {
 	// Check AfterDelete
 	if hasMethod(valueType, "AfterDelete") || hasMethod(ptrType, "AfterDelete") {
 		metadata.Hooks.HasAfterDelete = true
+	}
+
+	// Check BeforeReadCollection
+	if hasMethod(valueType, "BeforeReadCollection") || hasMethod(ptrType, "BeforeReadCollection") {
+		metadata.Hooks.HasBeforeReadCollection = true
+	}
+
+	// Check AfterReadCollection
+	if hasMethod(valueType, "AfterReadCollection") || hasMethod(ptrType, "AfterReadCollection") {
+		metadata.Hooks.HasAfterReadCollection = true
+	}
+
+	// Check BeforeReadEntity
+	if hasMethod(valueType, "BeforeReadEntity") || hasMethod(ptrType, "BeforeReadEntity") {
+		metadata.Hooks.HasBeforeReadEntity = true
+	}
+
+	// Check AfterReadEntity
+	if hasMethod(valueType, "AfterReadEntity") || hasMethod(ptrType, "AfterReadEntity") {
+		metadata.Hooks.HasAfterReadEntity = true
 	}
 }
 

--- a/internal/metadata/hooks_detection_test.go
+++ b/internal/metadata/hooks_detection_test.go
@@ -1,0 +1,51 @@
+package metadata_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/query"
+	"gorm.io/gorm"
+)
+
+type testReadHooksEntity struct {
+	ID int `json:"id" odata:"key"`
+}
+
+func (testReadHooksEntity) BeforeReadCollection(ctx context.Context, r *http.Request, opts *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error) {
+	return nil, nil
+}
+
+func (testReadHooksEntity) AfterReadCollection(ctx context.Context, r *http.Request, opts *query.QueryOptions, results interface{}) (interface{}, error) {
+	return results, nil
+}
+
+func (*testReadHooksEntity) BeforeReadEntity(ctx context.Context, r *http.Request, opts *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error) {
+	return nil, nil
+}
+
+func (*testReadHooksEntity) AfterReadEntity(ctx context.Context, r *http.Request, opts *query.QueryOptions, entity interface{}) (interface{}, error) {
+	return entity, nil
+}
+
+func TestDetectReadHooks(t *testing.T) {
+	meta, err := metadata.AnalyzeEntity(testReadHooksEntity{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity(testReadHooksEntity) returned error: %v", err)
+	}
+
+	if !meta.Hooks.HasBeforeReadCollection {
+		t.Errorf("expected HasBeforeReadCollection to be true")
+	}
+	if !meta.Hooks.HasAfterReadCollection {
+		t.Errorf("expected HasAfterReadCollection to be true")
+	}
+	if !meta.Hooks.HasBeforeReadEntity {
+		t.Errorf("expected HasBeforeReadEntity to be true")
+	}
+	if !meta.Hooks.HasAfterReadEntity {
+		t.Errorf("expected HasAfterReadEntity to be true")
+	}
+}


### PR DESCRIPTION
## Summary
- add read hook availability flags to entity metadata and detect matching methods
- document the expected read hook signatures for developers
- add unit coverage that verifies detection of the new read hooks

## Testing
- golangci-lint run ./...
- go test ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68ffdc5eb0e08328875559e56763573a