### PR TITLE
Emit skiptoken next links for navigation properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ rely on version numbers to reason about compatibility.
 - `Service.RegisterEntity` and `Service.RegisterSingleton` now return descriptive errors when duplicate names are registered
   instead of overwriting existing metadata.
 
+### Fixed
+
+- Navigation property pagination now emits `$skiptoken` next links and documents the ordering requirements for deterministic paging.
+
 ## [v0.1.0] - 2025-11-07 _(planned)_
 
 ### Added

--- a/internal/handlers/skiptoken_helper.go
+++ b/internal/handlers/skiptoken_helper.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+	"reflect"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/query"
+	"github.com/nlstn/go-odata/internal/response"
+	"github.com/nlstn/go-odata/internal/skiptoken"
+)
+
+// buildNextLinkWithSkipToken constructs a next link URL using $skiptoken when possible.
+// The caller must ensure the result slice uses a deterministic ordering that matches the
+// provided query options (e.g., explicit $orderby or stable key ordering) so that the
+// generated token can be decoded reliably on subsequent requests.
+func buildNextLinkWithSkipToken(
+	meta *metadata.EntityMetadata,
+	queryOptions *query.QueryOptions,
+	sliceValue interface{},
+	r *http.Request,
+) *string {
+	if queryOptions.Top == nil {
+		return nil
+	}
+
+	v := reflect.ValueOf(sliceValue)
+	if v.Kind() != reflect.Slice || v.Len() == 0 {
+		return nil
+	}
+
+	lastIndex := *queryOptions.Top - 1
+	if lastIndex < 0 || lastIndex >= v.Len() {
+		return nil
+	}
+
+	lastEntity := v.Index(lastIndex).Interface()
+
+	keyProps := make([]string, len(meta.KeyProperties))
+	for i, kp := range meta.KeyProperties {
+		keyProps[i] = kp.JsonName
+	}
+
+	orderByProps := make([]string, len(queryOptions.OrderBy))
+	for i, ob := range queryOptions.OrderBy {
+		orderByProps[i] = ob.Property
+		if ob.Descending {
+			orderByProps[i] += " desc"
+		}
+	}
+
+	token, err := skiptoken.ExtractFromEntity(lastEntity, keyProps, orderByProps)
+	if err != nil {
+		return nil
+	}
+
+	encoded, err := skiptoken.Encode(token)
+	if err != nil {
+		return nil
+	}
+
+	nextURL := response.BuildNextLinkWithSkipToken(r, encoded)
+	return &nextURL
+}

--- a/test/navigation_query_options_test.go
+++ b/test/navigation_query_options_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/nlstn/go-odata"
@@ -172,6 +173,19 @@ func TestNavigationPropertyQueryOptions(t *testing.T) {
 				values := response["value"].([]interface{})
 				if len(values) != 2 {
 					t.Errorf("Expected 2 descriptions, got %d", len(values))
+				}
+
+				nextLink, ok := response["@odata.nextLink"].(string)
+				if !ok {
+					t.Fatalf("Expected @odata.nextLink in response, got %v", response["@odata.nextLink"])
+				}
+
+				parsed, err := url.Parse(nextLink)
+				if err != nil {
+					t.Fatalf("Failed to parse @odata.nextLink: %v", err)
+				}
+				if token := parsed.Query().Get("$skiptoken"); token == "" {
+					t.Fatalf("Expected $skiptoken query parameter in nextLink, got %s", nextLink)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- share the collection skiptoken next-link builder between entity sets and navigation collections
- ensure navigation collection handlers prefer $skiptoken links and fall back to $skip when needed
- add regression coverage for navigation $skiptoken links and document the behaviour in the changelog

## Testing
- golangci-lint run ./...
- go test ./...
- go build ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f50c106488328a24f005a04800f13)