### PR TITLE
Add authorization enforcement to handlers with AuthContext and ResourceDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ rely on version numbers to reason about compatibility.
 - MySQL is now fully supported with all compliance test suites passing on MySQL 8
 - CI/CD pipeline now runs compliance tests on SQLite, PostgreSQL, MariaDB, and MySQL to ensure cross-database compatibility
 - Authorization policy scaffolding with new auth types, operations, decisions, and service registration hook.
+- Authorization enforcement in entity, metadata, and service document handlers with request context/resource descriptors and OData-compliant 401/403 responses.
 - Added `ApplyQueryOptionsToSlice` helper for applying `$orderby`, `$skip`, and `$top` to in-memory slices with a `$filter` evaluation hook, along with public query option type aliases to simplify handler usage.
 - **Public hook interfaces**: `EntityHook` and `ReadHook` are now exported in the public API, making hooks discoverable via `go doc` and `pkg.go.dev`
   - Hook interface documentation includes comprehensive examples for lifecycle hooks (BeforeCreate, AfterCreate, etc.)

--- a/actions/bind_test.go
+++ b/actions/bind_test.go
@@ -111,4 +111,3 @@ func TestBindParams_RepeatCallsUseConsistentBinding(t *testing.T) {
 		t.Fatalf("BindParams() pointer result = %#v, want percentage 55", ptrResult)
 	}
 }
-

--- a/auth_adapter.go
+++ b/auth_adapter.go
@@ -43,4 +43,17 @@ func Deny(reason string) Decision {
 // SetPolicy registers an authorization policy for the service.
 func (s *Service) SetPolicy(policy Policy) {
 	s.policy = policy
+	if s.metadataHandler != nil {
+		s.metadataHandler.SetPolicy(policy)
+	}
+	if s.serviceDocumentHandler != nil {
+		s.serviceDocumentHandler.SetPolicy(policy)
+	}
+	if s.handlers != nil {
+		for _, handler := range s.handlers {
+			if handler != nil {
+				handler.SetPolicy(policy)
+			}
+		}
+	}
 }

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -1,0 +1,106 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/nlstn/go-odata/internal/auth"
+	"github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/response"
+)
+
+func buildAuthContext(r *http.Request) auth.AuthContext {
+	if r == nil {
+		return auth.AuthContext{}
+	}
+	return auth.AuthContext{
+		Request: auth.RequestMetadata{
+			Method:     r.Method,
+			Path:       r.URL.Path,
+			Headers:    r.Header.Clone(),
+			Query:      r.URL.Query(),
+			RemoteAddr: r.RemoteAddr,
+		},
+	}
+}
+
+func authorizeRequest(w http.ResponseWriter, r *http.Request, policy auth.Policy, resource auth.ResourceDescriptor, operation auth.Operation, logger *slog.Logger) bool {
+	if policy == nil {
+		return true
+	}
+
+	decision := policy.Authorize(buildAuthContext(r), resource, operation)
+	if decision.Allowed {
+		return true
+	}
+
+	statusCode := http.StatusForbidden
+	message := "Forbidden"
+	if r != nil && r.Header.Get("Authorization") == "" {
+		statusCode = http.StatusUnauthorized
+		message = "Unauthorized"
+	}
+
+	if err := response.WriteError(w, statusCode, message, decision.Reason); err != nil {
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Error("Error writing authorization response", "error", err)
+	}
+	return false
+}
+
+func buildEntityResourceDescriptor(entityMetadata *metadata.EntityMetadata, entityKey string, propertyPath []string) auth.ResourceDescriptor {
+	resource := auth.ResourceDescriptor{
+		PropertyPath: append([]string(nil), propertyPath...),
+	}
+	if entityMetadata == nil {
+		return resource
+	}
+	resource.EntitySetName = entityMetadata.EntitySetName
+	resource.EntityType = entityMetadata.EntityName
+	if entityKey == "" {
+		return resource
+	}
+	resource.KeyValues = buildKeyValues(entityMetadata, entityKey)
+	return resource
+}
+
+func buildKeyValues(entityMetadata *metadata.EntityMetadata, entityKey string) map[string]interface{} {
+	if entityMetadata == nil || entityKey == "" {
+		return nil
+	}
+
+	components := &response.ODataURLComponents{
+		EntityKeyMap: make(map[string]string),
+	}
+	if err := parseCompositeKey(entityKey, components); err != nil {
+		if len(entityMetadata.KeyProperties) != 1 {
+			return nil
+		}
+		keyProp := entityMetadata.KeyProperties[0]
+		return map[string]interface{}{keyProp.JsonName: entityKey}
+	}
+
+	if len(components.EntityKeyMap) == 0 {
+		return nil
+	}
+
+	keyValues := make(map[string]interface{}, len(components.EntityKeyMap))
+	for _, keyProp := range entityMetadata.KeyProperties {
+		if value, ok := components.EntityKeyMap[keyProp.JsonName]; ok {
+			keyValues[keyProp.JsonName] = value
+			continue
+		}
+		if value, ok := components.EntityKeyMap[keyProp.Name]; ok {
+			keyValues[keyProp.JsonName] = value
+		}
+	}
+	if len(keyValues) > 0 {
+		return keyValues
+	}
+	for key, value := range components.EntityKeyMap {
+		keyValues[key] = value
+	}
+	return keyValues
+}

--- a/internal/handlers/authorization_test.go
+++ b/internal/handlers/authorization_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/auth"
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+type denyPolicy struct {
+	reason string
+}
+
+func (p denyPolicy) Authorize(_ auth.AuthContext, _ auth.ResourceDescriptor, _ auth.Operation) auth.Decision {
+	return auth.Deny(p.reason)
+}
+
+type operationPolicy struct {
+	expected auth.Operation
+	last     auth.Operation
+}
+
+func (p *operationPolicy) Authorize(_ auth.AuthContext, _ auth.ResourceDescriptor, operation auth.Operation) auth.Decision {
+	p.last = operation
+	if operation != p.expected {
+		return auth.Deny("unexpected operation")
+	}
+	return auth.Allow()
+}
+
+func TestEntityHandlerAuthorizationDenied(t *testing.T) {
+	handler, _ := setupTestHandler(t)
+	handler.SetPolicy(denyPolicy{reason: "blocked"})
+
+	t.Run("unauthorized without header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/TestEntities", nil)
+		w := httptest.NewRecorder()
+
+		handler.HandleCollection(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("Status = %v, want %v", w.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("forbidden with header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/TestEntities", nil)
+		req.Header.Set("Authorization", "Bearer token")
+		w := httptest.NewRecorder()
+
+		handler.HandleCollection(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Errorf("Status = %v, want %v", w.Code, http.StatusForbidden)
+		}
+	})
+}
+
+func TestMetadataHandlerAuthorizationUsesMetadataOperation(t *testing.T) {
+	entities := make(map[string]*metadata.EntityMetadata)
+	entityMeta, err := metadata.AnalyzeEntity(TestEntity{})
+	if err != nil {
+		t.Fatalf("Failed to analyze entity: %v", err)
+	}
+	entities[entityMeta.EntitySetName] = entityMeta
+
+	policy := &operationPolicy{expected: auth.OperationMetadata}
+	handler := NewMetadataHandler(entities)
+	handler.SetPolicy(policy)
+
+	req := httptest.NewRequest(http.MethodGet, "/$metadata", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleMetadata(w, req)
+
+	if policy.last != auth.OperationMetadata {
+		t.Fatalf("Expected operation %v, got %v", auth.OperationMetadata, policy.last)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusOK)
+	}
+}
+
+func TestServiceDocumentAuthorizationUsesReadOperation(t *testing.T) {
+	entities := make(map[string]*metadata.EntityMetadata)
+	entityMeta, err := metadata.AnalyzeEntity(TestEntity{})
+	if err != nil {
+		t.Fatalf("Failed to analyze entity: %v", err)
+	}
+	entities[entityMeta.EntitySetName] = entityMeta
+
+	policy := &operationPolicy{expected: auth.OperationRead}
+	handler := NewServiceDocumentHandler(entities, nil)
+	handler.SetPolicy(policy)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleServiceDocument(w, req)
+
+	if policy.last != auth.OperationRead {
+		t.Fatalf("Expected operation %v, got %v", auth.OperationRead, policy.last)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusOK)
+	}
+}

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -289,6 +289,7 @@ func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.D
 		txHandler := NewEntityHandler(tx, handler.metadata, handler.logger)
 		txHandler.SetNamespace(handler.namespace)
 		txHandler.SetDeltaTracker(handler.tracker)
+		txHandler.SetPolicy(handler.policy)
 		if handler.entitiesMetadata != nil {
 			txHandler.SetEntitiesMetadata(handler.entitiesMetadata)
 		}

--- a/internal/handlers/collection.go
+++ b/internal/handlers/collection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/query"
 )
 
@@ -23,10 +24,19 @@ func (h *EntityHandler) HandleCollection(w http.ResponseWriter, r *http.Request)
 
 	switch r.Method {
 	case http.MethodGet, http.MethodHead:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationQuery, h.logger) {
+			return
+		}
 		h.handleGetCollection(w, r)
 	case http.MethodPost:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationCreate, h.logger) {
+			return
+		}
 		h.handlePostEntity(w, r)
 	case http.MethodOptions:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationRead, h.logger) {
+			return
+		}
 		h.handleOptionsCollection(w)
 	default:
 		WriteError(w, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
@@ -53,8 +63,14 @@ func (h *EntityHandler) HandleCount(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet, http.MethodHead:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", []string{"$count"}), auth.OperationQuery, h.logger) {
+			return
+		}
 		h.handleGetCount(w, r)
 	case http.MethodOptions:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", []string{"$count"}), auth.OperationRead, h.logger) {
+			return
+		}
 		h.handleOptionsCount(w)
 	default:
 		WriteError(w, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/query"
 	"github.com/nlstn/go-odata/internal/trackchanges"
@@ -21,6 +22,7 @@ type EntityHandler struct {
 	namespace            string
 	tracker              *trackchanges.Tracker
 	logger               *slog.Logger
+	policy               auth.Policy
 	ftsManager           *query.FTSManager
 	keyGeneratorResolver func(string) (func(context.Context) (interface{}, error), bool)
 	overwrite            *entityOverwriteHandlers
@@ -74,6 +76,11 @@ func (h *EntityHandler) SetLogger(logger *slog.Logger) {
 		logger = slog.Default()
 	}
 	h.logger = logger
+}
+
+// SetPolicy sets the authorization policy for the handler.
+func (h *EntityHandler) SetPolicy(policy auth.Policy) {
+	h.policy = policy
 }
 
 // SetEntitiesMetadata sets the entities metadata registry for navigation property handling

--- a/internal/handlers/entity_media.go
+++ b/internal/handlers/entity_media.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/response"
 	"gorm.io/gorm"
 )
@@ -21,12 +22,23 @@ func (h *EntityHandler) HandleMediaEntityValue(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	propertyPath := []string{"$value"}
+
 	switch r.Method {
 	case http.MethodGet, http.MethodHead:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, entityKey, propertyPath), auth.OperationRead, h.logger) {
+			return
+		}
 		h.handleGetMediaEntityValue(w, r, entityKey)
 	case http.MethodPut:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, entityKey, propertyPath), auth.OperationUpdate, h.logger) {
+			return
+		}
 		h.handlePutMediaEntityValue(w, r, entityKey)
 	case http.MethodOptions:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, entityKey, propertyPath), auth.OperationRead, h.logger) {
+			return
+		}
 		h.handleOptionsMediaEntityValue(w)
 	default:
 		if err := response.WriteError(w, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,

--- a/internal/handlers/singleton.go
+++ b/internal/handlers/singleton.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/etag"
 	"github.com/nlstn/go-odata/internal/preference"
 	"github.com/nlstn/go-odata/internal/response"
@@ -30,12 +31,24 @@ func (h *EntityHandler) HandleSingleton(w http.ResponseWriter, r *http.Request) 
 
 	switch r.Method {
 	case http.MethodGet, http.MethodHead:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationRead, h.logger) {
+			return
+		}
 		h.handleGetSingleton(w, r)
 	case http.MethodPatch:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationUpdate, h.logger) {
+			return
+		}
 		h.handlePatchSingleton(w, r)
 	case http.MethodPut:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationUpdate, h.logger) {
+			return
+		}
 		h.handlePutSingleton(w, r)
 	case http.MethodOptions:
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationRead, h.logger) {
+			return
+		}
 		h.handleOptionsSingleton(w)
 	default:
 		if err := response.WriteError(w, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,

--- a/odata.go
+++ b/odata.go
@@ -365,6 +365,8 @@ func NewServiceWithConfig(db *gorm.DB, cfg ServiceConfig) (*Service, error) {
 		keyGenerators:            make(map[string]KeyGenerator),
 	}
 	s.metadataHandler.SetNamespace(DefaultNamespace)
+	s.metadataHandler.SetPolicy(s.policy)
+	s.serviceDocumentHandler.SetPolicy(s.policy)
 	s.operationsHandler = operations.NewHandler(s.actions, s.functions, s.handlers, s.entities, s.namespace, logger)
 	// Initialize batch handler with reference to service
 	s.batchHandler = handlers.NewBatchHandler(db, handlersMap, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -591,6 +593,7 @@ func (s *Service) RegisterEntity(entity interface{}) error {
 	handler.SetEntitiesMetadata(s.entities)
 	handler.SetDeltaTracker(s.deltaTracker)
 	handler.SetFTSManager(s.ftsManager)
+	handler.SetPolicy(s.policy)
 	handler.SetKeyGeneratorResolver(func(name string) (func(context.Context) (interface{}, error), bool) {
 		generator, ok := s.resolveKeyGenerator(name)
 		if !ok {
@@ -654,6 +657,7 @@ func (s *Service) RegisterSingleton(entity interface{}, singletonName string) er
 	handler.SetNamespace(s.namespace)
 	handler.SetEntitiesMetadata(s.entities)
 	handler.SetFTSManager(s.ftsManager)
+	handler.SetPolicy(s.policy)
 	handler.SetKeyGeneratorResolver(func(name string) (func(context.Context) (interface{}, error), bool) {
 		generator, ok := s.resolveKeyGenerator(name)
 		if !ok {
@@ -723,6 +727,7 @@ func (s *Service) RegisterVirtualEntity(entity interface{}) error {
 	handler.SetNamespace(s.namespace)
 	handler.SetEntitiesMetadata(s.entities)
 	handler.SetFTSManager(s.ftsManager)
+	handler.SetPolicy(s.policy)
 	handler.SetKeyGeneratorResolver(func(name string) (func(context.Context) (interface{}, error), bool) {
 		generator, ok := s.resolveKeyGenerator(name)
 		if !ok {


### PR DESCRIPTION
### Motivation
- Introduce per-request authorization so handlers can consult a pluggable `Policy` before performing OData operations.  
- Provide a uniform `AuthContext` (request headers, metadata) and `ResourceDescriptor` (entity set, key, property path) for policy decisions.  
- Return OData-compliant 401/403 error responses when authorization fails.  
- Ensure metadata and service document requests use a distinct metadata/read operation for authorization.

### Description
- Added `internal/handlers/auth.go` which builds `AuthContext`, constructs `ResourceDescriptor`/key maps, and exposes `authorizeRequest` that writes OData-compliant errors via `internal/response`.  
- Propagated `auth.Policy` into handlers by adding a `policy` field and `SetPolicy` on `EntityHandler`, `MetadataHandler`, and `ServiceDocumentHandler`, and wiring policy propagation in `auth_adapter.go` and `odata.go`.  
- Added authorization checks (`authorizeRequest`) across handler entry points including collection, entity, $ref, navigation, structural/complex/stream properties, media value, count, metadata, and service document, and propagated policy into batch transaction handlers.  
- Added tests in `internal/handlers/authorization_test.go` and updated `CHANGELOG.md` to document the new enforcement behavior.

### Testing
- Formatted sources with `gofmt -w .` and ran the linter with `golangci-lint run ./...`, which completed with no issues.  
- Ran the full test suite with `go test ./...` and the tests (including the new `internal/handlers/authorization_test.go`) passed.  
- Verified the project builds successfully with `go build ./...`.  
- Unit tests exercised handler authorization paths and confirmed metadata/service document operations use the expected `Operation` values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed2ec2ae083288cf498df1e8531ec)