### PR TITLE
Refactor function metadata helpers

### DIFF
--- a/internal/metadata/function_context.go
+++ b/internal/metadata/function_context.go
@@ -1,15 +1,17 @@
-package odata
+package metadata
 
 import (
 	"fmt"
 	"reflect"
 	"time"
-
-	"github.com/nlstn/go-odata/internal/metadata"
 )
 
-// functionContextFragment builds the metadata fragment for a function return type
-func (s *Service) functionContextFragment(returnType reflect.Type) string {
+var (
+	timeType = reflect.TypeOf(time.Time{})
+)
+
+// FunctionContextFragment builds the metadata fragment for a function return type.
+func FunctionContextFragment(returnType reflect.Type, entities map[string]*EntityMetadata) string {
 	if returnType == nil {
 		return ""
 	}
@@ -47,7 +49,7 @@ func (s *Service) functionContextFragment(returnType reflect.Type) string {
 		return edmType
 	}
 
-	if entityMeta := s.entityMetadataByType(typ); entityMeta != nil {
+	if entityMeta := entityMetadataByType(typ, entities); entityMeta != nil {
 		if isCollection {
 			return entityMeta.EntitySetName
 		}
@@ -75,7 +77,7 @@ func (s *Service) functionContextFragment(returnType reflect.Type) string {
 	return ""
 }
 
-func (s *Service) entityMetadataByType(goType reflect.Type) *metadata.EntityMetadata {
+func entityMetadataByType(goType reflect.Type, entities map[string]*EntityMetadata) *EntityMetadata {
 	if goType == nil {
 		return nil
 	}
@@ -84,7 +86,7 @@ func (s *Service) entityMetadataByType(goType reflect.Type) *metadata.EntityMeta
 		goType = goType.Elem()
 	}
 
-	for _, meta := range s.entities {
+	for _, meta := range entities {
 		if meta == nil {
 			continue
 		}
@@ -99,10 +101,6 @@ func (s *Service) entityMetadataByType(goType reflect.Type) *metadata.EntityMeta
 
 	return nil
 }
-
-var (
-	timeType = reflect.TypeOf(time.Time{})
-)
 
 func primitiveEdmType(goType reflect.Type) (string, bool) {
 	if goType == nil {

--- a/internal/metadata/function_context_test.go
+++ b/internal/metadata/function_context_test.go
@@ -1,0 +1,95 @@
+package metadata
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testEntity struct {
+	ID   int
+	Name string
+}
+
+type testComplex struct {
+	Street string
+}
+
+func TestFunctionContextFragment(t *testing.T) {
+	entities := map[string]*EntityMetadata{
+		"TestEntities": {
+			EntityType:    reflect.TypeOf(testEntity{}),
+			EntitySetName: "TestEntities",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		returnType reflect.Type
+		entities   map[string]*EntityMetadata
+		want       string
+	}{
+		{
+			name:       "primitive type",
+			returnType: reflect.TypeOf(""),
+			entities:   entities,
+			want:       "Edm.String",
+		},
+		{
+			name:       "primitive collection",
+			returnType: reflect.TypeOf([]int{}),
+			entities:   entities,
+			want:       "Collection(Edm.Int32)",
+		},
+		{
+			name:       "entity type",
+			returnType: reflect.TypeOf(testEntity{}),
+			entities:   entities,
+			want:       "TestEntities/$entity",
+		},
+		{
+			name:       "entity collection",
+			returnType: reflect.TypeOf([]testEntity{}),
+			entities:   entities,
+			want:       "TestEntities",
+		},
+		{
+			name:       "complex type",
+			returnType: reflect.TypeOf(testComplex{}),
+			entities:   entities,
+			want:       "ODataService.testComplex",
+		},
+		{
+			name:       "complex collection",
+			returnType: reflect.TypeOf([]testComplex{}),
+			entities:   entities,
+			want:       "Collection(ODataService.testComplex)",
+		},
+		{
+			name:       "untyped map",
+			returnType: reflect.TypeOf(map[string]interface{}{}),
+			entities:   entities,
+			want:       "Edm.Untyped",
+		},
+		{
+			name:       "untyped collection",
+			returnType: reflect.TypeOf([]map[string]interface{}{}),
+			entities:   entities,
+			want:       "Collection(Edm.Untyped)",
+		},
+		{
+			name:       "nil return type",
+			returnType: nil,
+			entities:   entities,
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FunctionContextFragment(tt.returnType, tt.entities)
+			if got != tt.want {
+				t.Fatalf("FunctionContextFragment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/service_operations.go
+++ b/service_operations.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nlstn/go-odata/internal/actions"
 	"github.com/nlstn/go-odata/internal/handlers"
+	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/response"
 )
 
@@ -156,7 +157,7 @@ func (s *Service) handleActionOrFunction(w http.ResponseWriter, r *http.Request,
 		metadataLevel := response.GetODataMetadataLevel(r)
 		w.Header().Set("Content-Type", fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
 
-		contextFragment := s.functionContextFragment(functionDef.ReturnType)
+		contextFragment := metadata.FunctionContextFragment(functionDef.ReturnType, s.entities)
 		if contextFragment == "" {
 			contextFragment = "Edm.String"
 		}


### PR DESCRIPTION
## Summary
- move the function return-type helper logic into internal/metadata and expose metadata.FunctionContextFragment
- update service operation handling to rely on the shared metadata helper
- add unit tests for primitive, entity, complex, untyped, and collection function return types

## Testing
- golangci-lint run ./... -v --timeout 5m
- go test ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_69022740e1808328a71eca68bce0f436