### PR TITLE
refactor: centralize OData version constant

### DIFF
--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -330,7 +330,7 @@ func (h *BatchHandler) createErrorResponse(statusCode int, message string) batch
 	errorBody := fmt.Sprintf(`{"error":{"code":"%d","message":"%s"}}`, statusCode, message)
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
-	headers[HeaderODataVersion] = []string{ODataVersionValue}
+	headers[HeaderODataVersion] = []string{response.ODataVersionValue}
 
 	return batchResponse{
 		StatusCode: statusCode,

--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -12,13 +12,6 @@ const (
 	HeaderODataEntityId     = "OData-EntityId"
 )
 
-// OData version constants
-const (
-	// ODataVersionValue is the OData protocol version this library implements
-	// Currently supporting OData v4.01 with backward compatibility for v4.0
-	ODataVersionValue = "4.01"
-)
-
 // Content type constants
 const (
 	ContentTypeJSON      = "application/json;odata.metadata=minimal"

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -30,7 +30,7 @@ func SetODataHeader(w http.ResponseWriter, key, value string) {
 // SetODataVersionHeader sets the OData-Version header with the correct version value.
 // This centralizes the version header setting to ensure consistency across all responses.
 func SetODataVersionHeader(w http.ResponseWriter) {
-	SetODataHeader(w, HeaderODataVersion, ODataVersionValue)
+	SetODataHeader(w, HeaderODataVersion, response.ODataVersionValue)
 }
 
 // buildKeyQuery builds a GORM query with WHERE conditions for the entity key(s)

--- a/internal/handlers/metadata.go
+++ b/internal/handlers/metadata.go
@@ -229,7 +229,7 @@ func (h *MetadataHandler) buildMetadataDocument() string {
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="%s">
   <edmx:DataServices>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ODataService">
-`, ODataVersionValue)
+`, response.ODataVersionValue)
 
 	// Add enum types
 	metadata += h.buildEnumTypes()
@@ -485,7 +485,7 @@ func (h *MetadataHandler) buildMetadataJSON() []byte {
 	// Build CSDL JSON structure
 	odataService := make(map[string]interface{})
 	csdl := map[string]interface{}{
-		"$Version":     ODataVersionValue,
+		"$Version":     response.ODataVersionValue,
 		"ODataService": odataService,
 	}
 


### PR DESCRIPTION
## Summary
- remove the duplicate ODataVersionValue constant from the handlers package
- update handlers to reference the shared response.ODataVersionValue constant

## Testing
- gofmt -w internal/handlers/constants.go internal/handlers/helpers.go internal/handlers/batch.go internal/handlers/metadata.go
- go test ./...
- golangci-lint run ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_69008241f7a883288fb4c301599678ce