### PR TITLE
Ensure entity update handlers report ETag mismatches

### DIFF
--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -13,6 +14,8 @@ import (
 	"github.com/nlstn/go-odata/internal/trackchanges"
 	"gorm.io/gorm"
 )
+
+var errETagMismatch = errors.New("etag mismatch")
 
 // handleDeleteEntity handles DELETE requests for individual entities
 func (h *EntityHandler) handleDeleteEntity(w http.ResponseWriter, r *http.Request, entityKey string) {
@@ -116,7 +119,7 @@ func (h *EntityHandler) fetchAndUpdateEntity(w http.ResponseWriter, r *http.Requ
 				ErrDetailPreconditionFailed); writeErr != nil {
 				fmt.Printf(LogMsgErrorWritingErrorResponse, writeErr)
 			}
-			return nil, nil, err
+			return nil, nil, errETagMismatch
 		}
 	}
 
@@ -278,7 +281,7 @@ func (h *EntityHandler) fetchAndReplaceEntity(w http.ResponseWriter, r *http.Req
 				ErrDetailPreconditionFailed); writeErr != nil {
 				fmt.Printf(LogMsgErrorWritingErrorResponse, writeErr)
 			}
-			return nil, err
+			return nil, errETagMismatch
 		}
 	}
 

--- a/internal/handlers/entity_write_test.go
+++ b/internal/handlers/entity_write_test.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type etagTestEntity struct {
+	ID      int    `json:"id" gorm:"primarykey" odata:"key"`
+	Version int    `json:"version" odata:"etag"`
+	Name    string `json:"name"`
+}
+
+func setupETagTestHandler(t *testing.T) (*EntityHandler, *gorm.DB) {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&etagTestEntity{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	entityMeta, err := metadata.AnalyzeEntity(etagTestEntity{})
+	if err != nil {
+		t.Fatalf("Failed to analyze entity: %v", err)
+	}
+
+	handler := NewEntityHandler(db, entityMeta)
+	return handler, db
+}
+
+func TestHandlePatchEntityIfMatchMismatch(t *testing.T) {
+	handler, db := setupETagTestHandler(t)
+
+	entity := etagTestEntity{ID: 1, Version: 1, Name: "Original"}
+	if err := db.Create(&entity).Error; err != nil {
+		t.Fatalf("Failed to create entity: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPatch, "/etagTestEntities(1)", strings.NewReader(`{"name":"Updated"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Prefer", "return=representation")
+	req.Header.Set(HeaderIfMatch, "W/\"mismatched\"")
+
+	w := httptest.NewRecorder()
+
+	handler.handlePatchEntity(w, req, "1")
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("Status = %v, want %v", w.Code, http.StatusPreconditionFailed)
+	}
+
+	if header := w.Header().Get(HeaderPreferenceApplied); header != "" {
+		t.Fatalf("Preference-Applied header was set: %q", header)
+	}
+
+	if header := w.Header().Get(HeaderODataEntityId); header != "" {
+		t.Fatalf("OData-EntityId header was set: %q", header)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("Failed to decode response body: %v", err)
+	}
+
+	if _, ok := body["error"]; !ok {
+		t.Fatalf("Response does not contain error object: %v", body)
+	}
+}
+
+func TestHandlePutEntityIfMatchMismatch(t *testing.T) {
+	handler, db := setupETagTestHandler(t)
+
+	entity := etagTestEntity{ID: 1, Version: 1, Name: "Original"}
+	if err := db.Create(&entity).Error; err != nil {
+		t.Fatalf("Failed to create entity: %v", err)
+	}
+
+	reqBody := `{"id":1,"version":1,"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/etagTestEntities(1)", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Prefer", "return=representation")
+	req.Header.Set(HeaderIfMatch, "W/\"mismatched\"")
+
+	w := httptest.NewRecorder()
+
+	handler.handlePutEntity(w, req, "1")
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("Status = %v, want %v", w.Code, http.StatusPreconditionFailed)
+	}
+
+	if header := w.Header().Get(HeaderPreferenceApplied); header != "" {
+		t.Fatalf("Preference-Applied header was set: %q", header)
+	}
+
+	if header := w.Header().Get(HeaderODataEntityId); header != "" {
+		t.Fatalf("OData-EntityId header was set: %q", header)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("Failed to decode response body: %v", err)
+	}
+
+	if _, ok := body["error"]; !ok {
+		t.Fatalf("Response does not contain error object: %v", body)
+	}
+}


### PR DESCRIPTION
## Summary
- return a sentinel error when PATCH/PUT ETag checks fail so callers stop after writing the 412 response
- add unit tests covering mismatched If-Match handling to ensure no success headers or payloads are emitted

## Testing
- golangci-lint run --timeout 5m ./...
- go test ./...
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_690359e2095c83289fb46dbdddea4023