### PR TITLE
Add policy query filters and navigation target authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ rely on version numbers to reason about compatibility.
 - Authorization policy scaffolding with new auth types, operations, decisions, and service registration hook.
 - Authorization enforcement in entity, metadata, and service document handlers with request context/resource descriptors and OData-compliant 401/403 responses.
 - Added `ApplyQueryOptionsToSlice` helper for applying `$orderby`, `$skip`, and `$top` to in-memory slices with a `$filter` evaluation hook, along with public query option type aliases to simplify handler usage.
+- Authorization policies can now provide query filters to constrain result sets, and navigation property access authorizes both source entities and target sets.
 - **Public hook interfaces**: `EntityHook` and `ReadHook` are now exported in the public API, making hooks discoverable via `go doc` and `pkg.go.dev`
   - Hook interface documentation includes comprehensive examples for lifecycle hooks (BeforeCreate, AfterCreate, etc.)
   - Read hook documentation with examples for tenant filtering and data redaction

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,6 +1,10 @@
 package auth
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/nlstn/go-odata/internal/query"
+)
 
 // AuthContext contains authentication and request metadata for authorization decisions.
 type AuthContext struct {
@@ -60,4 +64,11 @@ func Deny(reason string) Decision {
 // Policy defines the interface for authorization decisions.
 type Policy interface {
 	Authorize(ctx AuthContext, resource ResourceDescriptor, operation Operation) Decision
+}
+
+// QueryFilterProvider defines an optional extension point for providing additional
+// query filters based on authorization policy.
+type QueryFilterProvider interface {
+	Policy
+	QueryFilter(ctx AuthContext, resource ResourceDescriptor, operation Operation) (*query.FilterExpression, error)
 }

--- a/internal/handlers/collection.go
+++ b/internal/handlers/collection.go
@@ -92,6 +92,11 @@ func (h *EntityHandler) handleGetCount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := applyPolicyFilter(r, h.policy, buildEntityResourceDescriptor(h.metadata, "", []string{"$count"}), queryOptions); err != nil {
+		WriteError(w, http.StatusForbidden, "Authorization failed", err.Error())
+		return
+	}
+
 	scopes, hookErr := callBeforeReadCollection(h.metadata, r, queryOptions)
 	if hookErr != nil {
 		WriteError(w, http.StatusForbidden, "Authorization failed", hookErr.Error())
@@ -121,6 +126,11 @@ func (h *EntityHandler) handleGetCountOverwrite(w http.ResponseWriter, r *http.R
 	queryOptions, err := query.ParseQueryOptions(r.URL.Query(), h.metadata)
 	if err != nil {
 		WriteError(w, http.StatusBadRequest, ErrMsgInvalidQueryOptions, err.Error())
+		return
+	}
+
+	if err := applyPolicyFilter(r, h.policy, buildEntityResourceDescriptor(h.metadata, "", []string{"$count"}), queryOptions); err != nil {
+		WriteError(w, http.StatusForbidden, "Authorization failed", err.Error())
 		return
 	}
 

--- a/internal/handlers/collection_read.go
+++ b/internal/handlers/collection_read.go
@@ -72,6 +72,11 @@ func (h *EntityHandler) handleGetCollectionOverwrite(w http.ResponseWriter, r *h
 	// Apply default max top if no explicit $top is set
 	queryOptions = h.applyDefaultMaxTop(queryOptions)
 
+	if err := applyPolicyFilter(r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), queryOptions); err != nil {
+		WriteError(w, http.StatusForbidden, "Authorization failed", err.Error())
+		return
+	}
+
 	// Create overwrite context
 	ctx := &OverwriteContext{
 		QueryOptions: queryOptions,
@@ -129,6 +134,14 @@ func (h *EntityHandler) parseCollectionQueryOptions(w http.ResponseWriter, r *ht
 
 		// Apply default max top if no explicit $top is set
 		queryOptions = h.applyDefaultMaxTop(queryOptions)
+
+		if err := applyPolicyFilter(r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), queryOptions); err != nil {
+			return nil, &collectionRequestError{
+				StatusCode: http.StatusForbidden,
+				ErrorCode:  "Authorization failed",
+				Message:    err.Error(),
+			}
+		}
 
 		return queryOptions, nil
 	}

--- a/internal/query/helpers.go
+++ b/internal/query/helpers.go
@@ -134,3 +134,23 @@ func toSnakeCase(s string) string {
 	}
 	return strings.ToLower(result.String())
 }
+
+// MergeFilterExpressions combines two filter expressions using a logical AND.
+func MergeFilterExpressions(left *FilterExpression, right *FilterExpression) *FilterExpression {
+	if left == nil {
+		return right
+	}
+	if right == nil {
+		return left
+	}
+	return &FilterExpression{
+		Left:    left,
+		Right:   right,
+		Logical: LogicalAnd,
+	}
+}
+
+// ParseFilterExpression parses a raw filter string into a filter expression with metadata validation.
+func ParseFilterExpression(filterStr string, entityMetadata *metadata.EntityMetadata) (*FilterExpression, error) {
+	return parseFilter(filterStr, entityMetadata, map[string]bool{})
+}


### PR DESCRIPTION
### Motivation
- Allow authorization policies to provide query-time filter predicates that constrain result sets at the query execution layer.
- Ensure navigation property access is authorized not only against the source entity but also against the target entity set for both reads and $ref updates.
- Provide an extension point so policies can return additional filter predicates which are merged into parsed OData `QueryOptions` before execution.
- Make it possible to implement multi-tenant / row-level filtering and target-set ACLs via policies without changing handler logic.

### Description
- Added `QueryFilterProvider` to `auth` and a `QueryFilter` hook (`QueryFilter(ctx, resource, operation)`) so policies can supply a `*query.FilterExpression`.
- Added `MergeFilterExpressions` and `ParseFilterExpression` helpers in `internal/query/helpers.go` and `applyPolicyFilter`/`policyQueryFilter` in `internal/handlers/auth.go` to merge policy filters into `QueryOptions.Filter`.
- Applied `applyPolicyFilter` where collection query options are parsed or used (collection handlers and navigation collection query parsing) so policy filters are merged before execution.
- Extended navigation property handling to authorize the target entity set (for `OperationQuery` / `OperationRead` / `OperationUpdate` as appropriate) and enforce authorization on navigation `$ref` operations, and updated related code paths to use the merged filters.
- Added tests: `TestPolicyFilterConstrainsCollectionResults` and `TestNavigationPropertyRequiresTargetAuthorization`, and updated relation tests to register both source and target metadata for navigation tests; updated `CHANGELOG.md`.

### Testing
- Ran `golangci-lint run ./...` and fixed reported issues; final lint run passed with no issues.
- Ran `go test ./...` and all packages (including `internal/handlers` and `internal/query`) passed.
- Ran `go build ./...` which completed successfully.
- New and updated unit tests in `internal/handlers` were executed as part of `go test` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952900f5d2c83289e61e880e502428d)