### PR TITLE
Ensure $search compliance tests reject unsupported statuses

### DIFF
--- a/compliance-suite/tests/v4_0/11.2.4.1_query_search.go
+++ b/compliance-suite/tests/v4_0/11.2.4.1_query_search.go
@@ -3,6 +3,7 @@ package v4_0
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/nlstn/go-odata/compliance-suite/framework"
 )
@@ -25,21 +26,20 @@ func QuerySearch() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 {
-				var result map[string]interface{}
-				if err := json.Unmarshal(resp.Body, &result); err != nil {
-					return fmt.Errorf("failed to parse JSON: %w", err)
-				}
-
-				if _, ok := result["value"]; !ok {
-					return fmt.Errorf("response missing 'value' array")
-				}
-
-				return nil
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("expected status 200 but received %d", resp.StatusCode)
 			}
 
-			// $search may not be implemented
-			return ctx.Skip("$search not implemented")
+			var result map[string]interface{}
+			if err := json.Unmarshal(resp.Body, &result); err != nil {
+				return fmt.Errorf("failed to parse JSON: %w", err)
+			}
+
+			if _, ok := result["value"]; !ok {
+				return fmt.Errorf("response missing 'value' array")
+			}
+
+			return nil
 		},
 	)
 
@@ -53,20 +53,20 @@ func QuerySearch() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 {
-				var result map[string]interface{}
-				if err := json.Unmarshal(resp.Body, &result); err != nil {
-					return fmt.Errorf("failed to parse JSON: %w", err)
-				}
-
-				if _, ok := result["value"]; !ok {
-					return fmt.Errorf("response missing 'value' array")
-				}
-
-				return nil
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("expected status 200 but received %d", resp.StatusCode)
 			}
 
-			return ctx.Skip("$search not implemented")
+			var result map[string]interface{}
+			if err := json.Unmarshal(resp.Body, &result); err != nil {
+				return fmt.Errorf("failed to parse JSON: %w", err)
+			}
+
+			if _, ok := result["value"]; !ok {
+				return fmt.Errorf("response missing 'value' array")
+			}
+
+			return nil
 		},
 	)
 
@@ -80,20 +80,20 @@ func QuerySearch() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 {
-				var result map[string]interface{}
-				if err := json.Unmarshal(resp.Body, &result); err != nil {
-					return fmt.Errorf("failed to parse JSON: %w", err)
-				}
-
-				if _, ok := result["value"]; !ok {
-					return fmt.Errorf("response missing 'value' array")
-				}
-
-				return nil
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("expected status 200 but received %d", resp.StatusCode)
 			}
 
-			return ctx.Skip("$search not implemented")
+			var result map[string]interface{}
+			if err := json.Unmarshal(resp.Body, &result); err != nil {
+				return fmt.Errorf("failed to parse JSON: %w", err)
+			}
+
+			if _, ok := result["value"]; !ok {
+				return fmt.Errorf("response missing 'value' array")
+			}
+
+			return nil
 		},
 	)
 
@@ -107,20 +107,20 @@ func QuerySearch() *framework.TestSuite {
 				return err
 			}
 
-			if resp.StatusCode == 200 {
-				var result map[string]interface{}
-				if err := json.Unmarshal(resp.Body, &result); err != nil {
-					return fmt.Errorf("failed to parse JSON: %w", err)
-				}
-
-				if _, ok := result["value"]; !ok {
-					return fmt.Errorf("response missing 'value' array")
-				}
-
-				return nil
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("expected status 200 but received %d", resp.StatusCode)
 			}
 
-			return ctx.Skip("$search not implemented")
+			var result map[string]interface{}
+			if err := json.Unmarshal(resp.Body, &result); err != nil {
+				return fmt.Errorf("failed to parse JSON: %w", err)
+			}
+
+			if _, ok := result["value"]; !ok {
+				return fmt.Errorf("response missing 'value' array")
+			}
+
+			return nil
 		},
 	)
 


### PR DESCRIPTION
## Summary
- require the $search compliance tests to receive HTTP 200 responses instead of skipping when unsupported
- keep the existing JSON payload validations so compliant services must still return value arrays

## Testing
- golangci-lint run ./...
- go test ./...
- go build ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69174032a770832898d1fac9daa8bd5e)