### PR TITLE
Deduplicate metadata generation logic and optimize XML assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ rely on version numbers to reason about compatibility.
   duration is provided and continue purging expired rows in the background.
 - Compliance suite default output is now concise (overall progress and summary only); use `-verbose` for per-suite and per-test details.
 - Documentation now clarifies full-text search support for SQLite/PostgreSQL, along with fallback behavior and operational constraints.
+- Metadata generation now shares common logic between JSON and XML outputs, and XML assembly uses builders to reduce allocations.
 
 ### Fixed
 

--- a/internal/handlers/metadata_shared.go
+++ b/internal/handlers/metadata_shared.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"sort"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+type navigationBinding struct {
+	path   string
+	target string
+}
+
+type namedEnumDefinition struct {
+	name string
+	info *enumTypeInfo
+}
+
+func (h *MetadataHandler) navigationBindings(model metadataModel, entityMeta *metadata.EntityMetadata) []navigationBinding {
+	bindings := make([]navigationBinding, 0, len(entityMeta.Properties))
+	for _, prop := range entityMeta.Properties {
+		if prop.IsNavigationProp {
+			targetEntitySet := model.getEntitySetNameForType(prop.NavigationTarget)
+			bindings = append(bindings, navigationBinding{
+				path:   prop.JsonName,
+				target: targetEntitySet,
+			})
+		}
+	}
+	return bindings
+}
+
+func (h *MetadataHandler) sortedEnumDefinitions(model metadataModel) []namedEnumDefinition {
+	enumDefinitions := model.collectEnumDefinitions()
+	if len(enumDefinitions) == 0 {
+		return nil
+	}
+
+	enumNames := make([]string, 0, len(enumDefinitions))
+	for name := range enumDefinitions {
+		enumNames = append(enumNames, name)
+	}
+	sort.Strings(enumNames)
+
+	sorted := make([]namedEnumDefinition, 0, len(enumNames))
+	for _, name := range enumNames {
+		info := enumDefinitions[name]
+		if info == nil || len(info.Members) == 0 {
+			continue
+		}
+		sorted = append(sorted, namedEnumDefinition{
+			name: name,
+			info: info,
+		})
+	}
+
+	return sorted
+}
+
+func (h *MetadataHandler) propertyEdmType(model metadataModel, prop *metadata.PropertyMetadata) string {
+	if prop.IsEnum && prop.EnumTypeName != "" {
+		return model.qualifiedTypeName(prop.EnumTypeName)
+	}
+	return getEdmType(prop.Type)
+}
+
+func (h *MetadataHandler) propertyNullable(prop *metadata.PropertyMetadata) (value bool, include bool) {
+	if prop.Nullable != nil {
+		return *prop.Nullable, true
+	}
+	if !prop.IsRequired && !prop.IsKey {
+		return true, true
+	}
+	return false, false
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated logic between CSDL JSON and XML generation for maintainability and consistency.
- Centralize enum sorting, navigation bindings, and property type/nullability decisions to avoid diverging behavior.
- Improve XML metadata assembly performance by replacing repeated string concatenation with a `strings.Builder`.

### Description
- Added `internal/handlers/metadata_shared.go` with shared helpers `sortedEnumDefinitions`, `navigationBindings`, `propertyEdmType`, and `propertyNullable` and small types used by both formats.
- Updated `internal/handlers/metadata_json.go` to use the shared helpers and convert navigation bindings into the JSON map form via `navigationBindingsMap`.
- Refactored `internal/handlers/metadata_xml.go` to use `strings.Builder` for assembling the XML and to reuse the shared helpers for enums, navigation bindings, and property attributes.
- Updated `CHANGELOG.md` to note the metadata generation deduplication and XML builder optimization.

### Testing
- Ran `gofmt -w .` to format sources and ensure formatting correctness (succeeded).
- Ran `golangci-lint run ./...` with zero reported issues (succeeded).
- Executed `go test ./...` and all packages passed their tests (succeeded).
- Built the module with `go build ./...` to verify compilation (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b00ee420832897f92211157aa941)