### PR TITLE
Add property-level authorization filtering for $select and $expand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ rely on version numbers to reason about compatibility.
 - CI/CD pipeline now runs compliance tests on SQLite, PostgreSQL, MariaDB, and MySQL to ensure cross-database compatibility
 - Authorization policy scaffolding with new auth types, operations, decisions, and service registration hook.
 - Authorization enforcement in entity, metadata, and service document handlers with request context/resource descriptors and OData-compliant 401/403 responses.
+- Property-level authorization filtering for `$select` and `$expand`, including projection-safe response shaping.
 - Added `ApplyQueryOptionsToSlice` helper for applying `$orderby`, `$skip`, and `$top` to in-memory slices with a `$filter` evaluation hook, along with public query option type aliases to simplify handler usage.
 - **Public hook interfaces**: `EntityHook` and `ReadHook` are now exported in the public API, making hooks discoverable via `go doc` and `pkg.go.dev`
   - Hook interface documentation includes comprehensive examples for lifecycle hooks (BeforeCreate, AfterCreate, etc.)

--- a/internal/handlers/collection.go
+++ b/internal/handlers/collection.go
@@ -86,7 +86,7 @@ func (h *EntityHandler) handleGetCount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queryOptions, err := query.ParseQueryOptions(r.URL.Query(), h.metadata)
+	queryOptions, err := query.ParseQueryOptions(r.URL.Query(), h.metadata, h.policy, buildAuthContext(r))
 	if err != nil {
 		WriteError(w, http.StatusBadRequest, ErrMsgInvalidQueryOptions, err.Error())
 		return
@@ -118,7 +118,7 @@ func (h *EntityHandler) handleGetCount(w http.ResponseWriter, r *http.Request) {
 
 // handleGetCountOverwrite handles GET count requests using the overwrite handler
 func (h *EntityHandler) handleGetCountOverwrite(w http.ResponseWriter, r *http.Request) {
-	queryOptions, err := query.ParseQueryOptions(r.URL.Query(), h.metadata)
+	queryOptions, err := query.ParseQueryOptions(r.URL.Query(), h.metadata, h.policy, buildAuthContext(r))
 	if err != nil {
 		WriteError(w, http.StatusBadRequest, ErrMsgInvalidQueryOptions, err.Error())
 		return

--- a/internal/handlers/collection_response.go
+++ b/internal/handlers/collection_response.go
@@ -44,7 +44,7 @@ func (h *EntityHandler) collectionResponseWriter(w http.ResponseWriter, r *http.
 		}
 
 		metadataProvider := newMetadataAdapter(h.metadata, h.namespace)
-		if err := response.WriteODataCollectionWithNavigationAndDelta(w, r, h.metadata.EntitySetName, results, totalCount, nextLink, deltaLink, metadataProvider, expandedProps, h.metadata); err != nil {
+		if err := response.WriteODataCollectionWithNavigationAndDelta(w, r, h.metadata.EntitySetName, results, totalCount, nextLink, deltaLink, metadataProvider, expandedProps, h.metadata, queryOptions.Select, queryOptions.SelectSpecified); err != nil {
 			h.logger.Error("Error writing OData response", "error", err)
 		}
 

--- a/internal/handlers/count_test.go
+++ b/internal/handlers/count_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/query"
 )
 
@@ -88,7 +89,7 @@ func TestEntityHandlerCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			helperReq := httptest.NewRequest(http.MethodGet, tt.url, nil)
-			queryOptions, err := query.ParseQueryOptions(helperReq.URL.Query(), handler.metadata)
+			queryOptions, err := query.ParseQueryOptions(helperReq.URL.Query(), handler.metadata, nil, auth.AuthContext{})
 			if err != nil {
 				t.Fatalf("failed to parse query options: %v", err)
 			}
@@ -200,7 +201,7 @@ func TestCountConsistencyAcrossEndpoints(t *testing.T) {
 			}
 
 			helperReq := httptest.NewRequest(http.MethodGet, countURL, nil)
-			queryOptions, err := query.ParseQueryOptions(helperReq.URL.Query(), handler.metadata)
+			queryOptions, err := query.ParseQueryOptions(helperReq.URL.Query(), handler.metadata, nil, auth.AuthContext{})
 			if err != nil {
 				t.Fatalf("failed to parse query options: %v", err)
 			}

--- a/internal/handlers/navigation_properties.go
+++ b/internal/handlers/navigation_properties.go
@@ -218,7 +218,7 @@ func (h *EntityHandler) handleNavigationCollectionWithQueryOptions(w http.Respon
 		Metadata: targetMetadata,
 
 		ParseQueryOptions: func() (*query.QueryOptions, error) {
-			return query.ParseQueryOptions(r.URL.Query(), targetMetadata)
+			return query.ParseQueryOptions(r.URL.Query(), targetMetadata, h.policy, buildAuthContext(r))
 		},
 
 		BeforeRead: func(queryOptions *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error) {
@@ -280,8 +280,8 @@ func (h *EntityHandler) handleNavigationCollectionWithQueryOptions(w http.Respon
 				results = query.ApplySearch(results, queryOptions.Search, targetMetadata)
 			}
 
-			if len(queryOptions.Select) > 0 {
-				results = query.ApplySelect(results, queryOptions.Select, targetMetadata, queryOptions.Expand)
+			if queryOptions.SelectSpecified {
+				results = query.ApplySelect(results, queryOptions.Select, targetMetadata, queryOptions.Expand, queryOptions.SelectSpecified)
 			}
 
 			return results, nil

--- a/internal/handlers/relations_test.go
+++ b/internal/handlers/relations_test.go
@@ -839,16 +839,9 @@ func TestNavigationLinksWithSelect(t *testing.T) {
 		t.Error("Name should be present")
 	}
 
-	// Navigation link should still be present even with $select
-	navLink, hasNavLink := firstAuthor["Books@odata.navigationLink"]
-	if !hasNavLink {
-		t.Error("Expected Books@odata.navigationLink to be present even with $select")
-	}
-
-	// Validate the navigation link format
-	expectedPattern := "http://localhost:8080/Authors(1)/Books"
-	if navLink != expectedPattern {
-		t.Errorf("Expected navigation link to be %s, got %v", expectedPattern, navLink)
+	// Navigation link should be omitted when the navigation property is not selected
+	if _, hasNavLink := firstAuthor["Books@odata.navigationLink"]; hasNavLink {
+		t.Error("Did not expect Books@odata.navigationLink when not selected")
 	}
 
 	// Books property should not be present

--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -1152,6 +1152,25 @@ func (metadata *EntityMetadata) ResolvePropertyPath(path string) (*PropertyMetad
 	return currentProp, prefixBuilder.String(), nil
 }
 
+// SplitPropertyPath splits a property path into segments, trimming whitespace and removing empty segments.
+func (metadata *EntityMetadata) SplitPropertyPath(path string) []string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return nil
+	}
+
+	parts := strings.Split(trimmed, "/")
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		segment := strings.TrimSpace(part)
+		if segment == "" {
+			continue
+		}
+		segments = append(segments, segment)
+	}
+	return segments
+}
+
 // FindComplexField returns a nested property within a complex type by either struct field name or JSON name.
 func (property *PropertyMetadata) FindComplexField(name string) *PropertyMetadata {
 	if property == nil || !property.IsComplexType || property.ComplexTypeFields == nil {

--- a/internal/query/applier.go
+++ b/internal/query/applier.go
@@ -87,8 +87,8 @@ func ApplyQueryOptionsWithFTS(db *gorm.DB, options *QueryOptions, entityMetadata
 
 	// Apply select at database level to fetch only needed columns
 	// Skip this if compute is present, as compute handles the select clause
-	if len(options.Select) > 0 && options.Compute == nil {
-		db = applySelect(db, options.Select, entityMetadata)
+	if options.SelectSpecified && options.Compute == nil {
+		db = applySelect(db, options.Select, entityMetadata, options.SelectSpecified)
 	}
 
 	// Apply filter

--- a/internal/query/apply_shared.go
+++ b/internal/query/apply_shared.go
@@ -9,8 +9,11 @@ import (
 
 // applySelectToExpandedEntity applies select to an expanded navigation property (single entity or collection)
 // This is a simplified version that doesn't require full metadata - it works with reflection
-func applySelectToExpandedEntity(expandedValue interface{}, selectedProps []string) interface{} {
-	if len(selectedProps) == 0 || expandedValue == nil {
+func applySelectToExpandedEntity(expandedValue interface{}, selectedProps []string, selectSpecified bool) interface{} {
+	if expandedValue == nil {
+		return expandedValue
+	}
+	if !selectSpecified {
 		return expandedValue
 	}
 

--- a/internal/query/apply_test.go
+++ b/internal/query/apply_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/metadata"
 )
 
@@ -548,7 +549,7 @@ func TestParseQueryOptions_Apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			queryValues, _ := url.ParseQuery(tt.query)
-			result, err := ParseQueryOptions(queryValues, meta)
+			result, err := ParseQueryOptions(queryValues, meta, nil, auth.AuthContext{})
 			if tt.expectErr {
 				if err == nil {
 					t.Error("Expected error but got none")

--- a/internal/query/authorization.go
+++ b/internal/query/authorization.go
@@ -1,0 +1,118 @@
+package query
+
+import (
+	"strings"
+
+	"github.com/nlstn/go-odata/internal/auth"
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+func filterSelectedProperties(selected []string, entityMetadata *metadata.EntityMetadata, policy auth.Policy, authCtx auth.AuthContext, computedAliases map[string]bool) []string {
+	if policy == nil || len(selected) == 0 {
+		return selected
+	}
+
+	filtered := make([]string, 0, len(selected))
+	for _, propName := range selected {
+		trimmed := strings.TrimSpace(propName)
+		if trimmed == "" {
+			continue
+		}
+		if computedAliases != nil && computedAliases[trimmed] {
+			filtered = append(filtered, propName)
+			continue
+		}
+
+		propertyPath := propertyPathSegments(entityMetadata, trimmed)
+		if authorizePropertyPath(policy, authCtx, entityMetadata, propertyPath) {
+			filtered = append(filtered, propName)
+		}
+	}
+
+	return filtered
+}
+
+func filterExpandOptions(expand []ExpandOption, entityMetadata *metadata.EntityMetadata, policy auth.Policy, authCtx auth.AuthContext, prefix []string) []ExpandOption {
+	if policy == nil || len(expand) == 0 {
+		return expand
+	}
+
+	filtered := make([]ExpandOption, 0, len(expand))
+	for _, expandOpt := range expand {
+		navSegments := append([]string{}, prefix...)
+		navSegments = append(navSegments, propertyPathSegments(entityMetadata, expandOpt.NavigationProperty)...)
+
+		if !authorizePropertyPath(policy, authCtx, entityMetadata, navSegments) {
+			continue
+		}
+
+		if expandOpt.SelectSpecified {
+			expandOpt.Select = filterSelectedPropertiesWithPrefix(expandOpt.Select, entityMetadata, policy, authCtx, navSegments)
+		}
+		expandOpt.Expand = filterExpandOptions(expandOpt.Expand, entityMetadata, policy, authCtx, navSegments)
+		filtered = append(filtered, expandOpt)
+	}
+
+	return filtered
+}
+
+func filterSelectedPropertiesWithPrefix(selected []string, entityMetadata *metadata.EntityMetadata, policy auth.Policy, authCtx auth.AuthContext, prefix []string) []string {
+	if policy == nil || len(selected) == 0 {
+		return selected
+	}
+
+	filtered := make([]string, 0, len(selected))
+	for _, propName := range selected {
+		trimmed := strings.TrimSpace(propName)
+		if trimmed == "" {
+			continue
+		}
+
+		path := append([]string{}, prefix...)
+		path = append(path, propertyPathSegments(entityMetadata, trimmed)...)
+		if authorizePropertyPath(policy, authCtx, entityMetadata, path) {
+			filtered = append(filtered, propName)
+		}
+	}
+
+	return filtered
+}
+
+func authorizePropertyPath(policy auth.Policy, authCtx auth.AuthContext, entityMetadata *metadata.EntityMetadata, propertyPath []string) bool {
+	if policy == nil || len(propertyPath) == 0 {
+		return true
+	}
+
+	resource := auth.ResourceDescriptor{
+		PropertyPath: append([]string(nil), propertyPath...),
+	}
+	if entityMetadata != nil {
+		resource.EntitySetName = entityMetadata.EntitySetName
+		resource.EntityType = entityMetadata.EntityName
+	}
+
+	return policy.Authorize(authCtx, resource, auth.OperationRead).Allowed
+}
+
+func propertyPathSegments(entityMetadata *metadata.EntityMetadata, path string) []string {
+	if entityMetadata != nil {
+		if segments := entityMetadata.SplitPropertyPath(path); len(segments) > 0 {
+			return segments
+		}
+	}
+
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, "/")
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		segment := strings.TrimSpace(part)
+		if segment == "" {
+			continue
+		}
+		segments = append(segments, segment)
+	}
+	return segments
+}

--- a/internal/query/compute_test.go
+++ b/internal/query/compute_test.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/nlstn/go-odata/internal/auth"
 )
 
 // TestCompute_ArithmeticOperations tests $compute with arithmetic operations
@@ -217,7 +219,7 @@ func TestCompute_WithSelect(t *testing.T) {
 			queryParams.Set("$compute", tt.compute)
 			queryParams.Set("$select", tt.select_)
 
-			options, err := ParseQueryOptions(queryParams, meta)
+			options, err := ParseQueryOptions(queryParams, meta, nil, auth.AuthContext{})
 
 			if tt.expectErr {
 				if err == nil {
@@ -268,7 +270,7 @@ func TestCompute_WithFilter(t *testing.T) {
 			queryParams.Set("$compute", tt.compute)
 			queryParams.Set("$filter", tt.filter)
 
-			options, err := ParseQueryOptions(queryParams, meta)
+			options, err := ParseQueryOptions(queryParams, meta, nil, auth.AuthContext{})
 
 			if tt.expectErr {
 				if err == nil {
@@ -319,7 +321,7 @@ func TestCompute_WithOrderBy(t *testing.T) {
 			queryParams.Set("$compute", tt.compute)
 			queryParams.Set("$orderby", tt.orderby)
 
-			options, err := ParseQueryOptions(queryParams, meta)
+			options, err := ParseQueryOptions(queryParams, meta, nil, auth.AuthContext{})
 
 			if tt.expectErr {
 				if err == nil {
@@ -419,7 +421,7 @@ func TestCompute_ParseFromQueryOptions(t *testing.T) {
 			queryParams := url.Values{}
 			queryParams.Set("$compute", tt.compute)
 
-			options, err := ParseQueryOptions(queryParams, meta)
+			options, err := ParseQueryOptions(queryParams, meta, nil, auth.AuthContext{})
 
 			if tt.expectErr {
 				if err == nil {

--- a/internal/query/expand_parser.go
+++ b/internal/query/expand_parser.go
@@ -110,6 +110,7 @@ func parseNestedExpandOptionsCore(expand *ExpandOption, optionsStr string, entit
 
 		switch strings.ToLower(key) {
 		case "$select":
+			expand.SelectSpecified = true
 			expand.Select = parseSelect(value)
 		case "$expand":
 			// Parse nested $expand recursively without metadata validation

--- a/internal/query/expand_test.go
+++ b/internal/query/expand_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/metadata"
 )
 
@@ -28,7 +29,7 @@ func TestParseExpandSimple(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -49,7 +50,7 @@ func TestParseExpandWithNestedTop(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($top=5)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestParseExpandWithNestedSkip(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($skip=2)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -95,7 +96,7 @@ func TestParseExpandWithNestedSelect(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($select=Title)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -118,7 +119,7 @@ func TestParseExpandWithMultipleNestedOptions(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($select=Title;$top=3;$skip=1)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -149,7 +150,7 @@ func TestParseExpandInvalid(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "InvalidProperty")
 
-	_, err := ParseQueryOptions(params, authorMeta)
+	_, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err == nil {
 		t.Error("Expected error for invalid navigation property")
 	}
@@ -164,7 +165,7 @@ func TestParseExpandMultiple(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -183,7 +184,7 @@ func TestParseExpandWithFilterAndOrderBy(t *testing.T) {
 	params.Set("$filter", "Name eq 'Test'")
 	params.Set("$orderby", "Name asc")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -209,7 +210,7 @@ func TestParseExpandWithCount(t *testing.T) {
 	params.Set("$expand", "Books")
 	params.Set("$count", "true")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -232,7 +233,7 @@ func TestParseExpandWithTopAndSkip(t *testing.T) {
 	params.Set("$top", "10")
 	params.Set("$skip", "5")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -257,7 +258,7 @@ func TestParseExpandWithNestedFilter(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($filter=Title eq 'Test Book')")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -291,7 +292,7 @@ func TestParseExpandWithNestedOrderBy(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($orderby=Title desc)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -322,7 +323,7 @@ func TestParseExpandWithMultipleNestedFilters(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($filter=Title eq 'Book A' or Title eq 'Book B')")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -352,7 +353,7 @@ func TestParseExpandWithAllNestedOptions(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($filter=Title ne 'Archived';$select=Title;$orderby=Title;$top=5;$skip=2)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -479,7 +480,7 @@ func TestParseExpandWithComplexFilter(t *testing.T) {
 			params := url.Values{}
 			params.Set("$expand", tt.expandQuery)
 
-			options, err := ParseQueryOptions(params, authorMeta)
+			options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 			if (err != nil) != tt.expectErr {
 				t.Errorf("Expected error: %v, got: %v", tt.expectErr, err)
 				return
@@ -558,7 +559,7 @@ func TestParseExpandWithMultipleLevels(t *testing.T) {
 			params := url.Values{}
 			params.Set("$expand", tt.expandQuery)
 
-			options, err := ParseQueryOptions(params, authorMeta)
+			options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 			if (err != nil) != tt.expectErr {
 				t.Errorf("Expected error: %v, got: %v", tt.expectErr, err)
 				return
@@ -578,7 +579,7 @@ func TestParseNestedExpand(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($expand=Author)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -611,7 +612,7 @@ func TestParseNestedExpandWithOptions(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Books($expand=Author($select=Name);$top=5)")
 
-	options, err := ParseQueryOptions(params, authorMeta)
+	options, err := ParseQueryOptions(params, authorMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -676,7 +677,7 @@ func TestParseMultiLevelNestedExpand(t *testing.T) {
 	params := url.Values{}
 	params.Set("$expand", "Members($expand=Club)")
 
-	options, err := ParseQueryOptions(params, userMeta)
+	options, err := ParseQueryOptions(params, userMeta, nil, auth.AuthContext{})
 	if err != nil {
 		t.Fatalf("Failed to parse query options: %v", err)
 	}
@@ -775,7 +776,7 @@ func TestComplexFilterCombinations(t *testing.T) {
 			params := url.Values{}
 			params.Set("$filter", tt.filter)
 
-			options, err := ParseQueryOptions(params, productMeta)
+			options, err := ParseQueryOptions(params, productMeta, nil, auth.AuthContext{})
 			if (err != nil) != tt.expectErr {
 				t.Errorf("Expected error: %v, got: %v (filter: %s)", tt.expectErr, err, tt.filter)
 				return
@@ -827,7 +828,7 @@ func TestParseOrderByWithMultipleProperties(t *testing.T) {
 			params := url.Values{}
 			params.Set("$orderby", tt.orderBy)
 
-			options, err := ParseQueryOptions(params, productMeta)
+			options, err := ParseQueryOptions(params, productMeta, nil, auth.AuthContext{})
 			if (err != nil) != tt.expectErr {
 				t.Errorf("Expected error: %v, got: %v", tt.expectErr, err)
 				return

--- a/internal/query/parser_authorization_test.go
+++ b/internal/query/parser_authorization_test.go
@@ -1,0 +1,91 @@
+package query
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/auth"
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+type denyPropertyPolicy struct {
+	denied map[string]bool
+}
+
+func (p denyPropertyPolicy) Authorize(_ auth.AuthContext, resource auth.ResourceDescriptor, _ auth.Operation) auth.Decision {
+	path := strings.Join(resource.PropertyPath, "/")
+	if p.denied[path] {
+		return auth.Deny("blocked")
+	}
+	return auth.Allow()
+}
+
+func TestParseQueryOptionsFiltersUnauthorizedSelect(t *testing.T) {
+	meta := getTestMetadata(t)
+	params := url.Values{}
+	params.Set("$select", "Name,Price")
+
+	policy := denyPropertyPolicy{denied: map[string]bool{"Price": true}}
+	options, err := ParseQueryOptions(params, meta, policy, auth.AuthContext{})
+	if err != nil {
+		t.Fatalf("ParseQueryOptions failed: %v", err)
+	}
+
+	if !options.SelectSpecified {
+		t.Fatal("expected SelectSpecified to be true")
+	}
+
+	if len(options.Select) != 1 || options.Select[0] != "Name" {
+		t.Fatalf("expected only Name to be selected, got %v", options.Select)
+	}
+}
+
+func TestParseQueryOptionsFiltersUnauthorizedExpand(t *testing.T) {
+	authorMeta, err := metadata.AnalyzeEntity(&TestAuthor{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity failed: %v", err)
+	}
+
+	params := url.Values{}
+	params.Set("$expand", "Books($select=Title,AuthorID)")
+
+	policy := denyPropertyPolicy{denied: map[string]bool{"Books/Title": true}}
+	options, err := ParseQueryOptions(params, authorMeta, policy, auth.AuthContext{})
+	if err != nil {
+		t.Fatalf("ParseQueryOptions failed: %v", err)
+	}
+
+	if len(options.Expand) != 1 {
+		t.Fatalf("expected 1 expand option, got %d", len(options.Expand))
+	}
+
+	expand := options.Expand[0]
+	if !expand.SelectSpecified {
+		t.Fatal("expected SelectSpecified to be true for expand")
+	}
+
+	if len(expand.Select) != 1 || expand.Select[0] != "AuthorID" {
+		t.Fatalf("expected AuthorID to remain in select, got %v", expand.Select)
+	}
+}
+
+func TestParseQueryOptionsRejectsUnauthorizedExpand(t *testing.T) {
+	authorMeta, err := metadata.AnalyzeEntity(&TestAuthor{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity failed: %v", err)
+	}
+
+	params := url.Values{}
+	params.Set("$expand", "Books")
+
+	policy := denyPropertyPolicy{denied: map[string]bool{"Books": true}}
+	options, err := ParseQueryOptions(params, authorMeta, policy, auth.AuthContext{})
+	if err != nil {
+		t.Fatalf("ParseQueryOptions failed: %v", err)
+	}
+
+	if len(options.Expand) != 0 {
+		t.Fatalf("expected expand to be filtered, got %d options", len(options.Expand))
+	}
+}

--- a/internal/query/parser_index_schema_test.go
+++ b/internal/query/parser_index_schema_test.go
@@ -3,6 +3,8 @@ package query
 import (
 	"net/url"
 	"testing"
+
+	"github.com/nlstn/go-odata/internal/auth"
 )
 
 func TestParseIndexOption(t *testing.T) {
@@ -53,7 +55,7 @@ func TestParseIndexOption(t *testing.T) {
 				t.Fatalf("Failed to parse query string: %v", err)
 			}
 
-			options, err := ParseQueryOptions(queryParams, meta)
+			options, err := ParseQueryOptions(queryParams, meta, nil, auth.AuthContext{})
 
 			if tt.expectError && err == nil {
 				t.Error("Expected error but got none")
@@ -123,7 +125,7 @@ func TestParseSchemaVersionOption(t *testing.T) {
 				t.Fatalf("Failed to parse query string: %v", err)
 			}
 
-			options, err := ParseQueryOptions(queryParams, meta)
+			options, err := ParseQueryOptions(queryParams, meta, nil, auth.AuthContext{})
 
 			if tt.expectError && err == nil {
 				t.Error("Expected error but got none")

--- a/internal/query/parser_test.go
+++ b/internal/query/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/metadata"
 )
 
@@ -306,7 +307,7 @@ func TestParseQueryOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			queryValues, _ := url.ParseQuery(tt.query)
-			result, err := ParseQueryOptions(queryValues, meta)
+			result, err := ParseQueryOptions(queryValues, meta, nil, auth.AuthContext{})
 			if tt.expectErr {
 				if err == nil {
 					t.Error("Expected error but got none")
@@ -473,7 +474,7 @@ func TestParseQueryOptions_WithSearch(t *testing.T) {
 				t.Fatalf("Failed to parse query string: %v", err)
 			}
 
-			options, err := ParseQueryOptions(queryParams, meta)
+			options, err := ParseQueryOptions(queryParams, meta, nil, auth.AuthContext{})
 
 			if tt.expectError && err == nil {
 				t.Error("Expected error but got none")

--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -19,13 +19,13 @@ func WriteODataCollectionWithDelta(w http.ResponseWriter, r *http.Request, entit
 }
 
 // WriteODataCollectionWithNavigation writes an OData collection response with navigation links.
-func WriteODataCollectionWithNavigation(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink *string, metadata EntityMetadataProvider, expandedProps []string, fullMetadata *metadata.EntityMetadata) error {
-	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, nil, metadata, expandedProps, fullMetadata)
+func WriteODataCollectionWithNavigation(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink *string, metadata EntityMetadataProvider, expandedProps []string, fullMetadata *metadata.EntityMetadata, selectedProps []string, selectSpecified bool) error {
+	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, nil, metadata, expandedProps, fullMetadata, selectedProps, selectSpecified)
 }
 
 // WriteODataCollectionWithNavigationAndDelta writes an OData collection response with navigation links and a delta link.
-func WriteODataCollectionWithNavigationAndDelta(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, metadata EntityMetadataProvider, expandedProps []string, fullMetadata *metadata.EntityMetadata) error {
-	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, deltaLink, metadata, expandedProps, fullMetadata)
+func WriteODataCollectionWithNavigationAndDelta(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, metadata EntityMetadataProvider, expandedProps []string, fullMetadata *metadata.EntityMetadata, selectedProps []string, selectSpecified bool) error {
+	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, deltaLink, metadata, expandedProps, fullMetadata, selectedProps, selectSpecified)
 }
 
 func writeODataCollectionResponse(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string) error {
@@ -80,7 +80,7 @@ func writeODataCollectionResponse(w http.ResponseWriter, r *http.Request, entity
 	return encoder.Encode(response)
 }
 
-func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, metadata EntityMetadataProvider, expandedProps []string, fullMetadata *metadata.EntityMetadata) error {
+func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, metadata EntityMetadataProvider, expandedProps []string, fullMetadata *metadata.EntityMetadata, selectedProps []string, selectSpecified bool) error {
 	if !IsAcceptableFormat(r) {
 		return WriteError(w, http.StatusNotAcceptable, "Not Acceptable",
 			"The requested format is not supported. Only application/json is supported for data responses.")
@@ -93,7 +93,7 @@ func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.R
 		contextURL = buildContextURL(r, entitySetName)
 	}
 
-	transformedData := addNavigationLinks(data, metadata, expandedProps, r, entitySetName, metadataLevel, fullMetadata)
+	transformedData := addNavigationLinks(data, metadata, expandedProps, r, entitySetName, metadataLevel, fullMetadata, selectedProps, selectSpecified)
 	if transformedData == nil {
 		transformedData = []interface{}{}
 	}

--- a/internal/response/collection_test.go
+++ b/internal/response/collection_test.go
@@ -33,7 +33,7 @@ func TestWriteODataCollectionWithNavigationWithNilData(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com/Products", nil)
 	w := httptest.NewRecorder()
 
-	if err := WriteODataCollectionWithNavigation(w, req, "Products", nil, nil, nil, nil, nil, nil); err != nil {
+	if err := WriteODataCollectionWithNavigation(w, req, "Products", nil, nil, nil, nil, nil, nil, nil, false); err != nil {
 		t.Fatalf("WriteODataCollectionWithNavigation failed: %v", err)
 	}
 

--- a/internal/response/navigation_links_test.go
+++ b/internal/response/navigation_links_test.go
@@ -6,9 +6,39 @@ import (
 	"testing"
 )
 
+type testMetadataProvider struct{}
+
+func (testMetadataProvider) GetProperties() []PropertyMetadata {
+	return []PropertyMetadata{
+		{Name: "ID", JsonName: "ID"},
+		{Name: "Name", JsonName: "Name"},
+		{Name: "Orders", JsonName: "Orders", IsNavigationProp: true},
+	}
+}
+
+func (testMetadataProvider) GetKeyProperty() *PropertyMetadata {
+	return &PropertyMetadata{Name: "ID", JsonName: "ID"}
+}
+
+func (testMetadataProvider) GetKeyProperties() []PropertyMetadata {
+	return []PropertyMetadata{{Name: "ID", JsonName: "ID"}}
+}
+
+func (testMetadataProvider) GetEntitySetName() string {
+	return "Products"
+}
+
+func (testMetadataProvider) GetETagProperty() *PropertyMetadata {
+	return nil
+}
+
+func (testMetadataProvider) GetNamespace() string {
+	return "Default"
+}
+
 func TestAddNavigationLinksWithNilData(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com/Products", nil)
-	result := addNavigationLinks(nil, nil, nil, req, "Products", "minimal", nil)
+	result := addNavigationLinks(nil, nil, nil, req, "Products", "minimal", nil, nil, false)
 
 	if result == nil {
 		t.Fatal("addNavigationLinks should not return nil for nil data")
@@ -25,7 +55,7 @@ func TestAddNavigationLinksWithNilData(t *testing.T) {
 
 func TestAddNavigationLinksWithEmptySlice(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com/Products", nil)
-	result := addNavigationLinks([]interface{}{}, nil, nil, req, "Products", "minimal", nil)
+	result := addNavigationLinks([]interface{}{}, nil, nil, req, "Products", "minimal", nil, nil, false)
 
 	if result == nil {
 		t.Fatal("addNavigationLinks should not return nil for empty slice")
@@ -46,7 +76,7 @@ func TestAddNavigationLinksWithEmptySlice(t *testing.T) {
 func TestAddNavigationLinksWithNonSliceData(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com/Products", nil)
 	single := map[string]interface{}{"ID": 1}
-	result := addNavigationLinks(single, nil, nil, req, "Products", "minimal", nil)
+	result := addNavigationLinks(single, nil, nil, req, "Products", "minimal", nil, nil, false)
 
 	if result == nil {
 		t.Fatal("addNavigationLinks should return empty slice for non-slice data")
@@ -58,5 +88,29 @@ func TestAddNavigationLinksWithNonSliceData(t *testing.T) {
 	}
 	if string(data) != "[]" {
 		t.Fatalf("expected [], got %s", string(data))
+	}
+}
+
+func TestAddNavigationLinksRespectsSelectProjection(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com/Products", nil)
+	data := []map[string]interface{}{
+		{
+			"ID":   1,
+			"Name": "Sample",
+		},
+	}
+
+	result := addNavigationLinks(data, testMetadataProvider{}, nil, req, "Products", "full", nil, []string{"Name"}, true)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	item, ok := result[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result[0])
+	}
+
+	if _, exists := item["Orders@odata.navigationLink"]; exists {
+		t.Fatal("unexpected navigation link for unselected property")
 	}
 }


### PR DESCRIPTION
### Motivation
- Enforce property-level authorization when clients request projections or expanded navigation properties so sensitive fields can be redacted early.
- Ensure authorization decisions can target specific property paths using `Policy.Authorize` with `ResourceDescriptor.PropertyPath` to support fine-grained access control.
- Preserve correct projection behavior so database queries and response shaping remain consistent when properties are removed by policy.
- Make authorization checks available during query parsing to avoid returning or loading unauthorized properties.

### Description
- Parse-time authorization: `ParseQueryOptions` now accepts `auth.Policy` and `auth.AuthContext` and evaluates property-level access while parsing `$select` and `$expand`.
- Authorization helpers: added `internal/query/authorization.go` to build property path segments, call `policy.Authorize(...)` for `auth.OperationRead`, and filter selected/expanded properties accordingly.
- Select/expand tracking: introduced `SelectSpecified` and `Expand.SelectSpecified` flags to distinguish explicitly-requested projections from defaults, and threaded that through select application (`applySelect`, `ApplySelect`, `ApplySelectToEntity`, `ApplySelectToMapResults`, and related helpers).
- Response shaping: response writers and navigation link generation now accept the selected projection and omit navigation links or properties when they were filtered by policy, with tests covering select-aware navigation link behavior.
- Tests & tweaks: updated query parsing and apply tests to pass a default `auth.AuthContext{}` and added `internal/query/parser_authorization_test.go` to validate filtering of unauthorized `$select` and `$expand` items.

### Testing
- Ran `gofmt -w .` and code was formatted successfully.
- Ran `golangci-lint run ./...` with zero reported issues.
- Ran the full test suite with `go test ./...` and all tests passed locally (including newly added authorization tests).
- Verified build with `go build ./...` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eec85c9508328a423f6e604a41883)