### PR TITLE
Enforce $compute compliance expectations

### DIFF
--- a/compliance-suite/tests/v4_01/11.2.5.11_orderby_computed_properties.go
+++ b/compliance-suite/tests/v4_01/11.2.5.11_orderby_computed_properties.go
@@ -2,7 +2,6 @@ package v4_01
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/nlstn/go-odata/compliance-suite/framework"
 )
@@ -25,11 +24,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "TaxedPrice")
 		},
 	)
 
@@ -43,11 +47,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "DiscountPrice", "TaxedPrice")
 		},
 	)
 
@@ -61,11 +70,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "DoublePrice")
 		},
 	)
 
@@ -79,11 +93,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "MarkedUpPrice")
 		},
 	)
 
@@ -97,11 +116,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "FinalPrice")
 		},
 	)
 
@@ -115,11 +139,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "SalePrice")
 		},
 	)
 
@@ -133,11 +162,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "HalfPrice")
 		},
 	)
 
@@ -151,11 +185,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "HighPrice")
 		},
 	)
 
@@ -169,20 +208,16 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 {
-				body := string(resp.Body)
-				if strings.Contains(body, "DoublePrice") {
-					return nil
-				}
-				return framework.NewError("Computed property not present in ordered response")
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			if resp.StatusCode == 400 || resp.StatusCode == 501 {
-				ctx.Log("$compute not supported (optional)")
-				return nil
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			return ensureComputedProperties(entities, "DoublePrice")
 		},
 	)
 
@@ -196,11 +231,22 @@ func OrderByComputedProperties() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			for i, entity := range entities {
+				if _, ok := entity["MarkedPrice"]; ok {
+					return framework.NewError(fmt.Sprintf("entity %d unexpectedly included computed property \"MarkedPrice\"", i))
+				}
+			}
+
+			return nil
 		},
 	)
 

--- a/compliance-suite/tests/v4_01/11.2.5.8_query_compute.go
+++ b/compliance-suite/tests/v4_01/11.2.5.8_query_compute.go
@@ -24,16 +24,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			// Accept 200 (supported) or 400/501 (not supported yet)
-			if resp.StatusCode == 200 {
-				return nil
-			}
-			if resp.StatusCode == 400 || resp.StatusCode == 501 {
-				ctx.Log("$compute not supported (optional OData v4.01 feature)")
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "PriceWithTax")
 		},
 	)
 
@@ -47,11 +47,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "UpperName")
 		},
 	)
 
@@ -65,11 +70,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "DoublePrice")
 		},
 	)
 
@@ -83,11 +93,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "PriceWithTax")
 		},
 	)
 
@@ -101,11 +116,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "HalfPrice")
 		},
 	)
 
@@ -119,11 +139,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "WithTax", "Discounted")
 		},
 	)
 
@@ -137,11 +162,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "CreatedYear")
 		},
 	)
 
@@ -155,19 +185,14 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			// Should return 400 when syntax is invalid, or 501 if not supported
 			if resp.StatusCode == 400 {
-				return nil
-			}
-			if resp.StatusCode == 501 {
-				ctx.Log("$compute not supported (optional)")
 				return nil
 			}
 			if resp.StatusCode == 200 {
 				return framework.NewError("Invalid syntax accepted")
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 400 or 501 but got %d", resp.StatusCode))
+			return framework.NewError(fmt.Sprintf("Expected 400 but got %d", resp.StatusCode))
 		},
 	)
 
@@ -181,11 +206,16 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			return ensureComputedProperties(entities, "Location")
 		},
 	)
 
@@ -199,11 +229,32 @@ func QueryCompute() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 || resp.StatusCode == 400 || resp.StatusCode == 501 {
-				return nil
+			if err := requireStatusOK(resp); err != nil {
+				return err
 			}
 
-			return framework.NewError(fmt.Sprintf("Expected 200, 400, or 501 but got %d", resp.StatusCode))
+			entities, err := decodeCollection(resp)
+			if err != nil {
+				return err
+			}
+
+			for i, entity := range entities {
+				categoryRaw, ok := entity["Category"]
+				if !ok {
+					return framework.NewError(fmt.Sprintf("entity %d missing expanded Category", i))
+				}
+
+				category, ok := categoryRaw.(map[string]interface{})
+				if !ok {
+					return framework.NewError(fmt.Sprintf("entity %d has invalid Category payload", i))
+				}
+
+				if _, ok := category["DoubleID"]; !ok {
+					return framework.NewError(fmt.Sprintf("entity %d expanded Category missing computed property \"DoubleID\"", i))
+				}
+			}
+
+			return nil
 		},
 	)
 

--- a/compliance-suite/tests/v4_01/compute_helpers.go
+++ b/compliance-suite/tests/v4_01/compute_helpers.go
@@ -1,0 +1,49 @@
+package v4_01
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/nlstn/go-odata/compliance-suite/framework"
+)
+
+type collectionResponse struct {
+	Value []map[string]interface{} `json:"value"`
+}
+
+func requireStatusOK(resp *framework.HTTPResponse) error {
+	if resp.StatusCode != http.StatusOK {
+		return framework.NewError(fmt.Sprintf("expected HTTP 200 OK but got %d", resp.StatusCode))
+	}
+	return nil
+}
+
+func decodeCollection(resp *framework.HTTPResponse) ([]map[string]interface{}, error) {
+	var payload collectionResponse
+	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+		return nil, framework.NewError(fmt.Sprintf("failed to parse JSON response: %v", err))
+	}
+
+	if payload.Value == nil {
+		return nil, framework.NewError("response body does not contain 'value' collection")
+	}
+
+	if len(payload.Value) == 0 {
+		return nil, framework.NewError("response collection is empty; cannot validate computed properties")
+	}
+
+	return payload.Value, nil
+}
+
+func ensureComputedProperties(entities []map[string]interface{}, aliases ...string) error {
+	for i, entity := range entities {
+		for _, alias := range aliases {
+			if _, ok := entity[alias]; !ok {
+				return framework.NewError(fmt.Sprintf("entity %d missing computed property %q", i, alias))
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- require successful 200 responses and validate computed members across the $compute compliance tests
- tighten $orderby with computed properties checks to assert computed aliases are materialized in payloads
- add shared helpers to decode OData collections and assert computed aliases consistently

## Testing
- go build ./...
- go test ./... *(fails: hangs against current suite)*
- golangci-lint run ./... *(fails: hangs against current suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173fe3fa388328a19d910700ac1559)