### PR TITLE
Potential fix for code scanning alert no. 23: Log entries created from user input

### DIFF
--- a/internal/async/manager.go
+++ b/internal/async/manager.go
@@ -438,6 +438,10 @@ func (m *Manager) ServeMonitor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Sanitize the job ID before using it in log entries to prevent log forgery.
+	safeID := strings.ReplaceAll(id, "\n", "")
+	safeID = strings.ReplaceAll(safeID, "\r", "")
+
 	var record JobRecord
 	db := m.db
 	if r != nil {
@@ -449,14 +453,14 @@ func (m *Manager) ServeMonitor(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r)
 			return
 		}
-		log.Printf("async: failed to load job %s: %v", id, err)
+		log.Printf("async: failed to load job %s: %v", safeID, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	snapshot, err := recordToSnapshot(&record)
 	if err != nil {
-		log.Printf("async: failed to deserialize job %s: %v", id, err)
+		log.Printf("async: failed to deserialize job %s: %v", safeID, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/NLstn/go-odata/security/code-scanning/23](https://github.com/NLstn/go-odata/security/code-scanning/23)

In general, to prevent log forgery from user-controlled values, sanitize or encode those values before including them in log messages. For plain-text logs, this usually means removing or replacing newline (`\n`) and carriage-return (`\r`) characters and optionally other control characters, so an attacker cannot inject extra lines or manipulate log structure.

In this specific case, the best minimal fix is to sanitize the `id` string right before it is used in logging, by stripping `\n` and `\r` characters. We can do this using the already-imported `strings` package, so no new imports are required. To avoid changing existing behavior, we will only use the sanitized version for logging, not for any database lookups or HTTP responses, so the semantics of job lookup remain exactly the same.

Concretely:
- In `ServeMonitor`, after `id := extractJobID(r)` (or at least before the first log usage), introduce a new local variable such as `safeID` that is derived by removing `\n` and `\r` from `id`.
- Use `safeID` instead of `id` in the two log.Printf calls on lines 452 and 459.
- Keep using the original `id` variable for database queries and control flow, so there is no functional change other than safer logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
