### PR TITLE
Add persistent change tracking storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ rely on version numbers to reason about compatibility.
 
 ## [Unreleased]
 
-- Track upcoming enhancements here.
+### Added
+
+- Persistent change-tracking storage backed by GORM, including a `_odata_change_log` table and
+  `ServiceConfig.PersistentChangeTracking` for restart-safe delta tokens.
+- Integration tests that recreate the service from stored change history to ensure delta tokens survive restarts.
 
 ## [v0.1.0] - 2025-11-07 _(planned)_
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ func main() {
     if err := service.EnableChangeTracking("Products"); err != nil {
         log.Fatal(err)
     }
+
+    // To persist change history across restarts, build the service with:
+    // service, err := odata.NewServiceWithConfig(db, odata.ServiceConfig{PersistentChangeTracking: true})
+    // and handle err accordingly. The tracker stores events in the reserved `_odata_change_log` table.
     
     // Create HTTP mux and register the OData service as a handler
     mux := http.NewServeMux()

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -165,7 +165,11 @@ func (h *EntityHandler) recordChange(entity interface{}, changeType trackchanges
 	if changeType != trackchanges.ChangeTypeDeleted {
 		data = h.entityToMap(entity)
 	}
-	h.tracker.RecordChange(h.metadata.EntitySetName, keyValues, data, changeType)
+	if _, err := h.tracker.RecordChange(h.metadata.EntitySetName, keyValues, data, changeType); err != nil {
+		if h.logger != nil {
+			h.logger.Error("failed to record change event", "entitySet", h.metadata.EntitySetName, "err", err)
+		}
+	}
 }
 
 func (h *EntityHandler) extractKeyValues(entity interface{}) map[string]interface{} {

--- a/internal/trackchanges/tracker.go
+++ b/internal/trackchanges/tracker.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+
+	"gorm.io/gorm"
 )
 
 // ChangeType represents the type of change recorded for an entity instance.
@@ -42,11 +44,41 @@ type entityHistory struct {
 type Tracker struct {
 	mu       sync.RWMutex
 	entities map[string]*entityHistory
+	db       *gorm.DB
 }
 
 // NewTracker creates a new change tracker.
 func NewTracker() *Tracker {
-	return &Tracker{entities: make(map[string]*entityHistory)}
+	tracker, err := newTracker(nil)
+	if err != nil {
+		panic(err)
+	}
+	return tracker
+}
+
+// NewTrackerWithDB creates a tracker backed by persistent storage.
+func NewTrackerWithDB(db *gorm.DB) (*Tracker, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database handle is required for persistent change tracking")
+	}
+	return newTracker(db)
+}
+
+func newTracker(db *gorm.DB) (*Tracker, error) {
+	tracker := &Tracker{entities: make(map[string]*entityHistory), db: db}
+	if db == nil {
+		return tracker, nil
+	}
+
+	if err := db.AutoMigrate(&changeRecord{}); err != nil {
+		return nil, fmt.Errorf("failed to migrate change tracking table: %w", err)
+	}
+
+	if err := tracker.loadFromDatabase(); err != nil {
+		return nil, err
+	}
+
+	return tracker, nil
 }
 
 // RegisterEntity ensures the tracker maintains history for the specified entity set.
@@ -61,9 +93,8 @@ func (t *Tracker) RegisterEntity(entitySet string) {
 }
 
 // RecordChange stores a change for the specified entity set and returns the new version number.
-func (t *Tracker) RecordChange(entitySet string, keyValues, data map[string]interface{}, changeType ChangeType) int64 {
+func (t *Tracker) RecordChange(entitySet string, keyValues, data map[string]interface{}, changeType ChangeType) (int64, error) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 
 	history, exists := t.entities[entitySet]
 	if !exists {
@@ -79,15 +110,30 @@ func (t *Tracker) RecordChange(entitySet string, keyValues, data map[string]inte
 		copiedData = copyMap(data)
 	}
 
-	history.Events = append(history.Events, ChangeEvent{
+	event := ChangeEvent{
 		EntitySet: entitySet,
 		KeyValues: copiedKeyValues,
 		Data:      copiedData,
 		Type:      changeType,
 		Version:   history.Version,
-	})
+	}
+	history.Events = append(history.Events, event)
+	version := history.Version
+	t.mu.Unlock()
 
-	return history.Version
+	if t.db != nil {
+		if err := t.persistEvent(event); err != nil {
+			t.mu.Lock()
+			history.Version--
+			if len(history.Events) > 0 {
+				history.Events = history.Events[:len(history.Events)-1]
+			}
+			t.mu.Unlock()
+			return 0, err
+		}
+	}
+
+	return version, nil
 }
 
 // CurrentToken returns a delta token that represents the current state of the entity set.
@@ -144,6 +190,56 @@ func (t *Tracker) EntitySetFromToken(token string) (string, error) {
 	return entitySet, err
 }
 
+func (t *Tracker) loadFromDatabase() error {
+	var records []changeRecord
+	if err := t.db.Order("entity_set asc, version asc").Find(&records).Error; err != nil {
+		return fmt.Errorf("failed to load change history: %w", err)
+	}
+
+	for _, record := range records {
+		keyValues, err := record.decodeKeyValues()
+		if err != nil {
+			return fmt.Errorf("failed to decode change record keys: %w", err)
+		}
+
+		data, err := record.decodeData()
+		if err != nil {
+			return fmt.Errorf("failed to decode change record data: %w", err)
+		}
+
+		history, exists := t.entities[record.EntitySet]
+		if !exists {
+			history = &entityHistory{}
+			t.entities[record.EntitySet] = history
+		}
+
+		event := ChangeEvent{
+			EntitySet: record.EntitySet,
+			KeyValues: keyValues,
+			Data:      data,
+			Type:      record.ChangeType,
+			Version:   record.Version,
+		}
+		history.Events = append(history.Events, event)
+		if record.Version > history.Version {
+			history.Version = record.Version
+		}
+	}
+
+	return nil
+}
+
+func (t *Tracker) persistEvent(event ChangeEvent) error {
+	record, err := newChangeRecord(event)
+	if err != nil {
+		return err
+	}
+	if err := t.db.Create(&record).Error; err != nil {
+		return fmt.Errorf("failed to persist change event: %w", err)
+	}
+	return nil
+}
+
 func encodeToken(entitySet string, version int64) (string, error) {
 	payload := deltaToken{
 		EntitySet: entitySet,
@@ -184,4 +280,60 @@ func copyMap(source map[string]interface{}) map[string]interface{} {
 		clone[k] = v
 	}
 	return clone
+}
+
+type changeRecord struct {
+	ID         uint       `gorm:"primaryKey"`
+	EntitySet  string     `gorm:"size:255;not null;index:idx_entity_version,priority:1"`
+	Version    int64      `gorm:"not null;index:idx_entity_version,priority:2"`
+	ChangeType ChangeType `gorm:"size:16;not null"`
+	KeyValues  []byte     `gorm:"not null"`
+	Data       []byte
+}
+
+func (changeRecord) TableName() string {
+	return "_odata_change_log"
+}
+
+func newChangeRecord(event ChangeEvent) (changeRecord, error) {
+	keyJSON, err := json.Marshal(event.KeyValues)
+	if err != nil {
+		return changeRecord{}, fmt.Errorf("failed to encode change keys: %w", err)
+	}
+
+	var dataJSON []byte
+	if event.Data != nil {
+		dataJSON, err = json.Marshal(event.Data)
+		if err != nil {
+			return changeRecord{}, fmt.Errorf("failed to encode change data: %w", err)
+		}
+	}
+
+	return changeRecord{
+		EntitySet:  event.EntitySet,
+		Version:    event.Version,
+		ChangeType: event.Type,
+		KeyValues:  keyJSON,
+		Data:       dataJSON,
+	}, nil
+}
+
+func (r changeRecord) decodeKeyValues() (map[string]interface{}, error) {
+	var keyValues map[string]interface{}
+	if err := json.Unmarshal(r.KeyValues, &keyValues); err != nil {
+		return nil, err
+	}
+	return keyValues, nil
+}
+
+func (r changeRecord) decodeData() (map[string]interface{}, error) {
+	if len(r.Data) == 0 {
+		return nil, nil
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(r.Data, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
 }

--- a/test/change_tracking_persistence_test.go
+++ b/test/change_tracking_persistence_test.go
@@ -1,0 +1,172 @@
+package odata_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type PersistentProduct struct {
+	ID   int    `json:"id" gorm:"primarykey" odata:"key"`
+	Name string `json:"name"`
+}
+
+func TestChangeTrackingPersistsAcrossRestart(t *testing.T) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "tracker.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&PersistentProduct{}); err != nil {
+		t.Fatalf("failed to migrate database: %v", err)
+	}
+
+	service, err := odata.NewServiceWithConfig(db, odata.ServiceConfig{PersistentChangeTracking: true})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+	if err := service.RegisterEntity(&PersistentProduct{}); err != nil {
+		t.Fatalf("register entity: %v", err)
+	}
+	if err := service.EnableChangeTracking("PersistentProducts"); err != nil {
+		t.Fatalf("enable change tracking: %v", err)
+	}
+
+	initialReq := httptest.NewRequest(http.MethodGet, "/PersistentProducts", nil)
+	initialReq.Header.Set("Prefer", "odata.track-changes")
+	initialRes := httptest.NewRecorder()
+	service.ServeHTTP(initialRes, initialReq)
+	if initialRes.Code != http.StatusOK {
+		t.Fatalf("initial response status: %d", initialRes.Code)
+	}
+	initialToken := extractDeltaToken(t, initialRes.Body.Bytes())
+
+	createReq := httptest.NewRequest(http.MethodPost, "/PersistentProducts", strings.NewReader(`{"id":1,"name":"Persisted"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRes := httptest.NewRecorder()
+	service.ServeHTTP(createRes, createReq)
+	if createRes.Code != http.StatusCreated {
+		t.Fatalf("create status: %d", createRes.Code)
+	}
+
+	sqlDB, err := db.DB()
+	if err == nil {
+		sqlDB.Close()
+	}
+
+	dbRestarted, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("reconnect database: %v", err)
+	}
+
+	serviceRestarted, err := odata.NewServiceWithConfig(dbRestarted, odata.ServiceConfig{PersistentChangeTracking: true})
+	if err != nil {
+		t.Fatalf("recreate service: %v", err)
+	}
+	if err := dbRestarted.AutoMigrate(&PersistentProduct{}); err != nil {
+		t.Fatalf("remigrate: %v", err)
+	}
+	if err := serviceRestarted.RegisterEntity(&PersistentProduct{}); err != nil {
+		t.Fatalf("register entity after restart: %v", err)
+	}
+	if err := serviceRestarted.EnableChangeTracking("PersistentProducts"); err != nil {
+		t.Fatalf("enable change tracking after restart: %v", err)
+	}
+
+	deltaReq := httptest.NewRequest(http.MethodGet, "/PersistentProducts?$deltatoken="+url.QueryEscape(initialToken), nil)
+	deltaRes := httptest.NewRecorder()
+	serviceRestarted.ServeHTTP(deltaRes, deltaReq)
+	if deltaRes.Code != http.StatusOK {
+		t.Fatalf("delta response status: %d", deltaRes.Code)
+	}
+	deltaBody := decodeJSON(t, deltaRes.Body.Bytes())
+	changes := valueEntries(t, deltaBody)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change after restart, got %d", len(changes))
+	}
+	if id, ok := changes[0]["id"].(float64); !ok || int(id) != 1 {
+		t.Fatalf("expected persisted entity id 1, got %v", changes[0]["id"])
+	}
+	nextToken := extractDeltaToken(t, deltaRes.Body.Bytes())
+
+	createAfterReq := httptest.NewRequest(http.MethodPost, "/PersistentProducts", strings.NewReader(`{"id":2,"name":"Restarted"}`))
+	createAfterReq.Header.Set("Content-Type", "application/json")
+	createAfterRes := httptest.NewRecorder()
+	serviceRestarted.ServeHTTP(createAfterRes, createAfterReq)
+	if createAfterRes.Code != http.StatusCreated {
+		t.Fatalf("create after restart status: %d", createAfterRes.Code)
+	}
+
+	followReq := httptest.NewRequest(http.MethodGet, "/PersistentProducts?$deltatoken="+url.QueryEscape(nextToken), nil)
+	followRes := httptest.NewRecorder()
+	serviceRestarted.ServeHTTP(followRes, followReq)
+	if followRes.Code != http.StatusOK {
+		t.Fatalf("follow-up delta status: %d", followRes.Code)
+	}
+	followBody := decodeJSON(t, followRes.Body.Bytes())
+	followChanges := valueEntries(t, followBody)
+	if len(followChanges) != 1 {
+		t.Fatalf("expected 1 change after restart write, got %d", len(followChanges))
+	}
+	if id, ok := followChanges[0]["id"].(float64); !ok || int(id) != 2 {
+		t.Fatalf("expected new entity id 2, got %v", followChanges[0]["id"])
+	}
+}
+
+func extractDeltaToken(t *testing.T, body []byte) string {
+	t.Helper()
+
+	payload := decodeJSON(t, body)
+	link, ok := payload["@odata.deltaLink"].(string)
+	if !ok || link == "" {
+		t.Fatalf("delta link missing: %v", payload["@odata.deltaLink"])
+	}
+	parsed, err := url.Parse(link)
+	if err != nil {
+		t.Fatalf("parse delta link: %v", err)
+	}
+	token := parsed.Query().Get("$deltatoken")
+	if token == "" {
+		t.Fatalf("delta token missing in link: %s", link)
+	}
+	return token
+}
+
+func decodeJSON(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	return payload
+}
+
+func valueEntries(t *testing.T, payload map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+
+	raw, ok := payload["value"].([]interface{})
+	if !ok {
+		t.Fatalf("missing value array in payload")
+	}
+	result := make([]map[string]interface{}, 0, len(raw))
+	for _, entry := range raw {
+		item, ok := entry.(map[string]interface{})
+		if !ok {
+			t.Fatalf("value entry is not object: %T", entry)
+		}
+		result = append(result, item)
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- add a GORM-backed `_odata_change_log` store for change tracking and load history when instantiating new trackers
- allow services to opt into persistent change tracking via `ServiceConfig` and document deployment guidance
- add tests that reopen the tracker and service to ensure delta tokens survive restarts

## Testing
- go test ./...
- golangci-lint run ./...
- go build ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f437f931083289edc6bd724ea6cd5)