### PR TITLE
Add respond-async preference handling

### DIFF
--- a/test/prefer_test.go
+++ b/test/prefer_test.go
@@ -444,3 +444,28 @@ func TestPreferHeader_MultiplePreferences(t *testing.T) {
 		t.Errorf("Preference-Applied = %v, want return=minimal", preferenceApplied)
 	}
 }
+
+func TestPreferHeader_RespondAsyncOnlyDoesNotSetPreferenceApplied(t *testing.T) {
+	service, _ := setupPreferTestService(t)
+
+	newProduct := map[string]interface{}{
+		"name":  "AsyncOnly",
+		"price": 15.00,
+	}
+	body, _ := json.Marshal(newProduct)
+
+	req := httptest.NewRequest(http.MethodPost, "/PreferTestProducts", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Prefer", "respond-async")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Status = %v, want %v", w.Code, http.StatusCreated)
+	}
+
+	if preferenceApplied := w.Header().Get("Preference-Applied"); preferenceApplied != "" {
+		t.Fatalf("Preference-Applied should be empty when async preference is not honored, got %q", preferenceApplied)
+	}
+}


### PR DESCRIPTION
## Summary
- track the respond-async preference, expose an apply helper, and add a sanitization utility for async dispatch
- cover respond-async parsing, sanitization, and Preference-Applied combinations in preference unit tests
- exercise synchronous handling of respond-async requests in integration tests

## Testing
- golangci-lint run ./... --timeout=5m
- go test ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_690285c07ffc8328ac71c7933608b06b