### PR TITLE
Refactor collection query handling

### DIFF
--- a/internal/handlers/collection_executor.go
+++ b/internal/handlers/collection_executor.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/query"
+	"github.com/nlstn/go-odata/internal/response"
+	"gorm.io/gorm"
+)
+
+// errRequestHandled is used to signal that the request has already been handled
+// and no further processing should occur.
+var errRequestHandled = errors.New("request already handled")
+
+// collectionRequestError represents an error that should be returned to the client
+// with a specific HTTP status code and error message.
+type collectionRequestError struct {
+	StatusCode int
+	ErrorCode  string
+	Message    string
+}
+
+func (e *collectionRequestError) Error() string {
+	return e.Message
+}
+
+// collectionExecutionContext provides the hooks required to execute a collection
+// query pipeline. Implementations can customize individual phases such as parsing
+// query options, running hooks, fetching data, computing next links, and writing
+// the final response while sharing the common orchestration logic.
+type collectionExecutionContext struct {
+	Metadata *metadata.EntityMetadata
+
+	ParseQueryOptions func() (*query.QueryOptions, error)
+	BeforeRead        func(*query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error)
+	CountFunc         func(*query.QueryOptions, []func(*gorm.DB) *gorm.DB) (*int64, error)
+	FetchFunc         func(*query.QueryOptions, []func(*gorm.DB) *gorm.DB) (interface{}, error)
+	NextLinkFunc      func(*query.QueryOptions, interface{}) (*string, interface{}, error)
+	AfterRead         func(*query.QueryOptions, interface{}) (interface{}, bool, error)
+	WriteResponse     func(*query.QueryOptions, interface{}, *int64, *string) error
+}
+
+func (h *EntityHandler) executeCollectionQuery(w http.ResponseWriter, ctx *collectionExecutionContext) {
+	if ctx == nil || ctx.ParseQueryOptions == nil || ctx.FetchFunc == nil || ctx.WriteResponse == nil {
+		panic("executeCollectionQuery requires ParseQueryOptions, FetchFunc, and WriteResponse callbacks")
+	}
+
+	queryOptions, err := ctx.ParseQueryOptions()
+	if !h.handleCollectionError(w, err, http.StatusBadRequest, ErrMsgInvalidQueryOptions) {
+		return
+	}
+
+	var scopes []func(*gorm.DB) *gorm.DB
+	if ctx.BeforeRead != nil {
+		scopes, err = ctx.BeforeRead(queryOptions)
+		if !h.handleCollectionError(w, err, http.StatusForbidden, "Authorization failed") {
+			return
+		}
+	}
+
+	var totalCount *int64
+	if ctx.CountFunc != nil {
+		totalCount, err = ctx.CountFunc(queryOptions, scopes)
+		if !h.handleCollectionError(w, err, http.StatusInternalServerError, ErrMsgDatabaseError) {
+			return
+		}
+	}
+
+	results, err := ctx.FetchFunc(queryOptions, scopes)
+	if !h.handleCollectionError(w, err, http.StatusInternalServerError, ErrMsgDatabaseError) {
+		return
+	}
+
+	var nextLink *string
+	if ctx.NextLinkFunc != nil {
+		nextLink, results, err = ctx.NextLinkFunc(queryOptions, results)
+		if !h.handleCollectionError(w, err, http.StatusInternalServerError, ErrMsgInternalError) {
+			return
+		}
+	}
+
+	if ctx.AfterRead != nil {
+		if override, hasOverride, hookErr := ctx.AfterRead(queryOptions, results); !h.handleCollectionError(w, hookErr, http.StatusForbidden, "Authorization failed") {
+			return
+		} else if hasOverride {
+			results = override
+		}
+	}
+
+	h.handleCollectionError(w, ctx.WriteResponse(queryOptions, results, totalCount, nextLink), http.StatusInternalServerError, ErrMsgInternalError)
+}
+
+func (h *EntityHandler) handleCollectionError(w http.ResponseWriter, err error, defaultStatus int, defaultCode string) bool {
+	if err == nil {
+		return true
+	}
+
+	if errors.Is(err, errRequestHandled) {
+		return false
+	}
+
+	var reqErr *collectionRequestError
+	if errors.As(err, &reqErr) {
+		status := reqErr.StatusCode
+		if status == 0 {
+			status = defaultStatus
+		}
+
+		code := reqErr.ErrorCode
+		if code == "" {
+			code = defaultCode
+		}
+
+		if writeErr := response.WriteError(w, status, code, reqErr.Message); writeErr != nil {
+			fmt.Printf(LogMsgErrorWritingErrorResponse, writeErr)
+		}
+		return false
+	}
+
+	if writeErr := response.WriteError(w, defaultStatus, defaultCode, err.Error()); writeErr != nil {
+		fmt.Printf(LogMsgErrorWritingErrorResponse, writeErr)
+	}
+	return false
+}

--- a/internal/handlers/collection_test.go
+++ b/internal/handlers/collection_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestHandleCollectionAppliesFilter(t *testing.T) {
+	handler, db := setupTestHandler(t)
+
+	entities := []TestEntity{
+		{ID: 1, Name: "Alpha"},
+		{ID: 2, Name: "Beta"},
+		{ID: 3, Name: "Gamma"},
+	}
+	for _, entity := range entities {
+		if err := db.Create(&entity).Error; err != nil {
+			t.Fatalf("failed to seed data: %v", err)
+		}
+	}
+
+	query := url.Values{}
+	query.Set("$filter", "name eq 'Beta'")
+	req := httptest.NewRequest(http.MethodGet, "/TestEntities?"+query.Encode(), nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleCollection(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 status, got %d", w.Code)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	values, ok := payload["value"].([]interface{})
+	if !ok {
+		t.Fatalf("expected value array in response")
+	}
+
+	if len(values) != 1 {
+		t.Fatalf("expected single entity, got %d", len(values))
+	}
+
+	entity, ok := values[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map entry for entity result")
+	}
+
+	if entity["name"] != "Beta" {
+		t.Fatalf("expected filtered entity 'Beta', got %v", entity["name"])
+	}
+}
+
+func TestHandleCollectionAppliesPagination(t *testing.T) {
+	handler, db := setupTestHandler(t)
+
+	entities := []TestEntity{
+		{ID: 1, Name: "One"},
+		{ID: 2, Name: "Two"},
+		{ID: 3, Name: "Three"},
+	}
+	for _, entity := range entities {
+		if err := db.Create(&entity).Error; err != nil {
+			t.Fatalf("failed to seed data: %v", err)
+		}
+	}
+
+	pagination := url.Values{}
+	pagination.Set("$orderby", "id")
+	pagination.Set("$top", "1")
+	pagination.Set("$skip", "1")
+	req := httptest.NewRequest(http.MethodGet, "/TestEntities?"+pagination.Encode(), nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleCollection(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 status, got %d", w.Code)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	values, ok := payload["value"].([]interface{})
+	if !ok {
+		t.Fatalf("expected value array in response")
+	}
+
+	if len(values) != 1 {
+		t.Fatalf("expected single entity due to pagination, got %d", len(values))
+	}
+
+	entity, ok := values[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map entry for paginated entity")
+	}
+
+	if id, ok := entity["id"].(float64); !ok || int(id) != 2 {
+		t.Fatalf("expected entity with ID 2 after pagination, got %v", entity["id"])
+	}
+}
+
+func TestHandleCollectionDeltaTokenWithoutTracker(t *testing.T) {
+	handler, db := setupTestHandler(t)
+	handler.SetDeltaTracker(nil)
+
+	if err := db.Create(&TestEntity{ID: 1, Name: "Entity"}).Error; err != nil {
+		t.Fatalf("failed to seed data: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/TestEntities?$deltatoken=invalid", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleCollection(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501 when track changes are disabled, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add an executeCollectionQuery helper to centralize collection query orchestration
- refactor entity and navigation collection handlers to reuse the shared pipeline
- expand handler tests to cover filters, pagination, and delta requests after the refactor

## Testing
- go test ./...
- golangci-lint run ./...


------
https://chatgpt.com/codex/tasks/task_e_69020671e44c8328b4459d0c02b4cf36