### PR TITLE
Add OData complex property request handling

### DIFF
--- a/internal/handlers/properties.go
+++ b/internal/handlers/properties.go
@@ -381,6 +381,96 @@ func (h *EntityHandler) IsComplexTypeProperty(propertyName string) bool {
 	return h.findComplexTypeProperty(propertyName) != nil
 }
 
+// HandleComplexTypeProperty handles GET, HEAD, and OPTIONS requests for complex type properties (e.g., Products(1)/ShippingAddress)
+// propertySegments represents the navigation path segments without $value/$ref/$count (e.g., ["ShippingAddress", "City"]).
+func (h *EntityHandler) HandleComplexTypeProperty(w http.ResponseWriter, r *http.Request, entityKey string, propertySegments []string, isValue bool) {
+	if len(propertySegments) == 0 {
+		h.writePropertyNotFoundError(w, "")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		h.handleGetComplexTypeProperty(w, r, entityKey, propertySegments, isValue)
+	case http.MethodOptions:
+		h.handleOptionsComplexTypeProperty(w)
+	default:
+		h.writeMethodNotAllowedError(w, r.Method, "complex property access")
+	}
+}
+
+// handleGetComplexTypeProperty resolves and writes a complex type property response
+func (h *EntityHandler) handleGetComplexTypeProperty(w http.ResponseWriter, r *http.Request, entityKey string, propertySegments []string, isValue bool) {
+	rootName := propertySegments[0]
+	complexProp := h.findComplexTypeProperty(rootName)
+	if complexProp == nil {
+		h.writePropertyNotFoundError(w, rootName)
+		return
+	}
+
+	if len(propertySegments) == 1 && isValue {
+		if err := response.WriteError(w, http.StatusBadRequest, "Invalid request",
+			"$value is not supported on complex properties"); err != nil {
+			fmt.Printf(LogMsgErrorWritingErrorResponse, err)
+		}
+		return
+	}
+
+	fieldValue, err := h.fetchComplexPropertyValue(w, entityKey, complexProp)
+	if err != nil {
+		return
+	}
+
+	// Handle root null complex property
+	if isNilPointer(fieldValue) {
+		h.writeNoContentForNullComplex(w, r)
+		return
+	}
+
+	// Prepare traversal state
+	contextSegments := []string{complexProp.JsonName}
+	currentValue := dereferenceValue(fieldValue)
+	currentType := dereferenceType(complexProp.Type)
+
+	// Traverse nested segments, if any
+	for idx, segment := range propertySegments[1:] {
+		resolved, resolvedType, resolvedJSONName, ok := resolveStructField(currentValue, segment)
+		if !ok {
+			// Support maps as well as structs
+			if currentValue.Kind() == reflect.Map {
+				resolved, resolvedType, resolvedJSONName, ok = resolveMapField(currentValue, segment)
+			}
+		}
+
+		if !ok {
+			h.writePropertyNotFoundError(w, segment)
+			return
+		}
+
+		contextSegments = append(contextSegments, resolvedJSONName)
+		currentValue = resolved
+		currentType = resolvedType
+
+		// If there are more segments to traverse, ensure we can continue
+		if idx < len(propertySegments[1:])-1 {
+			if isNilPointer(currentValue) {
+				h.writeComplexSegmentNullError(w, contextSegments)
+				return
+			}
+			currentValue = dereferenceValue(currentValue)
+			currentType = dereferenceType(currentType)
+		}
+	}
+
+	h.writeResolvedComplexValue(w, r, entityKey, contextSegments, currentValue, currentType, isValue)
+}
+
+// handleOptionsComplexTypeProperty handles OPTIONS requests for complex properties
+func (h *EntityHandler) handleOptionsComplexTypeProperty(w http.ResponseWriter) {
+	w.Header().Set("Allow", "GET, HEAD, OPTIONS")
+	w.WriteHeader(http.StatusOK)
+}
+
 // HandleStructuralProperty handles GET and OPTIONS requests for structural properties (e.g., Products(1)/Name)
 // When isValue is true, returns the raw property value without JSON wrapper (e.g., Products(1)/Name/$value)
 func (h *EntityHandler) HandleStructuralProperty(w http.ResponseWriter, r *http.Request, entityKey string, propertyName string, isValue bool) {
@@ -421,6 +511,352 @@ func (h *EntityHandler) handleGetStructuralProperty(w http.ResponseWriter, r *ht
 func (h *EntityHandler) handleOptionsStructuralProperty(w http.ResponseWriter) {
 	w.Header().Set("Allow", "GET, HEAD, OPTIONS")
 	w.WriteHeader(http.StatusOK)
+}
+
+// fetchComplexPropertyValue fetches a complex property value from an entity without applying select clauses
+func (h *EntityHandler) fetchComplexPropertyValue(w http.ResponseWriter, entityKey string, prop *metadata.PropertyMetadata) (reflect.Value, error) {
+	entity := reflect.New(h.metadata.EntityType).Interface()
+	db, err := h.buildKeyQuery(entityKey)
+	if err != nil {
+		if writeErr := response.WriteError(w, http.StatusBadRequest, ErrMsgInvalidKey, err.Error()); writeErr != nil {
+			fmt.Printf(LogMsgErrorWritingErrorResponse, writeErr)
+		}
+		return reflect.Value{}, err
+	}
+
+	if err := db.First(entity).Error; err != nil {
+		h.handlePropertyFetchError(w, err, entityKey)
+		return reflect.Value{}, err
+	}
+
+	entityValue := reflect.ValueOf(entity).Elem()
+	fieldValue := entityValue.FieldByName(prop.Name)
+	if !fieldValue.IsValid() {
+		if writeErr := response.WriteError(w, http.StatusInternalServerError, ErrMsgInternalError,
+			"Could not access complex property"); writeErr != nil {
+			fmt.Printf(LogMsgErrorWritingErrorResponse, writeErr)
+		}
+		return reflect.Value{}, fmt.Errorf("invalid field")
+	}
+
+	return fieldValue, nil
+}
+
+// writeNoContentForNullComplex writes a 204 No Content response for null complex properties
+func (h *EntityHandler) writeNoContentForNullComplex(w http.ResponseWriter, r *http.Request) {
+	metadataLevel := response.GetODataMetadataLevel(r)
+	w.Header().Set(HeaderContentType, fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeComplexSegmentNullError writes an error when a nested complex segment is null
+func (h *EntityHandler) writeComplexSegmentNullError(w http.ResponseWriter, contextSegments []string) {
+	path := strings.Join(contextSegments, "/")
+	if err := response.WriteError(w, http.StatusNotFound, "Property not found",
+		fmt.Sprintf("Complex property path '%s' is null", path)); err != nil {
+		fmt.Printf(LogMsgErrorWritingErrorResponse, err)
+	}
+}
+
+// writeResolvedComplexValue writes the resolved complex property (or nested primitive) response
+func (h *EntityHandler) writeResolvedComplexValue(w http.ResponseWriter, r *http.Request, entityKey string, contextSegments []string, value reflect.Value, valueType reflect.Type, isValue bool) {
+	if isComplexValue(value, valueType) {
+		if isValue {
+			if err := response.WriteError(w, http.StatusBadRequest, "Invalid request",
+				"$value is not supported on complex properties"); err != nil {
+				fmt.Printf(LogMsgErrorWritingErrorResponse, err)
+			}
+			return
+		}
+
+		if isNilPointer(value) {
+			h.writeNoContentForNullComplex(w, r)
+			return
+		}
+
+		resolvedValue := dereferenceValue(value)
+		h.writeComplexValueResponse(w, r, entityKey, contextSegments, resolvedValue)
+		return
+	}
+
+	// Primitive value resolution
+	resolvedValue := dereferenceValue(value)
+
+	if isValue {
+		h.writeRawPrimitiveValue(w, r, resolvedValue)
+		return
+	}
+
+	h.writePrimitiveComplexPropertyResponse(w, r, entityKey, contextSegments, value)
+}
+
+// writeComplexValueResponse serializes a complex value (struct or map) with @odata.context
+func (h *EntityHandler) writeComplexValueResponse(w http.ResponseWriter, r *http.Request, entityKey string, contextSegments []string, value reflect.Value) {
+	metadataLevel := response.GetODataMetadataLevel(r)
+	w.Header().Set(HeaderContentType, fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
+	w.WriteHeader(http.StatusOK)
+
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	contextPath := strings.Join(contextSegments, "/")
+	responseMap := make(map[string]interface{})
+	if metadataLevel != "none" {
+		contextURL := fmt.Sprintf("%s/$metadata#%s(%s)/%s", response.BuildBaseURL(r), h.metadata.EntitySetName, entityKey, contextPath)
+		responseMap[ODataContextProperty] = contextURL
+	}
+
+	switch value.Kind() {
+	case reflect.Struct:
+		structMap := structValueToMap(value)
+		for k, v := range structMap {
+			responseMap[k] = v
+		}
+	case reflect.Map:
+		iter := value.MapRange()
+		for iter.Next() {
+			key := iter.Key()
+			if key.Kind() == reflect.String {
+				responseMap[key.String()] = iter.Value().Interface()
+			}
+		}
+	default:
+		responseMap["value"] = value.Interface()
+	}
+
+	if err := json.NewEncoder(w).Encode(responseMap); err != nil {
+		fmt.Printf("Error writing complex property response: %v\n", err)
+	}
+}
+
+// writePrimitiveComplexPropertyResponse writes a primitive property (nested within a complex type)
+func (h *EntityHandler) writePrimitiveComplexPropertyResponse(w http.ResponseWriter, r *http.Request, entityKey string, contextSegments []string, value reflect.Value) {
+	metadataLevel := response.GetODataMetadataLevel(r)
+	w.Header().Set(HeaderContentType, fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
+	w.WriteHeader(http.StatusOK)
+
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	var valueInterface interface{}
+	if !value.IsValid() {
+		valueInterface = nil
+	} else if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			valueInterface = nil
+		} else {
+			valueInterface = value.Elem().Interface()
+		}
+	} else {
+		valueInterface = value.Interface()
+	}
+
+	responseBody := map[string]interface{}{
+		"value": valueInterface,
+	}
+
+	if metadataLevel != "none" {
+		contextURL := fmt.Sprintf("%s/$metadata#%s(%s)/%s", response.BuildBaseURL(r), h.metadata.EntitySetName, entityKey, strings.Join(contextSegments, "/"))
+		responseBody[ODataContextProperty] = contextURL
+	}
+
+	if err := json.NewEncoder(w).Encode(responseBody); err != nil {
+		fmt.Printf("Error writing complex primitive property response: %v\n", err)
+	}
+}
+
+// writeRawPrimitiveValue writes a primitive value in raw form for $value requests
+func (h *EntityHandler) writeRawPrimitiveValue(w http.ResponseWriter, r *http.Request, value reflect.Value) {
+	if !value.IsValid() {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		w.Header().Set(HeaderContentType, ContentTypePlainText)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64,
+		reflect.Bool:
+		w.Header().Set(HeaderContentType, ContentTypePlainText)
+	default:
+		w.Header().Set(HeaderContentType, "application/octet-stream")
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	if _, err := fmt.Fprintf(w, "%v", value.Interface()); err != nil {
+		fmt.Printf("Error writing raw primitive value: %v\n", err)
+	}
+}
+
+// resolveStructField resolves a field from a struct by segment name, returning the reflect.Value, type, and canonical JSON name
+func resolveStructField(value reflect.Value, segment string) (reflect.Value, reflect.Type, string, bool) {
+	if value.Kind() != reflect.Struct {
+		return reflect.Value{}, nil, "", false
+	}
+
+	valueType := value.Type()
+	lowerSegment := strings.ToLower(segment)
+	for i := 0; i < value.NumField(); i++ {
+		field := valueType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		jsonName := getJSONFieldName(field)
+		candidates := []string{field.Name, jsonName}
+		for _, candidate := range candidates {
+			if candidate == "" || candidate == "-" {
+				continue
+			}
+			if candidate == segment || strings.ToLower(candidate) == lowerSegment {
+				return value.Field(i), field.Type, jsonName, true
+			}
+		}
+	}
+
+	return reflect.Value{}, nil, "", false
+}
+
+// resolveMapField resolves a value from a map with string keys
+func resolveMapField(value reflect.Value, segment string) (reflect.Value, reflect.Type, string, bool) {
+	if value.Kind() != reflect.Map || value.Type().Key().Kind() != reflect.String {
+		return reflect.Value{}, nil, "", false
+	}
+
+	mapValue := value.MapIndex(reflect.ValueOf(segment))
+	if mapValue.IsValid() {
+		return mapValue, mapValue.Type(), segment, true
+	}
+
+	lowerSegment := strings.ToLower(segment)
+	iter := value.MapRange()
+	for iter.Next() {
+		key := iter.Key()
+		if strings.ToLower(key.String()) == lowerSegment {
+			val := iter.Value()
+			return val, val.Type(), key.String(), true
+		}
+	}
+
+	return reflect.Value{}, nil, "", false
+}
+
+// isNilPointer checks if a value is a nil pointer or interface
+func isNilPointer(value reflect.Value) bool {
+	if !value.IsValid() {
+		return true
+	}
+
+	switch value.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// dereferenceValue dereferences pointer values until a non-pointer is reached
+func dereferenceValue(value reflect.Value) reflect.Value {
+	for value.IsValid() && value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return reflect.Value{}
+		}
+		value = value.Elem()
+	}
+	return value
+}
+
+// dereferenceType dereferences pointer types until a non-pointer is reached
+func dereferenceType(t reflect.Type) reflect.Type {
+	if t == nil {
+		return nil
+	}
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+// isComplexValue determines if a resolved value should be treated as a complex object
+func isComplexValue(value reflect.Value, valueType reflect.Type) bool {
+	if !value.IsValid() {
+		if valueType == nil {
+			return false
+		}
+		value = reflect.New(dereferenceType(valueType)).Elem()
+	}
+
+	if value.Kind() == reflect.Map {
+		return true
+	}
+
+	resolvedType := valueType
+	if resolvedType == nil {
+		resolvedType = value.Type()
+	}
+
+	resolvedType = dereferenceType(resolvedType)
+	if resolvedType == nil {
+		return false
+	}
+
+	if resolvedType.Kind() != reflect.Struct {
+		return false
+	}
+
+	// Treat time.Time (and similar) as primitive despite being structs
+	if resolvedType.PkgPath() == "time" && resolvedType.Name() == "Time" {
+		return false
+	}
+
+	return true
+}
+
+// structValueToMap converts a struct to a map using JSON tag names
+func structValueToMap(value reflect.Value) map[string]interface{} {
+	result := make(map[string]interface{})
+	valueType := value.Type()
+	for i := 0; i < value.NumField(); i++ {
+		field := valueType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		jsonName := getJSONFieldName(field)
+		if jsonName == "-" {
+			continue
+		}
+		if jsonName == "" {
+			jsonName = field.Name
+		}
+
+		result[jsonName] = value.Field(i).Interface()
+	}
+	return result
+}
+
+// getJSONFieldName extracts the JSON field name from a struct field
+func getJSONFieldName(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return field.Name
+	}
+
+	parts := strings.Split(tag, ",")
+	if len(parts) == 0 || parts[0] == "" {
+		return field.Name
+	}
+
+	return parts[0]
 }
 
 // writeMethodNotAllowedError writes a method not allowed error for a specific context

--- a/test/complex_property_test.go
+++ b/test/complex_property_test.go
@@ -1,0 +1,233 @@
+package odata_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type ComplexPropertyAddress struct {
+	Street string `json:"street"`
+	City   string `json:"city"`
+}
+
+type ComplexPropertyProduct struct {
+	ID              int                     `json:"id" gorm:"primarykey" odata:"key"`
+	Name            string                  `json:"name"`
+	ShippingAddress *ComplexPropertyAddress `json:"shippingAddress,omitempty" gorm:"embedded;embeddedPrefix:ship_" odata:"nullable"`
+}
+
+func setupComplexPropertyService(t *testing.T) (*odata.Service, *gorm.DB) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&ComplexPropertyProduct{}, &ComplexPropertyAddress{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	service := odata.NewService(db)
+	if err := service.RegisterEntity(ComplexPropertyProduct{}); err != nil {
+		t.Fatalf("failed to register entity: %v", err)
+	}
+
+	return service, db
+}
+
+func TestComplexPropertyGET(t *testing.T) {
+	service, db := setupComplexPropertyService(t)
+
+	product := ComplexPropertyProduct{
+		ID:   1,
+		Name: "Widget",
+		ShippingAddress: &ComplexPropertyAddress{
+			Street: "123 Main St",
+			City:   "Metropolis",
+		},
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("failed to insert product: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ComplexPropertyProducts(1)/shippingAddress", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("expected application/json content type, got %s", contentType)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if context, ok := body["@odata.context"].(string); !ok || !strings.Contains(context, "shippingAddress") {
+		t.Fatalf("expected context to reference shippingAddress, got %v", body["@odata.context"])
+	}
+
+	if body["street"] != "123 Main St" {
+		t.Fatalf("expected street to be '123 Main St', got %v", body["street"])
+	}
+	if body["city"] != "Metropolis" {
+		t.Fatalf("expected city to be 'Metropolis', got %v", body["city"])
+	}
+}
+
+func TestComplexPropertyHEAD(t *testing.T) {
+	service, db := setupComplexPropertyService(t)
+
+	product := ComplexPropertyProduct{
+		ID:   1,
+		Name: "Widget",
+		ShippingAddress: &ComplexPropertyAddress{
+			Street: "123 Main St",
+			City:   "Metropolis",
+		},
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("failed to insert product: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodHead, "/ComplexPropertyProducts(1)/shippingAddress", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	if w.Body.Len() != 0 {
+		t.Fatalf("expected empty body for HEAD request, got %q", w.Body.String())
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Fatalf("expected json content type, got %s", contentType)
+	}
+}
+
+func TestComplexPropertyOPTIONS(t *testing.T) {
+	service, _ := setupComplexPropertyService(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/ComplexPropertyProducts(1)/shippingAddress", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	allow := w.Header().Get("Allow")
+	if allow != "GET, HEAD, OPTIONS" {
+		t.Fatalf("expected Allow header 'GET, HEAD, OPTIONS', got %s", allow)
+	}
+}
+
+func TestComplexPropertyNestedGET(t *testing.T) {
+	service, db := setupComplexPropertyService(t)
+
+	product := ComplexPropertyProduct{
+		ID:   1,
+		Name: "Widget",
+		ShippingAddress: &ComplexPropertyAddress{
+			Street: "123 Main St",
+			City:   "Metropolis",
+		},
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("failed to insert product: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ComplexPropertyProducts(1)/shippingAddress/city", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["value"] != "Metropolis" {
+		t.Fatalf("expected value 'Metropolis', got %v", body["value"])
+	}
+
+	if context, ok := body["@odata.context"].(string); !ok || !strings.Contains(context, "shippingAddress/city") {
+		t.Fatalf("expected context to include nested path, got %v", body["@odata.context"])
+	}
+}
+
+func TestComplexPropertyNestedValue(t *testing.T) {
+	service, db := setupComplexPropertyService(t)
+
+	product := ComplexPropertyProduct{
+		ID:   1,
+		Name: "Widget",
+		ShippingAddress: &ComplexPropertyAddress{
+			Street: "123 Main St",
+			City:   "Metropolis",
+		},
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("failed to insert product: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ComplexPropertyProducts(1)/shippingAddress/city/$value", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if body := strings.TrimSpace(w.Body.String()); body != "Metropolis" {
+		t.Fatalf("expected raw body 'Metropolis', got %q", body)
+	}
+
+	if contentType := w.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %s", contentType)
+	}
+}
+
+func TestComplexPropertyNull(t *testing.T) {
+	service, db := setupComplexPropertyService(t)
+
+	product := ComplexPropertyProduct{
+		ID:              1,
+		Name:            "Widget",
+		ShippingAddress: nil,
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("failed to insert product: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ComplexPropertyProducts(1)/shippingAddress", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- implement complex property request handling including nested traversal and serialization helpers
- extend URL parsing and routing to support complex property paths
- add integration and compliance tests covering complex property success cases and metadata

## Testing
- go test ./...
- go build ./...
- golangci-lint run ./...


------
https://chatgpt.com/codex/tasks/task_e_690090e981ac83288055739dea53d623