### PR TITLE
docs: describe read hooks capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Go library for building services that expose OData v4 APIs with automatic hand
 - 🔍 **Rich querying** - Supports all OData query options ($filter, $select, $expand, etc.)
 - 💾 **GORM integration** - Works with any GORM-compatible database
 - 🔒 **Optimistic concurrency** - Built-in ETag support
+- 🧰 **Lifecycle & read hooks** - Inject business logic, tenant filters, and response redaction
 - 🎯 **Custom operations** - Easy registration of actions and functions
 - 📊 **Data aggregation** - Supports $apply transformations
 - 🧪 **Fully tested** - 85+ compliance tests ensuring OData v4 adherence
@@ -88,7 +89,7 @@ This creates a fully functional OData v4 service accessible at `http://localhost
 - **[Entity Definition](documentation/entities.md)** - Define entities with rich metadata and relationships
 - **[Server Configuration](documentation/server-configuration.md)** - Configure the service, add middleware, and integrate with your application
 - **[Actions and Functions](documentation/actions-and-functions.md)** - Implement custom OData operations
-- **[Advanced Features](documentation/advanced-features.md)** - Singletons, ETags, and lifecycle hooks
+- **[Advanced Features](documentation/advanced-features.md)** - Singletons, ETags, lifecycle hooks, and read hooks for tenant filtering or redaction
 - **[Testing](documentation/testing.md)** - Unit tests, compliance tests, and performance profiling
 
 ## What You Get

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,7 +12,7 @@ Welcome to the go-odata documentation! This directory contains detailed guides f
 ### Advanced Usage
 
 - **[Actions and Functions](actions-and-functions.md)** - Implement custom OData operations beyond standard CRUD
-- **[Advanced Features](advanced-features.md)** - Use singletons, ETags for concurrency control, and lifecycle hooks
+- **[Advanced Features](advanced-features.md)** - Use singletons, ETags for concurrency control, lifecycle hooks, and read hooks for authorization/redaction
 
 ### Testing & Development
 
@@ -57,7 +57,7 @@ Extend your service with custom operations. Learn about:
 Leverage powerful OData v4 features:
 - **Singletons**: Single-instance entities accessible by name
 - **ETags**: Optimistic concurrency control for safe updates
-- **Lifecycle Hooks**: Execute custom logic at specific points in entity lifecycle
+- **Lifecycle & Read Hooks**: Execute custom logic at specific points in entity lifecycle, add tenant filters, or redact responses before returning data
 
 ### Testing
 Ensure your OData service works correctly:


### PR DESCRIPTION
## Summary
- document the before/after read hooks in the advanced features guide with tenant filtering and response redaction examples
- highlight read hook capabilities in the documentation overview and the project README so they are easier to discover
- add entity guide guidance on how read hooks interact with query options, pagination, and $count

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_690087bddd0c8328b4b40c1877ecfb3b