### PR TITLE
Export hook interfaces to public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ rely on version numbers to reason about compatibility.
 ### Added
 - PostgreSQL is now fully supported alongside SQLite with all 105 compliance test suites passing on both databases
 - CI/CD pipeline now runs compliance tests on both SQLite and PostgreSQL to ensure cross-database compatibility
+- **Public hook interfaces**: `EntityHook` and `ReadHook` are now exported in the public API, making hooks discoverable via `go doc` and `pkg.go.dev`
+  - Hook interface documentation includes comprehensive examples for lifecycle hooks (BeforeCreate, AfterCreate, etc.)
+  - Read hook documentation with examples for tenant filtering and data redaction
+  - Added "Hooks: Inject Custom Logic" section to README with quick-start examples
+  - Improved discoverability: hooks are now prominent in main package documentation
 
 ### Fixed
 - Data race in async monitor configuration resolved by synchronizing access in the router, fixing `-race` CI test failures in `internal/service/runtime.TestServiceRespondAsyncFlow`.


### PR DESCRIPTION
## Summary

This PR makes the hook interfaces public and improves their documentation, addressing feedback that hooks were not well-exposed in the public API.

## Changes

### 1. Exported Hook Interfaces
- **EntityHook**: Lifecycle hooks for create/update/delete operations
  - BeforeCreate, AfterCreate, BeforeUpdate, AfterUpdate, BeforeDelete, AfterDelete
- **ReadHook**: Read hooks for customizing query behavior
  - BeforeReadCollection, AfterReadCollection, BeforeReadEntity, AfterReadEntity

### 2. Comprehensive Documentation
- Added package-level godoc explaining hook concepts and usage
- EntityHook interface with detailed method descriptions and code examples
- ReadHook interface with detailed method descriptions and code examples
- Documentation of hook execution order and error handling
- Instructions for accessing the active transaction via TransactionFromContext

### 3. README Updates
- Added 'Hooks: Inject Custom Logic' section with quick-start examples
- Lifecycle hooks example showing validation and logging
- Read hooks example showing tenant filtering and data redaction
- Links to EntityHook documentation and advanced features guide

### 4. CHANGELOG Updates
- Documented new public hook interfaces
- Noted improved discoverability via `go doc` and `pkg.go.dev`

## Benefits

✅ Hooks now discoverable via `go doc` and visible on `pkg.go.dev`
✅ IDE autocomplete now works for hook methods
✅ README highlights hooks with practical examples
✅ Comprehensive godoc with code examples
✅ No breaking changes - internal implementation unchanged

## Testing

- All tests pass (105+ hook-related tests)
- Golangci-lint: 0 issues
- Build verified