### PR TITLE
Clarify full-text search docs: document SQLite/Postgres support and constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ rely on version numbers to reason about compatibility.
 - Async job managers now apply a 24-hour default retention window when no
   duration is provided and continue purging expired rows in the background.
 - Compliance suite default output is now concise (overall progress and summary only); use `-verbose` for per-suite and per-test details.
-- Documentation now aligns database support statements with CI coverage and clarifies `$search` behavior per database.
+- Documentation now clarifies full-text search support for SQLite/PostgreSQL, along with fallback behavior and operational constraints.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ All standard OData v4 query options are supported:
 - `$orderby` - Sort results
 - `$top` / `$skip` - Pagination
 - `$count` - Include total count
-- `$search` - Full-text search (with database-native FTS support for SQLite and PostgreSQL)
+- `$search` - Full-text search (database-native FTS for SQLite/PostgreSQL; other backends fall back to in-memory search)
 - `$apply` - Data aggregation
 - `$deltatoken` - Change tracking (enable per entity with `EnableChangeTracking`)
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -61,6 +61,7 @@ Leverage powerful OData v4 features:
 - **Singletons**: Single-instance entities accessible by name
 - **ETags**: Optimistic concurrency control for safe updates
 - **Lifecycle & Read Hooks**: Execute custom logic at specific points in entity lifecycle, add tenant filters, or redact responses before returning data
+- **Full-Text Search**: Database-native FTS for SQLite/PostgreSQL with automatic in-memory fallback on other backends
 - **Geospatial Functions**: Query geographic data using geo.distance, geo.length, and geo.intersects
 
 ### Testing

--- a/documentation/advanced-features.md
+++ b/documentation/advanced-features.md
@@ -12,7 +12,7 @@ This guide covers advanced features of go-odata including singletons, ETags, lif
   - [Tenant Filtering Example](#tenant-filtering-example)
   - [Redacting Sensitive Data](#redacting-sensitive-data)
 - [Asynchronous Processing](#asynchronous-processing)
-- [Full-Text Search with SQLite FTS](#full-text-search-with-sqlite-fts)
+- [Full-Text Search with Database FTS](#full-text-search-with-database-fts)
 
 ## Singletons
 
@@ -987,13 +987,17 @@ The library automatically detects and uses the best available version.
 
 ### Limitations
 
-1. **SQLite Only**: FTS integration only works with SQLite databases. Other databases automatically use in-memory search.
+1. **Database Support**: Automatic FTS integration is available for SQLite (FTS3/4/5) and PostgreSQL only. All other database backends automatically fall back to the in-memory `$search` implementation.
 
-2. **Simple Queries**: FTS is optimized for simple full-text queries. Complex boolean expressions or advanced fuzzy matching may fall back to in-memory processing.
+2. **PostgreSQL Language Configuration**: PostgreSQL uses the built-in `english` text search configuration (`to_tsvector('english', ...)` and `plainto_tsquery('english', ...)`). If you need a different language or custom dictionary, you must modify the FTS implementation to change the configuration.
 
-3. **Storage Overhead**: FTS virtual tables require additional disk space (approximately 30-50% of indexed text).
+3. **PostgreSQL Trigger Requirements**: PostgreSQL FTS relies on helper tables, a GIN index, a `plpgsql` trigger function, and triggers to keep the search vectors in sync. The database user must have privileges to create tables, indexes, functions, and triggers; locked-down roles will prevent FTS initialization.
 
-4. **Write Performance**: FTS triggers add minimal overhead to INSERT/UPDATE/DELETE operations.
+4. **SQLite Build Requirements**: SQLite FTS requires FTS3/4/5 support to be compiled into the SQLite build (some minimal builds disable it). If none of the FTS modules are available, the library falls back to in-memory search.
+
+5. **Simple Queries**: FTS is optimized for simple full-text queries. Complex boolean expressions or advanced fuzzy matching may fall back to in-memory processing.
+
+6. **Storage/Write Overhead**: FTS tables require additional disk space (approximately 30-50% of indexed text), and triggers add some overhead to INSERT/UPDATE/DELETE operations.
 
 ### Best Practices
 


### PR DESCRIPTION
### Motivation

- Update documentation to accurately reflect that automatic FTS is supported for both SQLite and PostgreSQL and that other backends fall back to in-memory search.
- Call out operational constraints for PostgreSQL (language configuration and trigger/function/index requirements) and SQLite (FTS module build requirement) to avoid surprises for operators.
- Keep README and documentation index consistent with the detailed advanced-features guidance.

### Description

- Revised `documentation/advanced-features.md` to rename the FTS section and expand the `Limitations` list to document PostgreSQL support, language configuration, trigger/index/function privileges, and SQLite FTS build requirements.
- Updated `README.md` to clarify the `$search` line now reads that SQLite/PostgreSQL use database-native FTS and other backends fall back to in-memory search.
- Updated `documentation/README.md` to include a concise mention of database-native FTS for SQLite/PostgreSQL with an automatic in-memory fallback.
- Added a short changelog entry in `CHANGELOG.md` noting the documentation clarification about FTS support and constraints.

### Testing

- Ran code formatting with `gofmt -w .` and applied formatting successfully.
- Ran linting with `golangci-lint run ./...` and the lint run returned no issues.
- Executed the test suite with `go test ./...` and all packages passed.
- Verified build with `go build ./...` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bcda5a38083289ee9dc4709e691ca)