### PR TITLE
Add asynchronous job manager with lifecycle handling

### DIFF
--- a/internal/async/manager.go
+++ b/internal/async/manager.go
@@ -1,0 +1,474 @@
+package async
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"math"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// JobStatus represents the lifecycle state of an asynchronous job.
+type JobStatus string
+
+const (
+	// JobPending indicates the job has been created but not yet completed.
+	JobPending JobStatus = "pending"
+	// JobRunning indicates the job handler is executing.
+	JobRunning JobStatus = "running"
+	// JobCompleted indicates the job handler succeeded and produced a response.
+	JobCompleted JobStatus = "completed"
+	// JobFailed indicates the job handler finished with an error.
+	JobFailed JobStatus = "failed"
+	// JobCanceled indicates the job was canceled before completion.
+	JobCanceled JobStatus = "canceled"
+)
+
+// StoredResponse captures the output of an asynchronous job for later replay.
+type StoredResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// Job represents the execution of an asynchronous handler.
+type Job struct {
+	ID          string
+	Status      JobStatus
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	CompletedAt *time.Time
+	Response    *StoredResponse
+	Error       string
+
+	monitorURL string
+	retryAfter *time.Duration
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// WithMonitorURL sets the URL clients should poll for job status.
+func WithMonitorURL(url string) JobOption {
+	return func(j *Job) {
+		j.monitorURL = url
+	}
+}
+
+// WithRetryAfter configures an optional Retry-After header for the job.
+func WithRetryAfter(d time.Duration) JobOption {
+	return func(j *Job) {
+		j.retryAfter = &d
+	}
+}
+
+// JobOption mutates a job at creation time.
+type JobOption func(*Job)
+
+// Handler is the unit of work executed for an asynchronous job.
+type Handler func(ctx context.Context) (*StoredResponse, error)
+
+// Manager supervises asynchronous jobs, tracking their lifecycle and cleanup.
+type Manager struct {
+	mu            sync.Mutex
+	jobs          map[string]*Job
+	ttl           time.Duration
+	cleanupTicker *time.Ticker
+	stopCleanup   chan struct{}
+}
+
+// NewManager constructs a Manager with the supplied TTL for completed jobs.
+func NewManager(ttl time.Duration) *Manager {
+	m := &Manager{
+		jobs:        make(map[string]*Job),
+		ttl:         ttl,
+		stopCleanup: make(chan struct{}),
+	}
+
+	if ttl > 0 {
+		interval := ttl / 2
+		if interval <= 0 {
+			interval = ttl
+		}
+		m.cleanupTicker = time.NewTicker(interval)
+		go func() {
+			for {
+				select {
+				case <-m.cleanupTicker.C:
+					m.cleanupExpired()
+				case <-m.stopCleanup:
+					m.cleanupTicker.Stop()
+					return
+				}
+			}
+		}()
+	}
+
+	return m
+}
+
+// Close stops the manager's background cleanup.
+func (m *Manager) Close() {
+	if m.cleanupTicker == nil {
+		return
+	}
+	select {
+	case <-m.stopCleanup:
+		// already closed
+	default:
+		close(m.stopCleanup)
+	}
+}
+
+// StartJob registers a new asynchronous job and launches the handler in a goroutine.
+func (m *Manager) StartJob(ctx context.Context, handler Handler, opts ...JobOption) (*Job, error) {
+	if handler == nil {
+		return nil, errors.New("async: handler is required")
+	}
+
+	id, err := generateID()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	job := &Job{
+		ID:        id,
+		Status:    JobPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+		done:      make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(job)
+	}
+
+	jobCtx, cancel := context.WithCancel(ctx)
+	job.cancel = cancel
+
+	m.mu.Lock()
+	m.jobs[job.ID] = job
+	m.mu.Unlock()
+
+	go m.run(job, jobCtx, handler)
+
+	return job, nil
+}
+
+// GetJob retrieves a job by ID.
+func (m *Manager) GetJob(id string) (*Job, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.jobs[id]
+	return job, ok
+}
+
+// CancelJob requests cancellation of the specified job.
+func (m *Manager) CancelJob(id string) bool {
+	m.mu.Lock()
+	job, ok := m.jobs[id]
+	if !ok {
+		m.mu.Unlock()
+		return false
+	}
+
+	if job.Status == JobCompleted || job.Status == JobFailed || job.Status == JobCanceled {
+		m.mu.Unlock()
+		return false
+	}
+
+	cancel := job.cancel
+	m.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+
+	return true
+}
+
+// Wait blocks until the job reaches a terminal state.
+func (j *Job) Wait() {
+	<-j.done
+}
+
+func (m *Manager) run(job *Job, ctx context.Context, handler Handler) {
+	defer close(job.done)
+
+	m.updateStatus(job, JobRunning)
+
+	resp, err := handler(ctx)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+			m.finish(job, JobCanceled, resp, nil)
+			return
+		}
+		m.finish(job, JobFailed, resp, err)
+		return
+	}
+
+	m.finish(job, JobCompleted, resp, nil)
+}
+
+func (m *Manager) updateStatus(job *Job, status JobStatus) {
+	m.mu.Lock()
+	job.Status = status
+	now := time.Now()
+	job.UpdatedAt = now
+	m.mu.Unlock()
+}
+
+func (m *Manager) finish(job *Job, status JobStatus, resp *StoredResponse, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	job.Status = status
+	now := time.Now()
+	job.UpdatedAt = now
+	job.CompletedAt = &now
+
+	if resp != nil {
+		job.Response = cloneStoredResponse(resp)
+	}
+
+	if err != nil {
+		job.Error = err.Error()
+	}
+}
+
+func cloneStoredResponse(resp *StoredResponse) *StoredResponse {
+	if resp == nil {
+		return nil
+	}
+	cloned := &StoredResponse{
+		StatusCode: resp.StatusCode,
+		Body:       append([]byte(nil), resp.Body...),
+	}
+	if resp.Header != nil {
+		cloned.Header = make(http.Header, len(resp.Header))
+		for k, vv := range resp.Header {
+			cloned.Header[k] = append([]string(nil), vv...)
+		}
+	} else {
+		cloned.Header = make(http.Header)
+	}
+	return cloned
+}
+
+func generateID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func (m *Manager) cleanupExpired() {
+	if m.ttl <= 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-m.ttl)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for id, job := range m.jobs {
+		if job.CompletedAt == nil {
+			continue
+		}
+		if job.CompletedAt.Before(cutoff) {
+			delete(m.jobs, id)
+		}
+	}
+}
+
+// WriteInitialResponse writes the HTTP 202 response acknowledging an async job.
+func WriteInitialResponse(w http.ResponseWriter, job *Job) {
+	if job == nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	location := job.monitorURL
+	if location == "" {
+		location = job.ID
+	}
+	w.Header().Set("Location", location)
+	w.Header().Set("Preference-Applied", "respond-async")
+	if job.retryAfter != nil {
+		w.Header().Set("Retry-After", formatRetryAfter(*job.retryAfter))
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func formatRetryAfter(d time.Duration) string {
+	if d <= 0 {
+		return "0"
+	}
+	seconds := int64(math.Ceil(d.Seconds()))
+	return strconv.FormatInt(seconds, 10)
+}
+
+// ServeMonitor handles HTTP requests for job status monitoring.
+func (m *Manager) ServeMonitor(w http.ResponseWriter, r *http.Request) {
+	id := extractJobID(r)
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	m.mu.Lock()
+	job, ok := m.jobs[id]
+	m.mu.Unlock()
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		if m.CancelJob(id) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if job.Status == JobCanceled {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if job.Status == JobCompleted || job.Status == JobFailed {
+			m.mu.Lock()
+			delete(m.jobs, id)
+			m.mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	case http.MethodGet, http.MethodHead, "":
+		// continue below
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	switch job.Status {
+	case JobPending, JobRunning:
+		w.Header().Set("Preference-Applied", "respond-async")
+		if job.retryAfter != nil {
+			w.Header().Set("Retry-After", formatRetryAfter(*job.retryAfter))
+		}
+		w.WriteHeader(http.StatusAccepted)
+	case JobCompleted:
+		writeStoredResponse(w, job.Response, r.Method != http.MethodHead)
+	case JobFailed:
+		if job.Response != nil {
+			writeStoredResponse(w, job.Response, r.Method != http.MethodHead)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		if job.Error != "" && r.Method != http.MethodHead {
+			writeBytes(w, []byte(job.Error))
+		}
+	case JobCanceled:
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+func writeStoredResponse(w http.ResponseWriter, resp *StoredResponse, includeBody bool) {
+	if resp == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	copyHeader(w.Header(), resp.Header)
+	status := resp.StatusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	if includeBody && len(resp.Body) > 0 {
+		writeBytes(w, resp.Body)
+	}
+}
+
+func copyHeader(dst, src http.Header) {
+	for k := range dst {
+		dst.Del(k)
+	}
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func writeBytes(w http.ResponseWriter, body []byte) {
+	if len(body) == 0 {
+		return
+	}
+	if _, err := w.Write(body); err != nil {
+		return
+	}
+}
+
+func extractJobID(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return ""
+	}
+	p := r.URL.Path
+	if p == "" || p == "/" {
+		return ""
+	}
+	p = strings.TrimSuffix(p, "/")
+	return path.Base(p)
+}
+
+// MonitorURL returns the URL clients should poll for this job.
+func (j *Job) MonitorURL() string {
+	return j.monitorURL
+}
+
+// RetryAfter returns the configured retry duration if present.
+func (j *Job) RetryAfter() (time.Duration, bool) {
+	if j.retryAfter == nil {
+		return 0, false
+	}
+	return *j.retryAfter, true
+}
+
+// SetRetryAfter updates the retry-after duration for the job. A non-positive
+// duration clears the setting.
+func (j *Job) SetRetryAfter(d time.Duration) {
+	if d <= 0 {
+		j.retryAfter = nil
+		return
+	}
+	j.retryAfter = &d
+}
+
+// SetMonitorURL updates the monitoring URL for the job.
+func (j *Job) SetMonitorURL(url string) {
+	j.monitorURL = url
+}
+
+// ErrorMessage returns the stored error for the job.
+func (j *Job) ErrorMessage() string {
+	return j.Error
+}
+
+// IsTerminal reports whether the job has completed execution.
+func (j *Job) IsTerminal() bool {
+	switch j.Status {
+	case JobCompleted, JobFailed, JobCanceled:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/async/manager_test.go
+++ b/internal/async/manager_test.go
@@ -1,0 +1,160 @@
+package async
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestManagerLifecycle(t *testing.T) {
+	mgr := NewManager(0)
+	t.Cleanup(mgr.Close)
+
+	started := make(chan struct{})
+	finish := make(chan struct{})
+
+	handler := func(ctx context.Context) (*StoredResponse, error) {
+		close(started)
+		select {
+		case <-finish:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		hdr := http.Header{}
+		hdr.Set("Content-Type", "application/json")
+		return &StoredResponse{
+			StatusCode: http.StatusCreated,
+			Header:     hdr,
+			Body:       []byte(`{"status":"ok"}`),
+		}, nil
+	}
+
+	job, err := mgr.StartJob(context.Background(), handler, WithRetryAfter(2*time.Second))
+	if err != nil {
+		t.Fatalf("StartJob error: %v", err)
+	}
+	job.SetMonitorURL("/async/jobs/" + job.ID)
+
+	initial := httptest.NewRecorder()
+	WriteInitialResponse(initial, job)
+	if initial.Code != http.StatusAccepted {
+		t.Fatalf("expected initial status 202, got %d", initial.Code)
+	}
+	if got := initial.Header().Get("Location"); got != job.MonitorURL() {
+		t.Fatalf("expected Location %q, got %q", job.MonitorURL(), got)
+	}
+	if got := initial.Header().Get("Preference-Applied"); got != "respond-async" {
+		t.Fatalf("expected Preference-Applied header, got %q", got)
+	}
+	if got := initial.Header().Get("Retry-After"); got != "2" {
+		t.Fatalf("expected Retry-After of 2, got %q", got)
+	}
+
+	<-started
+
+	pendingReq := httptest.NewRequest(http.MethodGet, job.MonitorURL(), nil)
+	pendingRec := httptest.NewRecorder()
+	mgr.ServeMonitor(pendingRec, pendingReq)
+	if pendingRec.Code != http.StatusAccepted {
+		t.Fatalf("expected pending status 202, got %d", pendingRec.Code)
+	}
+	if got := pendingRec.Header().Get("Preference-Applied"); got != "respond-async" {
+		t.Fatalf("expected pending Preference-Applied header, got %q", got)
+	}
+
+	close(finish)
+	job.Wait()
+
+	completeReq := httptest.NewRequest(http.MethodGet, job.MonitorURL(), nil)
+	completeRec := httptest.NewRecorder()
+	mgr.ServeMonitor(completeRec, completeReq)
+
+	if completeRec.Code != http.StatusCreated {
+		t.Fatalf("expected completed status 201, got %d", completeRec.Code)
+	}
+	if got := completeRec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected Content-Type to be propagated, got %q", got)
+	}
+	if body := completeRec.Body.String(); body != `{"status":"ok"}` {
+		t.Fatalf("unexpected body %q", body)
+	}
+
+	headReq := httptest.NewRequest(http.MethodHead, job.MonitorURL(), nil)
+	headRec := httptest.NewRecorder()
+	mgr.ServeMonitor(headRec, headReq)
+	if headRec.Code != http.StatusCreated {
+		t.Fatalf("expected HEAD status to match final response, got %d", headRec.Code)
+	}
+	if headRec.Body.Len() != 0 {
+		t.Fatalf("expected no body for HEAD request, got %q", headRec.Body.String())
+	}
+}
+
+func TestManagerCancellation(t *testing.T) {
+	mgr := NewManager(0)
+	t.Cleanup(mgr.Close)
+
+	release := make(chan struct{})
+	handler := func(ctx context.Context) (*StoredResponse, error) {
+		select {
+		case <-release:
+			return &StoredResponse{StatusCode: http.StatusOK}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	job, err := mgr.StartJob(context.Background(), handler)
+	if err != nil {
+		t.Fatalf("StartJob error: %v", err)
+	}
+	job.SetMonitorURL("/async/jobs/" + job.ID)
+
+	cancelReq := httptest.NewRequest(http.MethodDelete, job.MonitorURL(), nil)
+	cancelRec := httptest.NewRecorder()
+	mgr.ServeMonitor(cancelRec, cancelReq)
+
+	if cancelRec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on cancel, got %d", cancelRec.Code)
+	}
+
+	job.Wait()
+	if job.Status != JobCanceled {
+		t.Fatalf("expected job status canceled, got %s", job.Status)
+	}
+
+	afterReq := httptest.NewRequest(http.MethodGet, job.MonitorURL(), nil)
+	afterRec := httptest.NewRecorder()
+	mgr.ServeMonitor(afterRec, afterReq)
+	if afterRec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 after cancellation, got %d", afterRec.Code)
+	}
+}
+
+func TestManagerCleanupRemovesOldJobs(t *testing.T) {
+	ttl := 10 * time.Millisecond
+	mgr := NewManager(ttl)
+	t.Cleanup(mgr.Close)
+
+	job, err := mgr.StartJob(context.Background(), func(ctx context.Context) (*StoredResponse, error) {
+		return &StoredResponse{StatusCode: http.StatusOK}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartJob error: %v", err)
+	}
+	job.SetMonitorURL("/async/jobs/" + job.ID)
+
+	job.Wait()
+	if _, ok := mgr.GetJob(job.ID); !ok {
+		t.Fatalf("expected job to be retained immediately after completion")
+	}
+
+	time.Sleep(3 * ttl)
+	mgr.cleanupExpired()
+
+	if _, ok := mgr.GetJob(job.ID); ok {
+		t.Fatalf("expected job to be cleaned up after TTL")
+	}
+}


### PR DESCRIPTION
## Summary
- add an internal async manager that tracks job lifecycle state, response data, and TTL cleanup
- provide helpers for initial and monitoring HTTP responses including cancellation handling
- cover the async manager with unit tests for lifecycle, cancellation, and cleanup flows

## Testing
- go test ./...
- go build ./...
- golangci-lint run ./...


------
https://chatgpt.com/codex/tasks/task_e_6902886fecac8328b87746eee03d55e4