### PR TITLE
Fix lambda navigation column resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ rely on version numbers to reason about compatibility.
 - Ensure function context URLs honor the configured service namespace when returning complex types.
 - NewService constructors now return a clear error when given a nil database handle, preventing later panics from misconfigured callers.
 - **Hook method names renamed with "OData" prefix**: All EntityHook interface methods have been renamed to avoid conflicts with GORM's hook detection logic
+- **Lambda filters now respect navigation target column mappings**: any/all predicates now resolve target entity column names via metadata, honoring custom GORM `column:` tags in navigation collections.
   - `BeforeCreate` → `ODataBeforeCreate`
   - `AfterCreate` → `ODataAfterCreate`
   - `BeforeUpdate` → `ODataBeforeUpdate`

--- a/cmd/complianceserver/entities/product_description.go
+++ b/cmd/complianceserver/entities/product_description.go
@@ -8,6 +8,7 @@ type ProductDescription struct {
 	LanguageKey string    `json:"LanguageKey" gorm:"primaryKey;size:2" odata:"key,maxlength=2"`
 	Description string    `json:"Description" gorm:"not null" odata:"required,maxlength=500,searchable"`
 	LongText    *string   `json:"LongText" gorm:"type:text" odata:"maxlength=2000,nullable,searchable"`
+	CustomName  string    `json:"CustomName" gorm:"column:custom_name"`
 	// Navigation property back to Product
 	Product *Product `json:"Product,omitempty" gorm:"foreignKey:ProductID;references:ID"`
 }
@@ -26,6 +27,7 @@ func GetSampleProductDescriptions() []ProductDescription {
 			LanguageKey: "EN",
 			Description: "High-performance laptop for productivity and gaming",
 			LongText:    stringPtr("This state-of-the-art laptop features the latest processor technology, dedicated graphics card, and ample RAM to handle all your computing needs. Perfect for both professional work and entertainment."),
+			CustomName:  "Promo",
 		},
 		{
 			ProductID:   uuid.Nil, // Will be set during seeding to first product (Laptop)


### PR DESCRIPTION
### Motivation
- Lambda (`any`/`all`) predicates on navigation collections must resolve property column names using the navigation target entity metadata so custom GORM `column:` tags are honored.
- Existing lambda handling used `toSnakeCase` for lambda properties which ignored `gorm:"column:..."` mappings and caused incorrect SQL predicates.
- Add coverage to prevent regressions by exercising a navigation target field with a custom `gorm:"column:custom_name"` mapping.
- Ensure compliance tests include the same scenario so server behavior is validated end-to-end.

### Description
- Thread navigation target metadata into lambda SQL builders by adding `getNavigationTargetMetadata` and passing the resulting `*metadata.EntityMetadata` into `buildLambdaCondition` and `buildFilterConditionForLambda`.
- Use the existing column resolution helper `GetColumnName` (instead of `toSnakeCase`) when building lambda subquery column references and function comparisons so GORM `column:` tags are respected.
- Add unit test `TestLambdaApplier_CustomColumnAny` in `internal/query/lambda_applier_test.go` that seeds a `CustomName` column mapped with `gorm:"column:custom_name"` and asserts `Descriptions/any(d: d/CustomName eq 'Promo')` works.
- Add compliance test `Lambda any with custom column mapping` in `compliance-suite/tests/v4_0/11.2.9_lambda_operators.go` and seed the compliance server sample data (`CustomName: "Promo"`) in `cmd/complianceserver/entities/product_description.go`; update `CHANGELOG.md`.

### Testing
- Ran `gofmt -w .` with no formatting issues.
- Ran `golangci-lint run ./...` and the linter returned `0 issues`.
- Ran `go test ./...` and all tests passed across packages (unit tests succeeded).
- Ran `go build ./...` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696619e98ac88328b70605ffebb1d445)