### PR TITLE
Improve parameter decoding for actions and functions

### DIFF
--- a/test/actions_functions_test.go
+++ b/test/actions_functions_test.go
@@ -613,7 +613,7 @@ func TestActionWithParameters(t *testing.T) {
 		},
 		ReturnType: nil,
 		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
-			productID := int(params["productId"].(float64))
+			productID := int(params["productId"].(int64))
 			price := params["price"].(float64)
 
 			if err := db.Model(&ActionTestProduct{}).Where("id = ?", productID).Update("price", price).Error; err != nil {


### PR DESCRIPTION
## Summary
- decode action request bodies into the concrete parameter types using reflection and JSON unmarshalling
- extend function parameter parsing to convert JSON fragments from the query/path and relax validation for assignable composite types
- add coverage for struct, slice, and nested parameters plus document the expanded parameter support

## Testing
- GOPROXY=off golangci-lint run ./... --timeout 5m
- go test ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_69027cbd17208328aa3c90faaa562713