### PR TITLE
Ensure introduction service document test asserts HTTP 200

### DIFF
--- a/compliance-suite/tests/v4_0/1.1_introduction.go
+++ b/compliance-suite/tests/v4_0/1.1_introduction.go
@@ -34,6 +34,9 @@ func Introduction() *framework.TestSuite {
 			if err != nil {
 				return err
 			}
+			if err := ctx.AssertStatusCode(resp, 200); err != nil {
+				return err
+			}
 			if !ctx.IsValidJSON(resp) {
 				return framework.NewError("Service document is not valid JSON")
 			}


### PR DESCRIPTION
## Summary
- assert a 200 OK response in the introduction suite's service document test before validating JSON
- ensure the test fails for non-200 responses instead of silently passing

## Testing
- go test ./... *(terminated due to hang)*
- golangci-lint run ./... *(terminated due to hang)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917402279288328b4a8ea71d9922a2b)