### PR TITLE
Propagate request contexts through handler database operations

### DIFF
--- a/internal/handlers/collection.go
+++ b/internal/handlers/collection.go
@@ -55,7 +55,7 @@ func (h *EntityHandler) handleGetCount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	count, countErr := h.countEntities(queryOptions, scopes)
+	count, countErr := h.countEntities(r.Context(), queryOptions, scopes)
 	if countErr != nil {
 		WriteError(w, http.StatusInternalServerError, ErrMsgDatabaseError, countErr.Error())
 		return

--- a/internal/handlers/collection_count.go
+++ b/internal/handlers/collection_count.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/nlstn/go-odata/internal/query"
@@ -8,8 +9,8 @@ import (
 )
 
 // countEntities applies query scopes and filters to return the total number of matching entities.
-func (h *EntityHandler) countEntities(queryOptions *query.QueryOptions, scopes []func(*gorm.DB) *gorm.DB) (int64, error) {
-	countDB := h.db.Model(reflect.New(h.metadata.EntityType).Interface())
+func (h *EntityHandler) countEntities(ctx context.Context, queryOptions *query.QueryOptions, scopes []func(*gorm.DB) *gorm.DB) (int64, error) {
+	countDB := h.db.WithContext(ctx).Model(reflect.New(h.metadata.EntityType).Interface())
 	if len(scopes) > 0 {
 		countDB = countDB.Scopes(scopes...)
 	}

--- a/internal/handlers/context_cancellation_test.go
+++ b/internal/handlers/context_cancellation_test.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestHandleGetCollectionHonorsContextCancellation(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&Product{}); err != nil {
+		t.Fatalf("failed to migrate database: %v", err)
+	}
+
+	db.Callback().Query().Before("gorm:query").Register("test_wait_for_cancel", func(db *gorm.DB) {
+		if db.Statement == nil || db.Statement.Context == nil {
+			return
+		}
+		<-db.Statement.Context.Done()
+		db.Error = db.Statement.Context.Err()
+	})
+
+	entityMeta, err := metadata.AnalyzeEntity(Product{})
+	if err != nil {
+		t.Fatalf("failed to analyze entity metadata: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewEntityHandler(db, entityMeta, logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/Products", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	done := make(chan struct{})
+
+	go func() {
+		handler.handleGetCollection(w, req)
+		close(done)
+	}()
+
+	time.AfterFunc(10*time.Millisecond, cancel)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return after context cancellation")
+	}
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}

--- a/internal/handlers/count_test.go
+++ b/internal/handlers/count_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +98,7 @@ func TestEntityHandlerCount(t *testing.T) {
 				t.Fatalf("before read hook failed: %v", hookErr)
 			}
 
-			helperCount, err := handler.countEntities(queryOptions, scopes)
+			helperCount, err := handler.countEntities(context.Background(), queryOptions, scopes)
 			if err != nil {
 				t.Fatalf("countEntities returned error: %v", err)
 			}
@@ -209,7 +210,7 @@ func TestCountConsistencyAcrossEndpoints(t *testing.T) {
 				t.Fatalf("before read hook failed: %v", hookErr)
 			}
 
-			helperCount, err := handler.countEntities(queryOptions, scopes)
+			helperCount, err := handler.countEntities(context.Background(), queryOptions, scopes)
 			if err != nil {
 				t.Fatalf("countEntities returned error: %v", err)
 			}

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -104,7 +105,7 @@ func (h *EntityHandler) IsSingleton() bool {
 func (h *EntityHandler) FetchEntity(entityKey string) (interface{}, error) {
 	// Use empty query options since we just need to verify entity exists
 	queryOptions := &query.QueryOptions{}
-	return h.fetchEntityByKey(entityKey, queryOptions, nil)
+	return h.fetchEntityByKey(context.Background(), entityKey, queryOptions, nil)
 }
 
 // IsNotFoundError checks if an error is a "not found" error

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,10 +14,10 @@ import (
 )
 
 // fetchEntityByKey fetches an entity by its key with optional expand
-func (h *EntityHandler) fetchEntityByKey(entityKey string, queryOptions *query.QueryOptions, scopes []func(*gorm.DB) *gorm.DB) (interface{}, error) {
+func (h *EntityHandler) fetchEntityByKey(ctx context.Context, entityKey string, queryOptions *query.QueryOptions, scopes []func(*gorm.DB) *gorm.DB) (interface{}, error) {
 	result := reflect.New(h.metadata.EntityType).Interface()
 
-	db, err := h.buildKeyQuery(h.db, entityKey)
+	db, err := h.buildKeyQuery(h.db.WithContext(ctx), entityKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- ensure collection and entity read paths call `WithContext` on base GORM handles before applying scopes or executing queries
- propagate request contexts through write handlers and navigation binding helpers so transactions and bindings respect cancellation
- add a regression test that cancels a request context mid-query to verify handlers abort quickly

## Testing
- golangci-lint run ./...
- go test ./...
- go build ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5d37b1788328a5c7ef84fc90b93e)