### PR TITLE
Add authorization policy scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ rely on version numbers to reason about compatibility.
 - MariaDB is now fully supported with all compliance test suites passing on MariaDB 11
 - MySQL is now fully supported with all compliance test suites passing on MySQL 8
 - CI/CD pipeline now runs compliance tests on SQLite, PostgreSQL, MariaDB, and MySQL to ensure cross-database compatibility
+- Authorization policy scaffolding with new auth types, operations, decisions, and service registration hook.
 - Added `ApplyQueryOptionsToSlice` helper for applying `$orderby`, `$skip`, and `$top` to in-memory slices with a `$filter` evaluation hook, along with public query option type aliases to simplify handler usage.
 - **Public hook interfaces**: `EntityHook` and `ReadHook` are now exported in the public API, making hooks discoverable via `go doc` and `pkg.go.dev`
   - Hook interface documentation includes comprehensive examples for lifecycle hooks (BeforeCreate, AfterCreate, etc.)

--- a/auth_adapter.go
+++ b/auth_adapter.go
@@ -1,0 +1,46 @@
+package odata
+
+import "github.com/nlstn/go-odata/internal/auth"
+
+// AuthContext contains authentication and request metadata for authorization decisions.
+type AuthContext = auth.AuthContext
+
+// RequestMetadata captures HTTP request details relevant to authorization.
+type RequestMetadata = auth.RequestMetadata
+
+// ResourceDescriptor describes the resource being accessed.
+type ResourceDescriptor = auth.ResourceDescriptor
+
+// Operation defines the type of action being authorized.
+type Operation = auth.Operation
+
+// Operation values for authorization checks.
+const (
+	OperationRead     = auth.OperationRead
+	OperationCreate   = auth.OperationCreate
+	OperationUpdate   = auth.OperationUpdate
+	OperationDelete   = auth.OperationDelete
+	OperationQuery    = auth.OperationQuery
+	OperationMetadata = auth.OperationMetadata
+)
+
+// Decision represents the result of an authorization check.
+type Decision = auth.Decision
+
+// Policy defines the interface for authorization decisions.
+type Policy = auth.Policy
+
+// Allow returns an allow decision.
+func Allow() Decision {
+	return auth.Allow()
+}
+
+// Deny returns a deny decision with an optional reason.
+func Deny(reason string) Decision {
+	return auth.Deny(reason)
+}
+
+// SetPolicy registers an authorization policy for the service.
+func (s *Service) SetPolicy(policy Policy) {
+	s.policy = policy
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,63 @@
+package auth
+
+import "net/http"
+
+// AuthContext contains authentication and request metadata for authorization decisions.
+type AuthContext struct {
+	Principal interface{}
+	Roles     []string
+	Claims    map[string]interface{}
+	Scopes    []string
+	Request   RequestMetadata
+}
+
+// RequestMetadata captures HTTP request details relevant to authorization.
+type RequestMetadata struct {
+	Method     string
+	Path       string
+	Headers    http.Header
+	Query      map[string][]string
+	RemoteAddr string
+}
+
+// ResourceDescriptor describes the resource being accessed.
+type ResourceDescriptor struct {
+	EntitySetName string
+	EntityType    string
+	KeyValues     map[string]interface{}
+	PropertyPath  []string
+}
+
+// Operation defines the type of action being authorized.
+type Operation int
+
+// Operation values for authorization checks.
+const (
+	OperationRead Operation = iota
+	OperationCreate
+	OperationUpdate
+	OperationDelete
+	OperationQuery
+	OperationMetadata
+)
+
+// Decision represents the result of an authorization check.
+type Decision struct {
+	Allowed bool
+	Reason  string
+}
+
+// Allow returns an allow decision.
+func Allow() Decision {
+	return Decision{Allowed: true}
+}
+
+// Deny returns a deny decision with an optional reason.
+func Deny(reason string) Decision {
+	return Decision{Allowed: false, Reason: reason}
+}
+
+// Policy defines the interface for authorization decisions.
+type Policy interface {
+	Authorize(ctx AuthContext, resource ResourceDescriptor, operation Operation) Decision
+}

--- a/odata.go
+++ b/odata.go
@@ -57,6 +57,7 @@ import (
 
 	"github.com/nlstn/go-odata/internal/actions"
 	"github.com/nlstn/go-odata/internal/async"
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/handlers"
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/query"
@@ -302,6 +303,8 @@ type Service struct {
 	asyncMonitorPrefix string
 	// logger is used for structured logging throughout the service
 	logger *slog.Logger
+	// policy handles authorization decisions when configured
+	policy auth.Policy
 	// ftsManager manages full-text search functionality for SQLite
 	ftsManager *query.FTSManager
 	// keyGenerators maintains registered key generator functions by name


### PR DESCRIPTION
### Motivation
- Introduce a minimal authorization abstraction so services can register policies that make allow/deny decisions for OData operations.
- Provide typed context and resource descriptors to carry principal, roles, scopes, and request metadata into policy checks.
- Define a small set of canonical operations to cover common OData actions (read/create/update/delete/query/metadata).
- Expose a public adapter so callers can register a policy implementation on the `Service` API.

### Description
- Added a new package `internal/auth` that defines `AuthContext`, `RequestMetadata`, `ResourceDescriptor`, the `Operation` enum, `Decision` with `Allow`/`Deny`, and the `Policy` interface.
- Added a public adapter `auth_adapter.go` that re-exports the auth types as `odata` aliases and provides `Allow`, `Deny`, and `(*Service).SetPolicy` for registering a service-level policy.
- Extended `Service` in `odata.go` with a `policy auth.Policy` field so the runtime can consult a configured policy (registration only; enforcement hooks are left to future work).
- Documented the addition in `CHANGELOG.md` under the "Added" section.

### Testing
- Ran linter with `golangci-lint run ./...` which produced `0 issues`.
- Ran unit and integration tests with `go test ./...` which completed successfully for all packages (the new `internal/auth` package contains no test files).
- Verified compilation with `go build ./...` which succeeded without build errors.
- Formatted sources with `gofmt -w .` as part of the change and ensured no lint/test/build regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb3ae5ccc8328830facc58283b01d)