### PR TITLE
Use OData error responses for pre-request hook failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rely on version numbers to reason about compatibility.
 ## [Unreleased]
 
 ### Fixed
+- Pre-request hook failures now return OData-formatted error responses for non-batch requests.
 - **Observability documentation and implementation cleanup**: 
   - Added nil check for logger before calling Info in SetObservability to prevent panic
   - Marked `EnableQueryOptionTracing` as not yet implemented with clear documentation

--- a/http_runtime.go
+++ b/http_runtime.go
@@ -1,6 +1,10 @@
 package odata
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/nlstn/go-odata/internal/response"
+)
 
 // ServeHTTP implements http.Handler by delegating to the runtime.
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +21,9 @@ func (s *Service) serveHTTP(w http.ResponseWriter, r *http.Request, allowAsync b
 	if s.preRequestHook != nil {
 		ctx, err := s.preRequestHook(r)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusForbidden)
+			if writeErr := response.WriteError(w, http.StatusForbidden, "Forbidden", err.Error()); writeErr != nil {
+				http.Error(w, writeErr.Error(), http.StatusInternalServerError)
+			}
 			return
 		}
 		if ctx != nil {

--- a/internal/observability/config.go
+++ b/internal/observability/config.go
@@ -25,8 +25,8 @@ type Config struct {
 	// This adds overhead but provides detailed insight into query performance.
 	EnableDetailedDBTracing bool
 
-// EnableQueryOptionTracing is reserved for future implementation.
-// When implemented, it will add query options ($filter, $select, etc.) as span attributes.
+	// EnableQueryOptionTracing is reserved for future implementation.
+	// When implemented, it will add query options ($filter, $select, etc.) as span attributes.
 	EnableQueryOptionTracing bool
 
 	// EnableServerTiming enables the Server-Timing HTTP response header.

--- a/test/pre_request_hook_test.go
+++ b/test/pre_request_hook_test.go
@@ -15,8 +15,8 @@ import (
 
 // PreRequestHookProduct is a test entity for pre-request hook tests
 type PreRequestHookProduct struct {
-	ID    uint   `json:"ID" gorm:"primaryKey" odata:"key"`
-	Name  string `json:"Name"`
+	ID    uint    `json:"ID" gorm:"primaryKey" odata:"key"`
+	Name  string  `json:"Name"`
 	Price float64 `json:"Price"`
 }
 


### PR DESCRIPTION
### Motivation
- Ensure pre-request hook failures return the same OData v4 JSON error structure used by the rest of the library for non-batch requests.
- Provide standard OData headers on hook errors so clients receive consistent responses.
- Avoid leaking plain text HTTP errors and align error formatting with other handlers.

### Description
- Added `github.com/nlstn/go-odata/internal/response` import to `http_runtime.go` and replaced `http.Error` with `response.WriteError` for pre-request hook failures.
- Added fallback handling that returns an `http.Error` only if `response.WriteError` itself fails to write.
- Updated `CHANGELOG.md` with an item describing the behavior change and applied minor formatting adjustments in `internal/observability/config.go` and `test/pre_request_hook_test.go`.

### Testing
- Ran `golangci-lint run ./...` with zero issues reported.
- Ran `go test ./...` and all packages passed.
- Ran `go build ./...` and the project built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a482e94908328b119cac6d254a4e2)