### PR TITLE
Apply default async job retention TTL with opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ rely on version numbers to reason about compatibility.
 
 - Lifecycle hooks now expose the active GORM transaction through `odata.TransactionFromContext`, enabling user code to perform
   additional queries that participate in the same commit.
+- `AsyncConfig.DisableRetention` allows services to opt out of automatic async
+  job cleanup when stricter audit retention is required.
 
 ### Changed
 
 - Moved service routing and operation handling into internal packages to reduce
   root-level surface area while keeping exported APIs unchanged.
+- Async job managers now apply a 24-hour default retention window when no
+  duration is provided and continue purging expired rows in the background.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ if err := service.EnableAsyncProcessing(odata.AsyncConfig{
     MonitorPathPrefix:    "/$async/jobs/", // default when empty
     DefaultRetryInterval: 5 * time.Second,  // Retry-After header while pending
     MaxQueueSize:         8,                // Optional worker limit
-    JobRetention:         15 * time.Minute, // How long to keep completed jobs
+    JobRetention:         15 * time.Minute, // Overrides the 24h default retention window
 }); err != nil {
     log.Fatalf("enable async processing: %v", err)
 }
@@ -175,6 +175,11 @@ With async processing enabled:
   keeps monitor state isolated from application models and allows a fresh
   `async.Manager` to serve completed job results until the retention TTL deletes
   the row.
+
+Completed jobs are kept for 24 hours by default (`async.DefaultJobRetention`).
+Setting `JobRetention` to zero uses that default, while applications that must
+retain data indefinitely can opt out by setting `DisableRetention: true` and
+managing cleanup manually.
 
 The development server (`cmd/devserver`) enables async processing by default
 using the standard `/$async/jobs/` prefix and advertises the monitor endpoint in


### PR DESCRIPTION
## Summary
- default asynchronous job managers to a 24-hour retention window and add an option to disable cleanup
- wire the new retention behaviour through `Service.EnableAsyncProcessing` and document it for users
- extend async manager tests to cover default retention cleanup and update project documentation

## Testing
- go test ./...
- golangci-lint run ./...
- go build ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910528a77ec8328b784e616caad5bf1)