### PR TITLE
Add async request handling support

### DIFF
--- a/service_async_test.go
+++ b/service_async_test.go
@@ -1,0 +1,85 @@
+package odata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type asyncTestEntity struct {
+	ID   uint `gorm:"primaryKey" odata:"key"`
+	Name string
+}
+
+func TestServiceRespondAsyncFlow(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&asyncTestEntity{}); err != nil {
+		t.Fatalf("failed to migrate test entity: %v", err)
+	}
+
+	svc := NewService(db)
+	if err := svc.RegisterEntity(&asyncTestEntity{}); err != nil {
+		t.Fatalf("failed to register entity: %v", err)
+	}
+
+	svc.EnableAsyncProcessing(AsyncConfig{
+		MonitorPathPrefix:    "/$async/jobs",
+		DefaultRetryInterval: 3 * time.Second,
+		JobRetention:         time.Minute,
+	})
+	if svc.asyncManager != nil {
+		t.Cleanup(svc.asyncManager.Close)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/AsyncTestEntities", nil)
+	req.Header.Set("Prefer", "return=minimal, respond-async")
+
+	rec := httptest.NewRecorder()
+	svc.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 Accepted, got %d", rec.Code)
+	}
+
+	if applied := rec.Header().Get("Preference-Applied"); applied != "respond-async" {
+		t.Fatalf("expected Preference-Applied to be respond-async, got %q", applied)
+	}
+
+	if retry := rec.Header().Get("Retry-After"); retry != "3" {
+		t.Fatalf("expected Retry-After header of 3, got %q", retry)
+	}
+
+	location := rec.Header().Get("Location")
+	if location == "" {
+		t.Fatal("expected Location header with monitor URL")
+	}
+
+	if !strings.HasPrefix(location, svc.asyncMonitorPrefix) {
+		t.Fatalf("monitor URL %q does not start with prefix %q", location, svc.asyncMonitorPrefix)
+	}
+
+	jobID := strings.TrimPrefix(location, svc.asyncMonitorPrefix)
+	job, ok := svc.asyncManager.GetJob(jobID)
+	if !ok {
+		t.Fatalf("expected job %q to be registered", jobID)
+	}
+
+	job.Wait()
+
+	monitorReq := httptest.NewRequest(http.MethodGet, location, nil)
+	monitorRec := httptest.NewRecorder()
+	svc.ServeHTTP(monitorRec, monitorReq)
+
+	if monitorRec.Code == http.StatusAccepted {
+		t.Fatalf("expected terminal monitor response, got status %d", monitorRec.Code)
+	}
+}

--- a/service_router.go
+++ b/service_router.go
@@ -1,12 +1,181 @@
 package odata
 
-import "net/http"
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/nlstn/go-odata/internal/async"
+	"github.com/nlstn/go-odata/internal/preference"
+)
 
 // ServeHTTP implements http.Handler by delegating to the internal router.
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.serveHTTP(w, r, true)
+}
+
+func (s *Service) serveHTTP(w http.ResponseWriter, r *http.Request, allowAsync bool) {
 	if s.router == nil {
 		http.Error(w, "service router not initialized", http.StatusInternalServerError)
 		return
 	}
+
+	if allowAsync && s.tryHandleAsync(w, r) {
+		return
+	}
+
 	s.router.ServeHTTP(w, r)
+}
+
+func (s *Service) tryHandleAsync(w http.ResponseWriter, r *http.Request) bool {
+	if s.asyncManager == nil || s.asyncConfig == nil {
+		return false
+	}
+
+	if s.asyncMonitorPrefix != "" && strings.HasPrefix(r.URL.Path, s.asyncMonitorPrefix) {
+		s.asyncManager.ServeMonitor(w, r)
+		return true
+	}
+
+	pref := preference.ParsePrefer(r)
+	if pref == nil || !pref.RespondAsyncRequested {
+		return false
+	}
+
+	trimmed := strings.TrimPrefix(r.URL.Path, "/")
+	if !isAsyncEligiblePath(trimmed) {
+		return false
+	}
+
+	body, err := bufferRequestBody(r)
+	if err != nil {
+		http.Error(w, "failed to buffer request body", http.StatusInternalServerError)
+		return true
+	}
+
+	sanitizedPrefer := preference.SanitizeForAsyncDispatch(r.Header.Get("Prefer"))
+
+	queueToken := s.acquireAsyncSlot()
+	if queueToken == nil {
+		// Fallback to synchronous execution
+		restoreRequestBody(r, body)
+		return false
+	}
+
+	handler := func(ctx context.Context) (*async.StoredResponse, error) {
+		defer queueToken.release()
+
+		reqCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		cloned := r.Clone(reqCtx)
+		restoreRequestBody(cloned, body)
+		if sanitizedPrefer == "" {
+			cloned.Header.Del("Prefer")
+		} else {
+			cloned.Header.Set("Prefer", sanitizedPrefer)
+		}
+
+		recorder := httptest.NewRecorder()
+		s.router.ServeHTTP(recorder, cloned)
+
+		return &async.StoredResponse{
+			StatusCode: recorder.Code,
+			Header:     cloneHeader(recorder.Header()),
+			Body:       append([]byte(nil), recorder.Body.Bytes()...),
+		}, nil
+	}
+
+	jobOpts := []async.JobOption{}
+	if s.asyncConfig.DefaultRetryInterval > 0 {
+		jobOpts = append(jobOpts, async.WithRetryAfter(s.asyncConfig.DefaultRetryInterval))
+	}
+
+	job, err := s.asyncManager.StartJob(r.Context(), handler, jobOpts...)
+	if err != nil {
+		restoreRequestBody(r, body)
+		queueToken.release()
+		http.Error(w, "failed to start async job", http.StatusInternalServerError)
+		return true
+	}
+
+	restoreRequestBody(r, body)
+
+	if s.asyncMonitorPrefix != "" {
+		job.SetMonitorURL(s.asyncMonitorPrefix + job.ID)
+	}
+
+	async.WriteInitialResponse(w, job)
+	return true
+}
+
+type queueToken struct {
+	ch chan struct{}
+}
+
+func (t *queueToken) release() {
+	if t == nil || t.ch == nil {
+		return
+	}
+	<-t.ch
+}
+
+func (s *Service) acquireAsyncSlot() *queueToken {
+	if s.asyncQueue == nil {
+		return &queueToken{}
+	}
+
+	select {
+	case s.asyncQueue <- struct{}{}:
+		return &queueToken{ch: s.asyncQueue}
+	default:
+		return nil
+	}
+}
+
+func bufferRequestBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	bodyReader := r.Body
+	defer func(body io.ReadCloser) {
+		_ = body.Close() //nolint:errcheck // best effort close
+	}(bodyReader)
+
+	body, err := io.ReadAll(bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func restoreRequestBody(r *http.Request, body []byte) {
+	if r.Body != nil {
+		_ = r.Body.Close() //nolint:errcheck // replace body regardless of close error
+	}
+	reader := bytes.NewReader(body)
+	r.Body = io.NopCloser(reader)
+	r.ContentLength = int64(len(body))
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+}
+
+func cloneHeader(h http.Header) http.Header {
+	cloned := make(http.Header, len(h))
+	for k, vals := range h {
+		cloned[k] = append([]string(nil), vals...)
+	}
+	return cloned
+}
+
+func isAsyncEligiblePath(path string) bool {
+	switch path {
+	case "", "$metadata", "$batch":
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- extend the Service to expose async processing configuration and manager wiring
- update ServeHTTP to dispatch respond-async requests through the async manager and fall back for ineligible routes
- add coverage for the async flow including monitor responses

## Testing
- go test ./...
- golangci-lint run ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_69028b0d33fc832884cde6cb5d51e4eb