### PR TITLE
Fix function response context metadata for declared return types

### DIFF
--- a/documentation/actions-and-functions.md
+++ b/documentation/actions-and-functions.md
@@ -55,7 +55,7 @@ GET /GetTopProducts?count=3
 **Response:**
 ```json
 {
-  "@odata.context": "$metadata#Edm.String",
+  "@odata.context": "$metadata#Products",
   "value": [
     {"ID": 1, "Name": "Laptop", "Price": 999.99},
     {"ID": 5, "Name": "Smartphone", "Price": 799.99},
@@ -93,7 +93,7 @@ GET /Products(1)/GetTotalPrice?taxRate=0.08
 **Response:**
 ```json
 {
-  "@odata.context": "$metadata#Edm.String",
+  "@odata.context": "$metadata#Edm.Double",
   "value": 1079.99
 }
 ```


### PR DESCRIPTION
## Summary
- generate @odata.context fragments for functions based on the declared return type, including entity sets and complex types
- reject unsupported media types before encoding function responses and omit @odata.context when metadata=none
- add regression tests covering primitive, entity, collection, and metadata=none scenarios and update documentation examples

## Testing
- go test ./...
- golangci-lint run ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_69008d4d4d1c832898c7dadea9feaca0