### PR TITLE
Clarify database support and `$search` behavior in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ rely on version numbers to reason about compatibility.
 - Async job managers now apply a 24-hour default retention window when no
   duration is provided and continue purging expired rows in the background.
 - Compliance suite default output is now concise (overall progress and summary only); use `-verbose` for per-suite and per-test details.
+- Documentation now aligns database support statements with CI coverage and clarifies `$search` behavior per database.
 
 ### Fixed
 
@@ -142,4 +143,3 @@ rely on version numbers to reason about compatibility.
 - This is the first documented release in the changelog. Subsequent releases
   will increment the version following semantic versioning rules and will be
   recorded in this changelog alongside Git tags.
-

--- a/README.md
+++ b/README.md
@@ -325,11 +325,11 @@ release plan so downstream integrations can assess compatibility expectations.
 
 The library works with any GORM-compatible database, but testing and active support vary by database:
 
-- ✅ **SQLite** - Fully supported and tested. All features work reliably. Includes native FTS (FTS3/4/5) for `$search`.
-- ✅ **PostgreSQL** - Fully supported and tested. All compliance tests pass on PostgreSQL 17. Includes native full-text search with `tsvector` and GIN indexes for `$search`.
-- ✅ **MariaDB** - Fully supported and tested. All compliance tests pass on MariaDB 11. `$search` falls back to in-memory filtering.
-- ✅ **MySQL** - Fully supported and tested. All compliance tests pass on MySQL 8. `$search` falls back to in-memory filtering.
-- ❓ **Other databases** (SQL Server, etc.) - Should work through GORM compatibility, but not actively tested. `$search` falls back to in-memory filtering.
+- ✅ **SQLite** - Fully supported and tested in CI. All features work reliably. Includes native FTS (FTS3/4/5) for `$search`.
+- ✅ **PostgreSQL** - Fully supported and tested in CI (PostgreSQL 17). Includes native full-text search with `tsvector` and GIN indexes for `$search`.
+- ✅ **MariaDB** - Fully supported and tested in CI (MariaDB 11). `$search` falls back to in-memory filtering.
+- ✅ **MySQL** - Fully supported and tested in CI (MySQL 8). `$search` falls back to in-memory filtering.
+- ❓ **Other databases** (SQL Server, etc.) - Support is in progress and not covered by CI. `$search` falls back to in-memory filtering.
 
 ### Using Other Databases
 

--- a/documentation/server-configuration.md
+++ b/documentation/server-configuration.md
@@ -469,9 +469,11 @@ The go-odata library works with GORM-compatible databases. Below are configurati
 
 ### Supported Databases
 
-- **SQLite** - Fully supported and tested
-- **PostgreSQL** - Support in progress (most features work)
-- **Other databases** - May work through GORM, but not actively tested. [Open an issue](https://github.com/NLstn/go-odata/issues) if you need support for a specific database.
+- **SQLite** - Fully supported and tested in CI. Includes native FTS (FTS3/4/5) for `$search`.
+- **PostgreSQL** - Fully supported and tested in CI (PostgreSQL 17). Includes native full-text search with `tsvector` and GIN indexes for `$search`.
+- **MariaDB** - Fully supported and tested in CI (MariaDB 11). `$search` falls back to in-memory filtering.
+- **MySQL** - Fully supported and tested in CI (MySQL 8). `$search` falls back to in-memory filtering.
+- **Other databases** - Support is in progress and not covered by CI. `$search` falls back to in-memory filtering. [Open an issue](https://github.com/NLstn/go-odata/issues) if you need support for a specific database.
 
 ### SQLite (In-Memory)
 


### PR DESCRIPTION
### Motivation

- Align documentation language with CI coverage to avoid ambiguous support statements for different databases.
- Make `$search` behavior explicit per dialect so users know when native FTS is used and when in-memory fallback applies.
- Keep the public changelog in sync with documentation updates.

### Description

- Update `README.md` and `documentation/server-configuration.md` to mark SQLite, PostgreSQL, MariaDB, and MySQL as "fully supported and tested in CI" and to clarify `$search` behavior per database. 
- Change wording for "Other databases" to state that support is in progress and not covered by CI, with `$search` falling back to in-memory filtering.
- Add a changelog entry in `CHANGELOG.md` noting the documentation alignment.
- Modified files: `README.md`, `documentation/server-configuration.md`, and `CHANGELOG.md`.

### Testing

- Ran the linter with `golangci-lint run ./...` which completed with no reported issues. 
- Ran unit tests with `go test ./...` which mostly passed but failed in `internal/service/runtime` due to `TestServiceRespondAsyncFlow` timing out. 
- Observed failures were caused by missing SQLite FTS5 module (`no such module: fts5`) and missing async jobs table (`no such table: _odata_async_jobs`) during tests. 
- Verified build success with `go build ./...` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bcd7f90188328887b894a339f6947)