### PR TITLE
Raise Go requirement to 1.24

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -123,7 +123,7 @@ The `compliance/` directory contains executable shell scripts that validate the 
 
 ### Requirements
 
-- Go 1.21 or later
+- Go 1.24 or later
 - GORM-compatible database driver
 - MIT License
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ behaviour.
 
 ## Requirements
 
-- Go 1.21 or later
+- Go 1.24 or later
 - GORM-compatible database driver
 
 ## Testing

--- a/cmd/perfserver/go.mod
+++ b/cmd/perfserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/NLstn/go-odata/perfserver
 
-go 1.24.7
+go 1.24
 
 replace github.com/nlstn/go-odata => ../../
 


### PR DESCRIPTION
## Summary
- update all module go directives to require Go 1.24
- document the Go 1.24 minimum version in project requirements and agent guidance
- configure CI jobs to install and cache Go 1.24 toolchains

## Testing
- go test ./...
- go build ./...
- golangci-lint run ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc9c5b2c08328b02cacec4a712ceb)