### PR TITLE
Implement enum metadata reflection and namespace configuration

### DIFF
--- a/cmd/complianceserver/entities/product.go
+++ b/cmd/complianceserver/entities/product.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ProductStatus represents product status as a flags enum
-type ProductStatus int
+type ProductStatus int32
 
 const (
 	// ProductStatusNone represents no status
@@ -19,6 +19,17 @@ const (
 	// ProductStatusFeatured represents that the product is featured
 	ProductStatusFeatured ProductStatus = 8
 )
+
+// EnumMembers returns the enum member mapping for compliance metadata generation.
+func (ProductStatus) EnumMembers() map[string]int {
+	return map[string]int{
+		"None":         int(ProductStatusNone),
+		"InStock":      int(ProductStatusInStock),
+		"OnSale":       int(ProductStatusOnSale),
+		"Discontinued": int(ProductStatusDiscontinued),
+		"Featured":     int(ProductStatusFeatured),
+	}
+}
 
 // Product represents a product entity for the compliance server
 type Product struct {

--- a/cmd/complianceserver/main.go
+++ b/cmd/complianceserver/main.go
@@ -74,6 +74,10 @@ func main() {
 	// Create OData service
 	service := odata.NewService(Db)
 
+	if err := service.SetNamespace("ComplianceService"); err != nil {
+		log.Fatal("Failed to set service namespace:", err)
+	}
+
 	// Register the Category, Product and ProductDescription entities
 	if err := service.RegisterEntity(&entities.Category{}); err != nil {
 		log.Fatal("Failed to register Category entity:", err)

--- a/cmd/devserver/entities/product.go
+++ b/cmd/devserver/entities/product.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ProductStatus represents product status as a flags enum
-type ProductStatus int
+type ProductStatus int32
 
 const (
 	// ProductStatusNone represents no status
@@ -22,6 +22,17 @@ const (
 	// ProductStatusFeatured represents that the product is featured
 	ProductStatusFeatured ProductStatus = 8
 )
+
+// EnumMembers returns the enum member mapping for metadata generation.
+func (ProductStatus) EnumMembers() map[string]int {
+	return map[string]int{
+		"None":         int(ProductStatusNone),
+		"InStock":      int(ProductStatusInStock),
+		"OnSale":       int(ProductStatusOnSale),
+		"Discontinued": int(ProductStatusDiscontinued),
+		"Featured":     int(ProductStatusFeatured),
+	}
+}
 
 // Product represents a product entity for the development server with rich metadata
 type Product struct {
@@ -48,11 +59,11 @@ func (p Product) BeforeCreate(ctx context.Context, r *http.Request) error {
 	// Check if the user is an admin
 	// In a real application, you would extract this from authentication tokens/session
 	isAdmin := r.Header.Get("X-User-Role") == "admin"
-	
+
 	if !isAdmin {
 		return fmt.Errorf("only administrators are allowed to create products")
 	}
-	
+
 	return nil
 }
 
@@ -62,11 +73,11 @@ func (p Product) BeforeUpdate(ctx context.Context, r *http.Request) error {
 	// Check if the user is an admin
 	// In a real application, you would extract this from authentication tokens/session
 	isAdmin := r.Header.Get("X-User-Role") == "admin"
-	
+
 	if !isAdmin {
 		return fmt.Errorf("only administrators are allowed to update products")
 	}
-	
+
 	return nil
 }
 

--- a/cmd/devserver/main.go
+++ b/cmd/devserver/main.go
@@ -71,6 +71,10 @@ func main() {
 	// Create OData service
 	service := odata.NewService(Db)
 
+	if err := service.SetNamespace("DevService"); err != nil {
+		log.Fatal("Failed to set service namespace:", err)
+	}
+
 	// Register the Category, Product and ProductDescription entities
 	if err := service.RegisterEntity(&entities.Category{}); err != nil {
 		log.Fatal("Failed to register Category entity:", err)

--- a/cmd/perfserver/entities/product.go
+++ b/cmd/perfserver/entities/product.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ProductStatus represents product status as a flags enum
-type ProductStatus int
+type ProductStatus int32
 
 const (
 	// ProductStatusNone represents no status
@@ -19,6 +19,17 @@ const (
 	// ProductStatusFeatured represents that the product is featured
 	ProductStatusFeatured ProductStatus = 8
 )
+
+// EnumMembers returns the enum member mapping for performance metadata generation.
+func (ProductStatus) EnumMembers() map[string]int {
+	return map[string]int{
+		"None":         int(ProductStatusNone),
+		"InStock":      int(ProductStatusInStock),
+		"OnSale":       int(ProductStatusOnSale),
+		"Discontinued": int(ProductStatusDiscontinued),
+		"Featured":     int(ProductStatusFeatured),
+	}
+}
 
 // Product represents a product entity for the compliance server
 type Product struct {

--- a/cmd/perfserver/main.go
+++ b/cmd/perfserver/main.go
@@ -149,6 +149,10 @@ func main() {
 	// Create OData service
 	service := odata.NewService(Db)
 
+	if err := service.SetNamespace("PerfService"); err != nil {
+		log.Fatal("Failed to set service namespace:", err)
+	}
+
 	// Register the Category, Product and ProductDescription entities
 	if err := service.RegisterEntity(&entities.Category{}); err != nil {
 		log.Fatal("Failed to register Category entity:", err)

--- a/compliance/README.md
+++ b/compliance/README.md
@@ -23,7 +23,7 @@ When running all tests (default), both v4.0 and v4.01 tests are executed.
 
 ## Overview
 
-The compliance test suite consists of **85 individual test scripts** with **779 individual test cases** organized by OData v4 specification sections. Each test script validates specific aspects of the OData protocol implementation.
+The compliance test suite consists of **86 individual test scripts** with **781 individual test cases** organized by OData v4 specification sections. Each test script validates specific aspects of the OData protocol implementation.
 
 ### Test Coverage Summary
 
@@ -32,7 +32,7 @@ The compliance test suite consists of **85 individual test scripts** with **779 
 - **12 URL Convention Tests** - Entity Addressing, Canonical URL, Property Access, Collection Operations, Metadata Levels, Delta Links, Lambda Operators, Property $value, Stream Properties, Type Casting, Singleton Operations
 - **24 Query Option Tests** - $filter (with string/date/arithmetic/type/logical/comparison/geo operators), $select, $orderby, $top, $skip, $skiptoken, $count, $expand, $search, $format, $apply (including advanced transformations), $compute, $index, nested expand options, query option combinations, orderby with computed properties
 - **13 Data Modification Tests** - GET, POST, PATCH, PUT, DELETE, HEAD, Conditional Requests, Relationships, Modify Relationships, Deep Insert, Batch (including error handling), Asynchronous, Navigation Property Operations, Action/Function Parameters
-- **8 Data Type Tests** - Primitive data types, Numeric edge cases, Nullable properties, Collection properties, Complex types, Enum types, Temporal types, Type definitions
+- **9 Data Type Tests** - Primitive data types, Numeric edge cases, Nullable properties, Collection properties, Complex types, Enum types (including metadata validation), Temporal types, Type definitions
 - **6 Advanced Tests** - Lambda operators, filter on expanded properties, vocabulary annotations, batch error handling, advanced aggregation transformations
 - **5 String & Internationalization Tests** - String functions, Unicode and internationalization, URL encoding, edge cases
 
@@ -182,6 +182,7 @@ Example report structure:
 - **5.1.4_temporal_data_types.sh** - Tests temporal OData types (Edm.Date, Edm.TimeOfDay, Edm.Duration), cast/isof functions, date/time literals and comparisons
 - **5.2_complex_types.sh** - Tests complex (structured) types, nested properties, filtering, and complex type operations
 - **5.3_enum_types.sh** - Tests enumeration types, enum filtering with numeric/string values, and enum operations
+- **5.3_enum_metadata_members.sh** - Validates enumeration metadata members and namespace configuration for registered enums
 - **5.4_type_definitions.sh** - Tests custom type definitions in metadata and their usage
 
 ### Headers & Response Codes (Section 8.x)

--- a/compliance/v4.0/5.3_enum_metadata_members.sh
+++ b/compliance/v4.0/5.3_enum_metadata_members.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# OData v4 Compliance Test: 5.3 Enumeration Types - Metadata Members
+# Verifies that enum metadata reflects actual Go enum values and configured namespace.
+# Spec Reference: https://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part3-csdl/odata-v4.0-errata03-os-part3-csdl-complete.html#sec_EnumerationType
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../test_framework.sh"
+
+echo "======================================"
+echo "OData v4 Compliance Test"
+echo "Section: 5.3 Enumeration Types (Metadata)"
+echo "======================================"
+
+test_enum_metadata_xml() {
+    local RESPONSE=$(http_get_body "$SERVER_URL/\$metadata")
+    local HTTP_CODE=$(http_get "$SERVER_URL/\$metadata")
+
+    if [ "$HTTP_CODE" != "200" ]; then
+        echo "  Details: Expected status 200, got $HTTP_CODE"
+        return 1
+    fi
+
+    if ! echo "$RESPONSE" | grep -q '<Schema[^>]*Namespace="ComplianceService"'; then
+        echo "  Details: Schema namespace is not ComplianceService"
+        return 1
+    fi
+
+    if ! echo "$RESPONSE" | grep -q '<EnumType Name="ProductStatus" UnderlyingType="Edm.Int32" IsFlags="true">'; then
+        echo "  Details: ProductStatus enum definition missing or incorrect"
+        return 1
+    fi
+
+    for MEMBER in "None" "InStock" "OnSale" "Discontinued" "Featured"; do
+        if ! echo "$RESPONSE" | grep -q "<Member Name=\"$MEMBER\""; then
+            echo "  Details: Enum member $MEMBER missing in XML metadata"
+            return 1
+        fi
+    done
+
+    if ! echo "$RESPONSE" | grep -q '<Member Name="Featured" Value="8" />'; then
+        echo "  Details: Featured member has incorrect value"
+        return 1
+    fi
+
+    return 0
+}
+
+test_enum_metadata_json() {
+    local RESPONSE=$(http_get_body "$SERVER_URL/\$metadata?\$format=json")
+    local HTTP_CODE=$(http_get "$SERVER_URL/\$metadata?\$format=json")
+
+    if [ "$HTTP_CODE" != "200" ]; then
+        echo "  Details: Expected status 200, got $HTTP_CODE"
+        return 1
+    fi
+
+    export RESPONSE
+    python3 - <<'PY'
+import json
+import os
+import sys
+
+data = json.loads(os.environ["RESPONSE"])
+schema = data.get("ComplianceService")
+if not isinstance(schema, dict):
+    print("  Details: JSON metadata missing ComplianceService schema")
+    sys.exit(1)
+
+enum = schema.get("ProductStatus")
+if not isinstance(enum, dict):
+    print("  Details: JSON metadata missing ProductStatus enum")
+    sys.exit(1)
+
+if enum.get("$UnderlyingType") != "Edm.Int32":
+    print("  Details: Unexpected underlying type", enum.get("$UnderlyingType"))
+    sys.exit(1)
+
+expected = {
+    "None": 0,
+    "InStock": 1,
+    "OnSale": 2,
+    "Discontinued": 4,
+    "Featured": 8,
+}
+
+for name, value in expected.items():
+    if enum.get(name) != value:
+        print(f"  Details: Enum member {name} expected {value}, got {enum.get(name)}")
+        sys.exit(1)
+
+if data.get("$EntityContainer") != "ComplianceService.Container":
+    print("  Details: Unexpected $EntityContainer value", data.get("$EntityContainer"))
+    sys.exit(1)
+PY
+    local PY_RESULT=$?
+    unset RESPONSE
+    return $PY_RESULT
+}
+
+run_test "XML metadata enumerates ProductStatus members" test_enum_metadata_xml
+run_test "JSON metadata enumerates ProductStatus members" test_enum_metadata_json
+
+print_summary
+
+exit $EXIT_CODE

--- a/enum.go
+++ b/enum.go
@@ -1,0 +1,46 @@
+package odata
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+// EnumMember describes a single enum member when registering enums programmatically.
+type EnumMember = metadata.EnumMember
+
+// RegisterEnumType registers enum metadata for the provided enum type using a map of member names to values.
+// The enumValue parameter accepts either a zero value of the enum type or a pointer to the enum type.
+// Values must be representable as signed 64-bit integers to comply with the OData specification.
+func RegisterEnumType(enumValue interface{}, members map[string]int64) error {
+	if enumValue == nil {
+		return fmt.Errorf("enumValue cannot be nil")
+	}
+	if len(members) == 0 {
+		return fmt.Errorf("enum members cannot be empty")
+	}
+
+	enumType := reflect.TypeOf(enumValue)
+	if enumType.Kind() == reflect.Pointer {
+		enumType = enumType.Elem()
+	}
+	if enumType == nil {
+		return fmt.Errorf("could not determine enum type")
+	}
+
+	converted := make([]metadata.EnumMember, 0, len(members))
+	for name, value := range members {
+		converted = append(converted, metadata.EnumMember{Name: name, Value: value})
+	}
+
+	sort.Slice(converted, func(i, j int) bool {
+		if converted[i].Value == converted[j].Value {
+			return converted[i].Name < converted[j].Name
+		}
+		return converted[i].Value < converted[j].Value
+	})
+
+	return metadata.RegisterEnumMembers(enumType, converted)
+}

--- a/internal/handlers/collection.go
+++ b/internal/handlers/collection.go
@@ -126,7 +126,7 @@ func (h *EntityHandler) handleGetCollection(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Write the OData response with navigation links
-	metadataProvider := newMetadataAdapter(h.metadata)
+	metadataProvider := newMetadataAdapter(h.metadata, h.namespace)
 	if err := response.WriteODataCollectionWithNavigation(w, r, h.metadata.EntitySetName, sliceValue, totalCount, nextLink, metadataProvider, expandedProps, h.metadata); err != nil {
 		// If we can't write the response, log the error but don't try to write another response
 		fmt.Printf("Error writing OData response: %v\n", err)

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -1,6 +1,9 @@
 package handlers
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/query"
 	"gorm.io/gorm"
@@ -11,19 +14,41 @@ type EntityHandler struct {
 	db               *gorm.DB
 	metadata         *metadata.EntityMetadata
 	entitiesMetadata map[string]*metadata.EntityMetadata
+	namespace        string
 }
 
 // NewEntityHandler creates a new entity handler
 func NewEntityHandler(db *gorm.DB, entityMetadata *metadata.EntityMetadata) *EntityHandler {
 	return &EntityHandler{
-		db:       db,
-		metadata: entityMetadata,
+		db:        db,
+		metadata:  entityMetadata,
+		namespace: defaultNamespace,
 	}
 }
 
 // SetEntitiesMetadata sets the entities metadata registry for navigation property handling
 func (h *EntityHandler) SetEntitiesMetadata(entitiesMetadata map[string]*metadata.EntityMetadata) {
 	h.entitiesMetadata = entitiesMetadata
+}
+
+// SetNamespace updates the namespace used for generated metadata annotations.
+func (h *EntityHandler) SetNamespace(namespace string) {
+	trimmed := strings.TrimSpace(namespace)
+	if trimmed == "" {
+		trimmed = defaultNamespace
+	}
+	h.namespace = trimmed
+}
+
+func (h *EntityHandler) namespaceOrDefault() string {
+	if strings.TrimSpace(h.namespace) == "" {
+		return defaultNamespace
+	}
+	return h.namespace
+}
+
+func (h *EntityHandler) qualifiedTypeName(typeName string) string {
+	return fmt.Sprintf("%s.%s", h.namespaceOrDefault(), typeName)
 }
 
 // IsSingleton returns true if this handler is for a singleton

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -158,7 +158,7 @@ func (h *EntityHandler) buildEntityResponseWithMetadata(navValue reflect.Value, 
 
 	// Add @odata.type for full metadata
 	if metadataLevel == "full" {
-		odataResponse.Set("@odata.type", "#ODataService."+h.metadata.EntityName)
+		odataResponse.Set("@odata.type", "#"+h.qualifiedTypeName(h.metadata.EntityName))
 	}
 
 	navType := navValue.Type()
@@ -224,7 +224,7 @@ func (h *EntityHandler) buildOrderedEntityResponseWithMetadata(result interface{
 
 	// Add @odata.type for full metadata
 	if metadataLevel == "full" {
-		odataResponse.Set("@odata.type", "#ODataService."+h.metadata.EntityName)
+		odataResponse.Set("@odata.type", "#"+h.qualifiedTypeName(h.metadata.EntityName))
 	}
 
 	// Handle map[string]interface{} (from $select filtering)
@@ -401,12 +401,14 @@ type metadataAdapter struct {
 	cachedKeyProperty   *response.PropertyMetadata
 	cachedKeyProperties []response.PropertyMetadata
 	cachedETagProperty  *response.PropertyMetadata
+	namespace           string
 }
 
 // newMetadataAdapter creates a new metadataAdapter with pre-computed cached properties
-func newMetadataAdapter(metadata *metadata.EntityMetadata) *metadataAdapter {
+func newMetadataAdapter(metadata *metadata.EntityMetadata, namespace string) *metadataAdapter {
 	adapter := &metadataAdapter{
-		metadata: metadata,
+		metadata:  metadata,
+		namespace: namespace,
 	}
 
 	// Pre-compute and cache all properties
@@ -480,6 +482,13 @@ func (a *metadataAdapter) GetEntitySetName() string {
 func (a *metadataAdapter) GetETagProperty() *response.PropertyMetadata {
 	// Return cached ETag property
 	return a.cachedETagProperty
+}
+
+func (a *metadataAdapter) GetNamespace() string {
+	if strings.TrimSpace(a.namespace) == "" {
+		return defaultNamespace
+	}
+	return a.namespace
 }
 
 // ValidateODataVersion checks if the OData-MaxVersion header is compatible with OData v4.0

--- a/internal/metadata/enum_registry.go
+++ b/internal/metadata/enum_registry.go
@@ -1,0 +1,274 @@
+package metadata
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+// EnumMember represents a single member of an enum type for metadata generation.
+type EnumMember struct {
+	Name  string
+	Value int64
+}
+
+var enumRegistry = struct {
+	sync.RWMutex
+	data map[reflect.Type][]EnumMember
+}{
+	data: make(map[reflect.Type][]EnumMember),
+}
+
+// RegisterEnumMembers registers enum members for the given enum type.
+// The enumType must resolve to an integral type (signed or unsigned) that is compatible with OData enum types.
+func RegisterEnumMembers(enumType reflect.Type, members []EnumMember) error {
+	if enumType == nil {
+		return fmt.Errorf("enum type cannot be nil")
+	}
+
+	baseType := resolveEnumBaseType(enumType)
+	if baseType == nil {
+		return fmt.Errorf("enum type %s must be an integral type", enumType)
+	}
+
+	if len(members) == 0 {
+		return fmt.Errorf("enum type %s must have at least one member", baseType.Name())
+	}
+
+	// Validate members: ensure unique names and deterministic ordering.
+	seenNames := make(map[string]struct{})
+	seenValues := make(map[int64]struct{})
+	normalized := make([]EnumMember, len(members))
+	for i, member := range members {
+		if member.Name == "" {
+			return fmt.Errorf("enum type %s has a member with an empty name", baseType.Name())
+		}
+		if _, exists := seenNames[member.Name]; exists {
+			return fmt.Errorf("enum type %s has duplicate member name %s", baseType.Name(), member.Name)
+		}
+		seenNames[member.Name] = struct{}{}
+
+		if _, exists := seenValues[member.Value]; exists {
+			return fmt.Errorf("enum type %s has duplicate member value %d", baseType.Name(), member.Value)
+		}
+		seenValues[member.Value] = struct{}{}
+
+		normalized[i] = member
+	}
+
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].Value == normalized[j].Value {
+			return normalized[i].Name < normalized[j].Name
+		}
+		return normalized[i].Value < normalized[j].Value
+	})
+
+	enumRegistry.Lock()
+	defer enumRegistry.Unlock()
+	enumRegistry.data[baseType] = normalized
+	return nil
+}
+
+// getRegisteredEnumMembers retrieves registered enum members for the given enum type.
+func getRegisteredEnumMembers(enumType reflect.Type) ([]EnumMember, bool) {
+	enumRegistry.RLock()
+	defer enumRegistry.RUnlock()
+	members, ok := enumRegistry.data[enumType]
+	if !ok {
+		return nil, false
+	}
+	copied := make([]EnumMember, len(members))
+	copy(copied, members)
+	return copied, true
+}
+
+// ResolveEnumMembers resolves enum members for the provided field type.
+// It first checks the registry and, if not found, attempts to call an EnumMembers() map[string]<int> method on the enum type.
+func ResolveEnumMembers(fieldType reflect.Type) ([]EnumMember, reflect.Type, error) {
+	baseType := resolveEnumBaseType(fieldType)
+	if baseType == nil {
+		return nil, nil, fmt.Errorf("enum field type %s must ultimately resolve to an integral type", fieldType)
+	}
+
+	if members, ok := getRegisteredEnumMembers(baseType); ok {
+		return members, baseType, nil
+	}
+
+	members, err := extractEnumMembersViaMethod(baseType)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(members) == 0 {
+		return nil, nil, fmt.Errorf("enum type %s has no registered members", baseType.Name())
+	}
+
+	if err := RegisterEnumMembers(baseType, members); err != nil {
+		return nil, nil, err
+	}
+
+	return members, baseType, nil
+}
+
+// resolveEnumBaseType unwraps pointers, slices, and arrays to find the underlying enum type.
+func resolveEnumBaseType(t reflect.Type) reflect.Type {
+	if t == nil {
+		return nil
+	}
+
+	for {
+		switch t.Kind() {
+		case reflect.Pointer, reflect.Slice, reflect.Array:
+			t = t.Elem()
+			continue
+		}
+		break
+	}
+
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return t
+	default:
+		return nil
+	}
+}
+
+// extractEnumMembersViaMethod attempts to call EnumMembers() on the enum type to obtain members.
+func extractEnumMembersViaMethod(enumType reflect.Type) ([]EnumMember, error) {
+	pointerValue := reflect.New(enumType)
+	method := pointerValue.MethodByName("EnumMembers")
+	if !method.IsValid() {
+		value := pointerValue.Elem()
+		if value.CanAddr() {
+			method = value.Addr().MethodByName("EnumMembers")
+		}
+		if !method.IsValid() {
+			method = value.MethodByName("EnumMembers")
+		}
+	}
+
+	if !method.IsValid() {
+		return nil, nil
+	}
+
+	if method.Type().NumIn() != 0 || method.Type().NumOut() != 1 {
+		return nil, fmt.Errorf("EnumMembers method on type %s must have signature EnumMembers() map[string]<integer>", enumType.Name())
+	}
+
+	resultType := method.Type().Out(0)
+	if resultType.Kind() != reflect.Map || resultType.Key().Kind() != reflect.String {
+		return nil, fmt.Errorf("EnumMembers method on type %s must return map[string]<integer>", enumType.Name())
+	}
+
+	values := method.Call(nil)
+	if len(values) != 1 {
+		return nil, fmt.Errorf("EnumMembers method on type %s returned unexpected results", enumType.Name())
+	}
+
+	mapValue := values[0]
+	if mapValue.IsNil() {
+		return nil, fmt.Errorf("EnumMembers method on type %s returned nil", enumType.Name())
+	}
+
+	iter := mapValue.MapRange()
+	members := make([]EnumMember, 0, mapValue.Len())
+	seen := make(map[string]struct{})
+	valueKind := resultType.Elem().Kind()
+	if !isSupportedEnumValueKind(valueKind) {
+		return nil, fmt.Errorf("EnumMembers method on type %s must return map[string]<integer>", enumType.Name())
+	}
+
+	for iter.Next() {
+		name := iter.Key().String()
+		if name == "" {
+			return nil, fmt.Errorf("enum type %s has a member with an empty name", enumType.Name())
+		}
+		if _, exists := seen[name]; exists {
+			return nil, fmt.Errorf("enum type %s has duplicate member name %s", enumType.Name(), name)
+		}
+		seen[name] = struct{}{}
+
+		value := iter.Value()
+		memberValue, err := convertEnumValueToInt64(value)
+		if err != nil {
+			return nil, fmt.Errorf("enum type %s has invalid member %s: %w", enumType.Name(), name, err)
+		}
+		members = append(members, EnumMember{Name: name, Value: memberValue})
+	}
+
+	sort.Slice(members, func(i, j int) bool {
+		if members[i].Value == members[j].Value {
+			return members[i].Name < members[j].Name
+		}
+		return members[i].Value < members[j].Value
+	})
+
+	return members, nil
+}
+
+func isSupportedEnumValueKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	default:
+		return false
+	}
+}
+
+func convertEnumValueToInt64(value reflect.Value) (int64, error) {
+	switch value.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		unsigned := value.Uint()
+		if unsigned > math.MaxInt64 {
+			return 0, fmt.Errorf("value %d exceeds maximum supported enum value", unsigned)
+		}
+		return int64(unsigned), nil
+	default:
+		return 0, fmt.Errorf("unsupported enum value kind %s", value.Kind())
+	}
+}
+
+// DetermineEnumUnderlyingType returns the corresponding Edm type for the enum.
+func DetermineEnumUnderlyingType(enumType reflect.Type) (string, error) {
+	enumType = resolveEnumBaseType(enumType)
+	if enumType == nil {
+		return "", fmt.Errorf("enum type must be an integer")
+	}
+
+	switch enumType.Kind() {
+	case reflect.Int8:
+		return "Edm.SByte", nil
+	case reflect.Uint8:
+		return "Edm.Byte", nil
+	case reflect.Int16:
+		return "Edm.Int16", nil
+	case reflect.Uint16:
+		return "Edm.Int32", nil
+	case reflect.Int32:
+		return "Edm.Int32", nil
+	case reflect.Uint32:
+		return "Edm.Int64", nil
+	case reflect.Int64:
+		return "Edm.Int64", nil
+	case reflect.Uint64:
+		return "", fmt.Errorf("Edm.Int64 is the maximum supported underlying type; uint64 is not supported")
+	case reflect.Int:
+		if strconv.IntSize == 32 {
+			return "Edm.Int32", nil
+		}
+		return "Edm.Int64", nil
+	case reflect.Uint:
+		if strconv.IntSize == 32 {
+			return "Edm.Int64", nil
+		}
+		return "Edm.Int64", nil
+	default:
+		return "Edm.Int32", nil
+	}
+}

--- a/internal/response/odata.go
+++ b/internal/response/odata.go
@@ -41,6 +41,7 @@ type EntityMetadataProvider interface {
 	GetKeyProperties() []PropertyMetadata // Returns all key properties (single or composite)
 	GetEntitySetName() string
 	GetETagProperty() *PropertyMetadata // Returns the ETag property if configured
+	GetNamespace() string
 }
 
 // PropertyMetadata represents metadata about a property
@@ -325,7 +326,7 @@ func processMapEntity(entity reflect.Value, metadata EntityMetadataProvider, exp
 		// Get entity type name from entity set name (remove trailing 's' for simple pluralization)
 		// This is a simplified approach - in a real implementation, we'd get this from metadata
 		entityTypeName := getEntityTypeFromSetName(entitySetName)
-		entityMap["@odata.type"] = "#ODataService." + entityTypeName
+		entityMap["@odata.type"] = "#" + metadata.GetNamespace() + "." + entityTypeName
 	}
 
 	// Add navigation links only for full metadata (per OData v4 spec)
@@ -399,7 +400,7 @@ func processStructEntityOrdered(entity reflect.Value, metadata EntityMetadataPro
 	// Add @odata.type annotation for full metadata
 	if metadataLevel == "full" {
 		entityTypeName := getEntityTypeFromSetName(entitySetName)
-		entityMap.Set("@odata.type", "#ODataService."+entityTypeName)
+		entityMap.Set("@odata.type", "#"+metadata.GetNamespace()+"."+entityTypeName)
 	}
 
 	for j := 0; j < entity.NumField(); j++ {

--- a/odata_test.go
+++ b/odata_test.go
@@ -20,6 +20,18 @@ type InvalidEntity struct {
 	// No key field
 }
 
+type RegisteredEnum int
+
+const (
+	RegisteredEnumFoo RegisteredEnum = 0
+	RegisteredEnumBar RegisteredEnum = 4
+)
+
+type RegisteredEnumEntity struct {
+	ID    int            `json:"id" odata:"key"`
+	Value RegisteredEnum `json:"value" odata:"enum=RegisteredEnum"`
+}
+
 func setupTestDB(t *testing.T) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
@@ -137,6 +149,22 @@ func TestServiceRegisterMultipleEntities(t *testing.T) {
 		if _, exists := service.handlers[setName]; !exists {
 			t.Errorf("Handler for %s not found", setName)
 		}
+	}
+}
+
+func TestRegisterEnumType(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(db)
+
+	if err := RegisterEnumType(RegisteredEnum(0), map[string]int64{
+		"Foo": int64(RegisteredEnumFoo),
+		"Bar": int64(RegisteredEnumBar),
+	}); err != nil {
+		t.Fatalf("RegisterEnumType failed: %v", err)
+	}
+
+	if err := service.RegisterEntity(&RegisteredEnumEntity{}); err != nil {
+		t.Fatalf("RegisterEntity with registered enum failed: %v", err)
 	}
 }
 

--- a/test/enum_integration_test.go
+++ b/test/enum_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ProductStatus represents product status as a flags enum
-type ProductStatus int
+type ProductStatus int32
 
 const (
 	// ProductStatusNone represents no status
@@ -27,6 +27,17 @@ const (
 	// ProductStatusFeatured represents that the product is featured
 	ProductStatusFeatured ProductStatus = 8
 )
+
+// EnumMembers exposes the enum mapping for metadata generation.
+func (ProductStatus) EnumMembers() map[string]int {
+	return map[string]int{
+		"None":         int(ProductStatusNone),
+		"InStock":      int(ProductStatusInStock),
+		"OnSale":       int(ProductStatusOnSale),
+		"Discontinued": int(ProductStatusDiscontinued),
+		"Featured":     int(ProductStatusFeatured),
+	}
+}
 
 // EnumProduct represents a product entity with enum status for testing
 type EnumProduct struct {

--- a/test/namespace_integration_test.go
+++ b/test/namespace_integration_test.go
@@ -1,0 +1,113 @@
+package odata_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type NamespaceProduct struct {
+	ID   uint   `json:"ID" gorm:"primaryKey" odata:"key"`
+	Name string `json:"Name"`
+}
+
+func setupNamespaceDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	if err := db.AutoMigrate(&NamespaceProduct{}); err != nil {
+		t.Fatalf("failed to migrate namespace product: %v", err)
+	}
+	return db
+}
+
+func TestServiceCustomNamespace(t *testing.T) {
+	db := setupNamespaceDB(t)
+	service := odata.NewService(db)
+
+	if err := service.RegisterEntity(&NamespaceProduct{}); err != nil {
+		t.Fatalf("RegisterEntity failed: %v", err)
+	}
+
+	if err := service.SetNamespace("Contoso"); err != nil {
+		t.Fatalf("SetNamespace failed: %v", err)
+	}
+
+	// Verify XML metadata namespace
+	req := httptest.NewRequest(http.MethodGet, "/$metadata", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status for metadata: %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `Namespace="Contoso"`) {
+		t.Fatalf("expected namespace Contoso in metadata, got %s", body)
+	}
+	if !strings.Contains(body, `Type="Contoso.NamespaceProduct"`) {
+		t.Fatalf("expected fully qualified type in metadata, got %s", body)
+	}
+
+	// Verify JSON metadata namespace
+	reqJSON := httptest.NewRequest(http.MethodGet, "/$metadata?$format=json", nil)
+	wJSON := httptest.NewRecorder()
+	service.ServeHTTP(wJSON, reqJSON)
+	if wJSON.Code != http.StatusOK {
+		t.Fatalf("unexpected status for JSON metadata: %d", wJSON.Code)
+	}
+
+	var jsonMeta map[string]interface{}
+	if err := json.Unmarshal(wJSON.Body.Bytes(), &jsonMeta); err != nil {
+		t.Fatalf("failed to parse JSON metadata: %v", err)
+	}
+
+	schema, ok := jsonMeta["Contoso"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected Contoso schema in JSON metadata, got %v", jsonMeta)
+	}
+	if _, ok := schema["NamespaceProduct"].(map[string]interface{}); !ok {
+		t.Fatalf("expected NamespaceProduct type in Contoso schema, got %v", schema)
+	}
+	container, ok := schema["Container"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected Container section in JSON metadata, got %v", schema)
+	}
+	entitySet, ok := container["NamespaceProducts"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected NamespaceProducts entity set metadata, got %v", container)
+	}
+	if entityType, ok := entitySet["$Type"].(string); !ok || entityType != "Contoso.NamespaceProduct" {
+		t.Fatalf("expected NamespaceProducts $Type Contoso.NamespaceProduct, got %v", entitySet["$Type"])
+	}
+	if entityContainer, ok := jsonMeta["$EntityContainer"].(string); !ok || entityContainer != "Contoso.Container" {
+		t.Fatalf("expected $EntityContainer Contoso.Container, got %v", jsonMeta["$EntityContainer"])
+	}
+
+	// Seed data and verify @odata.type reflects namespace
+	if err := db.Create(&NamespaceProduct{ID: 1, Name: "Widget"}).Error; err != nil {
+		t.Fatalf("failed to seed product: %v", err)
+	}
+
+	reqEntity := httptest.NewRequest(http.MethodGet, "/NamespaceProducts(1)", nil)
+	reqEntity.Header.Set("Accept", "application/json;odata.metadata=full")
+	wEntity := httptest.NewRecorder()
+	service.ServeHTTP(wEntity, reqEntity)
+	if wEntity.Code != http.StatusOK {
+		t.Fatalf("unexpected status for entity fetch: %d", wEntity.Code)
+	}
+
+	var entity map[string]interface{}
+	if err := json.Unmarshal(wEntity.Body.Bytes(), &entity); err != nil {
+		t.Fatalf("failed to parse entity response: %v", err)
+	}
+	if entityType, ok := entity["@odata.type"].(string); !ok || entityType != "#Contoso.NamespaceProduct" {
+		t.Fatalf("expected @odata.type=#Contoso.NamespaceProduct, got %v", entity["@odata.type"])
+	}
+}


### PR DESCRIPTION
## Summary
- add an enum registry and registration helper so metadata uses real Go enum members and underlying types
- propagate configurable namespaces through metadata/entity handlers and sample services, plus add integration coverage
- document the new compliance test and script counts, and add a v4.0 test to validate enum metadata output

## Testing
- golangci-lint run --timeout=5m ./...
- go test ./...
- go build ./...
- ./compliance/run_compliance_tests.sh 5.3_enum_metadata_members

------
https://chatgpt.com/codex/tasks/task_e_69008eb6daec8328be5dbbb67630bf82