### PR TITLE
Make change tracking opt-in per entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ func main() {
     if err := service.RegisterEntity(&Product{}); err != nil {
         log.Fatal(err)
     }
+
+    // Enable change tracking for Products if you need $deltatoken responses
+    if err := service.EnableChangeTracking("Products"); err != nil {
+        log.Fatal(err)
+    }
     
     // Create HTTP mux and register the OData service as a handler
     mux := http.NewServeMux()
@@ -124,6 +129,7 @@ All standard OData v4 query options are supported:
 - `$count` - Include total count
 - `$search` - Full-text search
 - `$apply` - Data aggregation
+- `$deltatoken` - Change tracking (enable per entity with `EnableChangeTracking`)
 
 **Additional Features:**
 - Property access: `GET /Products(1)/Name`

--- a/cmd/complianceserver/main.go
+++ b/cmd/complianceserver/main.go
@@ -89,6 +89,10 @@ func main() {
 		log.Fatal("Failed to register ProductDescription entity:", err)
 	}
 
+	if err := service.EnableChangeTracking("Products"); err != nil {
+		log.Fatal("Failed to enable change tracking for Products:", err)
+	}
+
 	// Register the CompanyInfo singleton
 	if err := service.RegisterSingleton(&entities.CompanyInfo{}, "Company"); err != nil {
 		log.Fatal("Failed to register Company singleton:", err)

--- a/cmd/devserver/main.go
+++ b/cmd/devserver/main.go
@@ -89,6 +89,10 @@ func main() {
 		log.Fatal("Failed to register User entity:", err)
 	}
 
+	if err := service.EnableChangeTracking("Products"); err != nil {
+		log.Fatal("Failed to enable change tracking for Products:", err)
+	}
+
 	// Register the CompanyInfo singleton
 	if err := service.RegisterSingleton(&entities.CompanyInfo{}, "Company"); err != nil {
 		log.Fatal("Failed to register Company singleton:", err)

--- a/cmd/perfserver/main.go
+++ b/cmd/perfserver/main.go
@@ -163,6 +163,10 @@ func main() {
 		log.Fatal("Failed to register ProductDescription entity:", err)
 	}
 
+	if err := service.EnableChangeTracking("Products"); err != nil {
+		log.Fatal("Failed to enable change tracking for Products:", err)
+	}
+
 	// Register the CompanyInfo singleton
 	if err := service.RegisterSingleton(&entities.CompanyInfo{}, "Company"); err != nil {
 		log.Fatal("Failed to register Company singleton:", err)

--- a/internal/handlers/collection_test.go
+++ b/internal/handlers/collection_test.go
@@ -108,9 +108,8 @@ func TestHandleCollectionAppliesPagination(t *testing.T) {
 	}
 }
 
-func TestHandleCollectionDeltaTokenWithoutTracker(t *testing.T) {
+func TestHandleCollectionDeltaTokenWithoutChangeTracking(t *testing.T) {
 	handler, db := setupTestHandler(t)
-	handler.SetDeltaTracker(nil)
 
 	if err := db.Create(&TestEntity{ID: 1, Name: "Entity"}).Error; err != nil {
 		t.Fatalf("failed to seed data: %v", err)

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -59,6 +59,27 @@ func (h *EntityHandler) SetDeltaTracker(tracker *trackchanges.Tracker) {
 	h.tracker = tracker
 }
 
+// EnableChangeTracking turns on change tracking for this entity handler.
+// It registers the entity set with the configured tracker so that delta tokens can be issued.
+func (h *EntityHandler) EnableChangeTracking() error {
+	if h.metadata == nil {
+		return fmt.Errorf("entity metadata is not initialized")
+	}
+	if h.metadata.IsSingleton {
+		return fmt.Errorf("change tracking is not supported for singleton '%s'", h.metadata.EntitySetName)
+	}
+	if h.tracker == nil {
+		return fmt.Errorf("change tracker is not configured for entity set '%s'", h.metadata.EntitySetName)
+	}
+	if h.metadata.ChangeTrackingEnabled {
+		return nil
+	}
+
+	h.metadata.ChangeTrackingEnabled = true
+	h.tracker.RegisterEntity(h.metadata.EntitySetName)
+	return nil
+}
+
 // IsSingleton returns true if this handler is for a singleton
 func (h *EntityHandler) IsSingleton() bool {
 	return h.metadata.IsSingleton

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -149,7 +149,10 @@ func (h *EntityHandler) handleFetchError(w http.ResponseWriter, err error, entit
 }
 
 func (h *EntityHandler) supportsTrackChanges() bool {
-	return h.tracker != nil && !h.metadata.IsSingleton
+	if h.metadata == nil {
+		return false
+	}
+	return h.tracker != nil && h.metadata.ChangeTrackingEnabled && !h.metadata.IsSingleton
 }
 
 func (h *EntityHandler) recordChange(entity interface{}, changeType trackchanges.ChangeType) {

--- a/internal/handlers/track_changes_test.go
+++ b/internal/handlers/track_changes_test.go
@@ -19,6 +19,10 @@ import (
 func TestHandleCollectionTrackChanges(t *testing.T) {
 	handler, db := setupTestHandler(t)
 
+	if err := handler.EnableChangeTracking(); err != nil {
+		t.Fatalf("failed to enable change tracking: %v", err)
+	}
+
 	if err := db.Create(&TestEntity{ID: 1, Name: "Initial"}).Error; err != nil {
 		t.Fatalf("failed to seed data: %v", err)
 	}
@@ -174,6 +178,10 @@ func setupTrackChangesHandlerWithETag(t *testing.T) (*EntityHandler, *gorm.DB, *
 	tracker := trackchanges.NewTracker()
 	tracker.RegisterEntity(entityMeta.EntitySetName)
 	handler.SetDeltaTracker(tracker)
+
+	if err := handler.EnableChangeTracking(); err != nil {
+		t.Fatalf("failed to enable change tracking: %v", err)
+	}
 
 	return handler, db, entityMeta
 }

--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -8,17 +8,19 @@ import (
 
 // EntityMetadata holds metadata information about an OData entity
 type EntityMetadata struct {
-	EntityType       reflect.Type
-	EntityName       string
-	EntitySetName    string
-	Properties       []PropertyMetadata
-	KeyProperties    []PropertyMetadata // Support for composite keys
-	KeyProperty      *PropertyMetadata  // Deprecated: Use KeyProperties for single or composite keys, kept for backwards compatibility
-	ETagProperty     *PropertyMetadata  // Property used for ETag generation (optional)
-	IsSingleton      bool               // True if this is a singleton (single instance accessible by name)
-	SingletonName    string             // Name of the singleton (if IsSingleton is true)
-	HasStream        bool               // True if this is a media entity (has a media stream)
-	StreamProperties []PropertyMetadata // Named stream properties on this entity
+	EntityType    reflect.Type
+	EntityName    string
+	EntitySetName string
+	Properties    []PropertyMetadata
+	KeyProperties []PropertyMetadata // Support for composite keys
+	KeyProperty   *PropertyMetadata  // Deprecated: Use KeyProperties for single or composite keys, kept for backwards compatibility
+	ETagProperty  *PropertyMetadata  // Property used for ETag generation (optional)
+	IsSingleton   bool               // True if this is a singleton (single instance accessible by name)
+	SingletonName string             // Name of the singleton (if IsSingleton is true)
+	HasStream     bool               // True if this is a media entity (has a media stream)
+	// ChangeTrackingEnabled indicates whether $deltatoken and change tracking responses are enabled for this entity set
+	ChangeTrackingEnabled bool
+	StreamProperties      []PropertyMetadata // Named stream properties on this entity
 	// Hooks defines which lifecycle hooks are available on this entity
 	Hooks struct {
 		HasBeforeCreate         bool

--- a/odata.go
+++ b/odata.go
@@ -99,9 +99,26 @@ func (s *Service) RegisterEntity(entity interface{}) error {
 	handler.SetDeltaTracker(s.deltaTracker)
 	s.handlers[entityMetadata.EntitySetName] = handler
 
-	s.deltaTracker.RegisterEntity(entityMetadata.EntitySetName)
-
 	fmt.Printf("Registered entity: %s (EntitySet: %s)\n", entityMetadata.EntityName, entityMetadata.EntitySetName)
+	return nil
+}
+
+// EnableChangeTracking enables OData change tracking for the specified entity set.
+// When enabled, the service will issue delta tokens and record entity changes.
+func (s *Service) EnableChangeTracking(entitySetName string) error {
+	handler, exists := s.handlers[entitySetName]
+	if !exists {
+		return fmt.Errorf("entity set '%s' is not registered", entitySetName)
+	}
+
+	if handler == nil {
+		return fmt.Errorf("entity handler for '%s' is not initialized", entitySetName)
+	}
+
+	if err := handler.EnableChangeTracking(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add a change-tracking enablement API and metadata flag so delta responses are only issued when explicitly enabled per entity set
- update sample servers, documentation, and tests to reflect the opt-in behavior and validate disabled delta handling

## Testing
- go test ./...
- go build ./...
- golangci-lint run ./...


------
https://chatgpt.com/codex/tasks/task_e_690284aad6ec832885cc11c13c3154ae