### PR TITLE
Fail fast when service constructors receive nil database handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ rely on version numbers to reason about compatibility.
 ### Fixed
 
 - Ensure function context URLs honor the configured service namespace when returning complex types.
+- NewService constructors now return a clear error when given a nil database
+  handle, preventing later panics from misconfigured callers.
 
 ## [v0.4.0] - 2025-11-08
 

--- a/odata.go
+++ b/odata.go
@@ -78,6 +78,10 @@ func NewService(db *gorm.DB) *Service {
 
 // NewServiceWithConfig creates a new OData service instance with additional configuration.
 func NewServiceWithConfig(db *gorm.DB, cfg ServiceConfig) (*Service, error) {
+	if db == nil {
+		return nil, fmt.Errorf("odata: database handle is required")
+	}
+
 	entities := make(map[string]*metadata.EntityMetadata)
 	handlersMap := make(map[string]*handlers.EntityHandler)
 	logger := slog.Default()

--- a/odata_test.go
+++ b/odata_test.go
@@ -46,6 +46,43 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	return db
 }
 
+func TestNewServiceWithConfigNilDB(t *testing.T) {
+	service, err := NewServiceWithConfig(nil, ServiceConfig{})
+	if err == nil {
+		t.Fatal("expected error when creating service with nil database")
+	}
+
+	expected := "odata: database handle is required"
+	if err.Error() != expected {
+		t.Fatalf("unexpected error: got %q, want %q", err.Error(), expected)
+	}
+
+	if service != nil {
+		t.Fatal("expected returned service to be nil when database is nil")
+	}
+}
+
+func TestNewServiceNilDBPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when creating service with nil database")
+		}
+
+		err, ok := r.(error)
+		if !ok {
+			t.Fatalf("expected panic to be an error, got %T", r)
+		}
+
+		expected := "odata: database handle is required"
+		if err.Error() != expected {
+			t.Fatalf("unexpected panic message: got %q, want %q", err.Error(), expected)
+		}
+	}()
+
+	_ = NewService(nil)
+}
+
 func TestNewService(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/test/composite_keys_test.go
+++ b/test/composite_keys_test.go
@@ -133,7 +133,6 @@ func TestCompositeKeyURLParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			service := odata.NewService(nil)
 			components := parseURLForTest(tt.url)
 
 			if tt.expectError {
@@ -155,7 +154,6 @@ func TestCompositeKeyURLParsing(t *testing.T) {
 				}
 			}
 
-			_ = service // avoid unused variable error
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- guard NewServiceWithConfig against nil database handles and let NewService fail immediately
- add unit coverage for nil database construction and remove a test helper that relied on NewService(nil)
- document the change in the changelog

## Testing
- go test ./...
- golangci-lint run ./...
- go build ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910508221308328920527ce86f90d1b)