### PR TITLE
Document surfacing RegisterEntity errors in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ func main() {
     service := odata.NewService(db)
     
     // Register entity
-    service.RegisterEntity(&Product{})
+    if err := service.RegisterEntity(&Product{}); err != nil {
+        log.Fatal(err)
+    }
     
     // Create HTTP mux and register the OData service as a handler
     mux := http.NewServeMux()
@@ -83,7 +85,8 @@ func main() {
 }
 ```
 
-This creates a fully functional OData v4 service accessible at `http://localhost:8080`.
+This creates a fully functional OData v4 service accessible at `http://localhost:8080`. Make sure to surface registration
+errors—invalid struct tags or duplicate entity names will cause `RegisterEntity` to fail and should be addressed immediately.
 
 ## Documentation
 

--- a/documentation/entities.md
+++ b/documentation/entities.md
@@ -29,8 +29,14 @@ type Product struct {
 
 ```go
 service := odata.NewService(db)
-service.RegisterEntity(&Product{})
+if err := service.RegisterEntity(&Product{}); err != nil {
+    // Surface registration errors like invalid tags or duplicate entity set names.
+    return err
+}
 ```
+
+Always bubble up registration errors—problems such as malformed tags or duplicate entity names are detected during
+`RegisterEntity` and should be fixed before serving requests.
 
 ## Entity with Rich Metadata
 


### PR DESCRIPTION
## Summary
- capture and handle errors from `RegisterEntity` in the quick start example
- update entity documentation to show and explain surfacing registration errors

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_69027d1cb7b883288ef5530f39920252