### PR TITLE
Validate nested $expand options against target metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ rely on version numbers to reason about compatibility.
 - **Cache eviction prevents unbounded memory growth**: Metadata cache now limited to 10 entries with automatic eviction keeping 5 most common versions (4.0, 4.01 prioritized).
 
 ### Fixed
+- Nested `$expand` options now validate `$select`, `$filter`, `$orderby`, and `$compute` against the expanded entity metadata, and expanded order-by/filter SQL uses metadata-aware column resolution with dialect quoting to avoid invalid property use and SQL mismatches.
 - **OData-MaxVersion header now correctly negotiates response version**: Per OData v4 spec section 8.2.6, the service now responds with the maximum supported version that is less than or equal to the requested `OData-MaxVersion` header. When a client sends `OData-MaxVersion: 4.0`, the response now correctly includes `OData-Version: 4.0` instead of the hardcoded `4.01`. This fixes compatibility with clients like Excel that only support OData v4.0.
 - **Batch responses now echo Content-ID headers**: Per OData v4 spec section 11.7.4, Content-ID headers from batch request parts are now properly echoed back in the corresponding response parts. This enables clients to correlate batch responses with their requests, which is essential for batch request processing and changeset referencing.
 - Pre-request hook failures now return OData-formatted error responses for non-batch requests.

--- a/compliance-suite/tests/v4_0/11.2.5.9_nested_expand_options.go
+++ b/compliance-suite/tests/v4_0/11.2.5.9_nested_expand_options.go
@@ -103,5 +103,33 @@ func NestedExpandOptions() *framework.TestSuite {
 		},
 	)
 
+	// Test 7: Expand with invalid nested $select
+	suite.AddTest(
+		"test_expand_invalid_nested_select",
+		"Expand with invalid nested $select returns 400",
+		func(ctx *framework.TestContext) error {
+			expand := url.QueryEscape("Descriptions($select=DoesNotExist)")
+			resp, err := ctx.GET("/Products?$expand=" + expand)
+			if err != nil {
+				return err
+			}
+			return ctx.AssertStatusCode(resp, 400)
+		},
+	)
+
+	// Test 8: Expand with invalid nested $filter
+	suite.AddTest(
+		"test_expand_invalid_nested_filter",
+		"Expand with invalid nested $filter returns 400",
+		func(ctx *framework.TestContext) error {
+			expand := url.QueryEscape("Descriptions($filter=DoesNotExist eq 'X')")
+			resp, err := ctx.GET("/Products?$expand=" + expand)
+			if err != nil {
+				return err
+			}
+			return ctx.AssertStatusCode(resp, 400)
+		},
+	)
+
 	return suite
 }

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -91,6 +91,9 @@ func (h *EntityHandler) SetPolicy(policy auth.Policy) {
 // SetEntitiesMetadata sets the entities metadata registry for navigation property handling
 func (h *EntityHandler) SetEntitiesMetadata(entitiesMetadata map[string]*metadata.EntityMetadata) {
 	h.entitiesMetadata = entitiesMetadata
+	if h.metadata != nil {
+		h.metadata.SetEntitiesRegistry(entitiesMetadata)
+	}
 }
 
 // SetKeyGeneratorResolver injects a resolver used to look up key generator functions by name.

--- a/internal/handlers/relations_test.go
+++ b/internal/handlers/relations_test.go
@@ -185,7 +185,12 @@ func TestExpandOnSingleEntity(t *testing.T) {
 func TestExpandWithNestedTop(t *testing.T) {
 	db := setupRelationTestDB(t)
 	authorMeta, _ := metadata.AnalyzeEntity(&Author{})
+	bookMeta, _ := metadata.AnalyzeEntity(&Book{})
 	handler := NewEntityHandler(db, authorMeta, nil)
+	handler.SetEntitiesMetadata(map[string]*metadata.EntityMetadata{
+		authorMeta.EntitySetName: authorMeta,
+		bookMeta.EntitySetName:   bookMeta,
+	})
 
 	req := httptest.NewRequest(http.MethodGet, "/Authors(1)?$expand=Books($top=1)", nil)
 	w := httptest.NewRecorder()
@@ -215,7 +220,12 @@ func TestExpandWithNestedTop(t *testing.T) {
 func TestExpandWithNestedSkip(t *testing.T) {
 	db := setupRelationTestDB(t)
 	authorMeta, _ := metadata.AnalyzeEntity(&Author{})
+	bookMeta, _ := metadata.AnalyzeEntity(&Book{})
 	handler := NewEntityHandler(db, authorMeta, nil)
+	handler.SetEntitiesMetadata(map[string]*metadata.EntityMetadata{
+		authorMeta.EntitySetName: authorMeta,
+		bookMeta.EntitySetName:   bookMeta,
+	})
 
 	req := httptest.NewRequest(http.MethodGet, "/Authors(1)?$expand=Books($skip=1)", nil)
 	w := httptest.NewRecorder()

--- a/internal/query/apply_expand.go
+++ b/internal/query/apply_expand.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/nlstn/go-odata/internal/metadata"
 	"gorm.io/gorm"
@@ -15,30 +16,20 @@ func applyExpand(db *gorm.DB, expand []ExpandOption, entityMetadata *metadata.En
 			continue
 		}
 
+		var targetMetadata *metadata.EntityMetadata
+		if entityMetadata != nil {
+			target, err := entityMetadata.ResolveNavigationTarget(expandOpt.NavigationProperty)
+			if err == nil {
+				targetMetadata = target
+			}
+		}
+
 		if needsPreloadCallback(expandOpt) {
 			db = db.Preload(navProp.Name, func(db *gorm.DB) *gorm.DB {
-				return applyExpandCallback(db, expandOpt)
+				return applyExpandCallback(db, expandOpt, targetMetadata)
 			})
 		} else {
 			db = db.Preload(navProp.Name)
-		}
-	}
-	return db
-}
-
-// applyExpandWithoutMetadata applies expand options without entity metadata
-// This is used for nested expand levels where we don't have easy access to target entity metadata
-func applyExpandWithoutMetadata(db *gorm.DB, expand []ExpandOption) *gorm.DB {
-	for _, expandOpt := range expand {
-		// Use the navigation property name directly since we don't have metadata
-		navPropName := expandOpt.NavigationProperty
-
-		if needsPreloadCallback(expandOpt) {
-			db = db.Preload(navPropName, func(db *gorm.DB) *gorm.DB {
-				return applyExpandCallback(db, expandOpt)
-			})
-		} else {
-			db = db.Preload(navPropName)
 		}
 	}
 	return db
@@ -52,19 +43,21 @@ func needsPreloadCallback(expandOpt ExpandOption) bool {
 }
 
 // applyExpandCallback applies the expand options within a GORM preload callback
-func applyExpandCallback(db *gorm.DB, expandOpt ExpandOption) *gorm.DB {
+func applyExpandCallback(db *gorm.DB, expandOpt ExpandOption, targetMetadata *metadata.EntityMetadata) *gorm.DB {
 	if expandOpt.Filter != nil {
-		db = applyFilterForExpand(db, expandOpt.Filter)
+		db = applyFilter(db, expandOpt.Filter, targetMetadata)
 	}
 
 	if len(expandOpt.OrderBy) > 0 {
+		dialect := getDatabaseDialect(db)
 		for _, item := range expandOpt.OrderBy {
 			direction := "ASC"
 			if item.Descending {
 				direction = "DESC"
 			}
-			columnName := toSnakeCase(item.Property)
-			db = db.Order(fmt.Sprintf("%s %s", columnName, direction))
+			columnName := GetColumnName(item.Property, targetMetadata)
+			quotedColumn := quoteColumnReference(dialect, columnName)
+			db = db.Order(fmt.Sprintf("%s %s", quotedColumn, direction))
 		}
 	}
 
@@ -77,113 +70,22 @@ func applyExpandCallback(db *gorm.DB, expandOpt ExpandOption) *gorm.DB {
 
 	// Recursively apply nested expand options
 	if len(expandOpt.Expand) > 0 {
-		db = applyExpandWithoutMetadata(db, expandOpt.Expand)
+		db = applyExpand(db, expandOpt.Expand, targetMetadata)
 	}
 
 	return db
 }
 
-// applyFilterForExpand applies filter to expanded navigation property without metadata context
-func applyFilterForExpand(db *gorm.DB, filter *FilterExpression) *gorm.DB {
-	if filter == nil {
-		return db
+func quoteColumnReference(dialect string, column string) string {
+	if column == "" {
+		return column
 	}
-
-	dialect := getDatabaseDialect(db)
-
-	if filter.Logical != "" {
-		leftDB := applyFilterForExpand(db, filter.Left)
-		rightDB := applyFilterForExpand(db, filter.Right)
-
-		switch filter.Logical {
-		case LogicalAnd:
-			return leftDB.Where(rightDB)
-		case LogicalOr:
-			leftQuery, leftArgs := buildSimpleFilterCondition(dialect, filter.Left)
-			rightQuery, rightArgs := buildSimpleFilterCondition(dialect, filter.Right)
-			combinedQuery := fmt.Sprintf("(%s) OR (%s)", leftQuery, rightQuery)
-			combinedArgs := append(leftArgs, rightArgs...)
-			return db.Where(combinedQuery, combinedArgs...)
+	if strings.Contains(column, ".") {
+		parts := strings.Split(column, ".")
+		for i, part := range parts {
+			parts[i] = quoteIdent(dialect, part)
 		}
+		return strings.Join(parts, ".")
 	}
-
-	query, args := buildSimpleFilterCondition(dialect, filter)
-	return db.Where(query, args...)
-}
-
-// buildSimpleFilterCondition builds a filter condition without metadata
-func buildSimpleFilterCondition(dialect string, filter *FilterExpression) (string, []interface{}) {
-	if filter == nil {
-		return "", nil
-	}
-
-	if filter.Logical != "" {
-		leftQuery, leftArgs := buildSimpleFilterCondition(dialect, filter.Left)
-		rightQuery, rightArgs := buildSimpleFilterCondition(dialect, filter.Right)
-
-		switch filter.Logical {
-		case LogicalAnd:
-			query := fmt.Sprintf("(%s) AND (%s)", leftQuery, rightQuery)
-			args := append(leftArgs, rightArgs...)
-			return query, args
-		case LogicalOr:
-			query := fmt.Sprintf("(%s) OR (%s)", leftQuery, rightQuery)
-			args := append(leftArgs, rightArgs...)
-			return query, args
-		}
-	}
-
-	if filter.Left != nil && filter.Left.Operator != "" {
-		return buildSimpleFunctionComparison(dialect, filter)
-	}
-
-	fieldName := toSnakeCase(filter.Property)
-	return buildSimpleOperatorCondition(filter.Operator, fieldName, filter.Value)
-}
-
-// buildSimpleOperatorCondition builds SQL for a simple operator condition
-func buildSimpleOperatorCondition(op FilterOperator, fieldName string, value interface{}) (string, []interface{}) {
-	switch op {
-	case OpEqual:
-		return fmt.Sprintf("%s = ?", fieldName), []interface{}{value}
-	case OpNotEqual:
-		return fmt.Sprintf("%s != ?", fieldName), []interface{}{value}
-	case OpGreaterThan:
-		return fmt.Sprintf("%s > ?", fieldName), []interface{}{value}
-	case OpGreaterThanOrEqual:
-		return fmt.Sprintf("%s >= ?", fieldName), []interface{}{value}
-	case OpLessThan:
-		return fmt.Sprintf("%s < ?", fieldName), []interface{}{value}
-	case OpLessThanOrEqual:
-		return fmt.Sprintf("%s <= ?", fieldName), []interface{}{value}
-	case OpContains:
-		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{"%" + fmt.Sprint(value) + "%"}
-	case OpStartsWith:
-		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{fmt.Sprint(value) + "%"}
-	case OpEndsWith:
-		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{"%" + fmt.Sprint(value)}
-	case OpHas:
-		return fmt.Sprintf("(%s & ?) = ?", fieldName), []interface{}{value, value}
-	default:
-		return "", nil
-	}
-}
-
-// buildSimpleFunctionComparison builds a comparison with a function on the left side (without metadata)
-func buildSimpleFunctionComparison(dialect string, filter *FilterExpression) (string, []interface{}) {
-	funcExpr := filter.Left
-	fieldName := toSnakeCase(funcExpr.Property)
-
-	funcSQL, funcArgs := buildFunctionSQL(dialect, funcExpr.Operator, fieldName, funcExpr.Value)
-	if funcSQL == "" {
-		return "", nil
-	}
-
-	compSQL := buildComparisonSQL(filter.Operator, funcSQL)
-	if compSQL == "" {
-		return "", nil
-	}
-
-	allArgs := append(funcArgs, filter.Value)
-	return compSQL, allArgs
+	return quoteIdent(dialect, column)
 }

--- a/internal/query/expand_test.go
+++ b/internal/query/expand_test.go
@@ -21,9 +21,42 @@ type TestBook struct {
 	Author   *TestAuthor `json:"Author,omitempty" gorm:"foreignKey:AuthorID"`
 }
 
+func buildAuthorBookMetadata(t *testing.T) (*metadata.EntityMetadata, *metadata.EntityMetadata) {
+	t.Helper()
+
+	authorMeta, err := metadata.AnalyzeEntity(&TestAuthor{})
+	if err != nil {
+		t.Fatalf("Failed to analyze author entity: %v", err)
+	}
+
+	bookMeta, err := metadata.AnalyzeEntity(&TestBook{})
+	if err != nil {
+		t.Fatalf("Failed to analyze book entity: %v", err)
+	}
+
+	setEntitiesRegistry(authorMeta, bookMeta)
+
+	return authorMeta, bookMeta
+}
+
+func setEntitiesRegistry(metas ...*metadata.EntityMetadata) {
+	entities := make(map[string]*metadata.EntityMetadata, len(metas))
+	for _, meta := range metas {
+		if meta == nil {
+			continue
+		}
+		entities[meta.EntitySetName] = meta
+	}
+	for _, meta := range metas {
+		if meta != nil {
+			meta.SetEntitiesRegistry(entities)
+		}
+	}
+}
+
 // TestParseExpandSimple tests parsing a simple $expand
 func TestParseExpandSimple(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books")
@@ -44,7 +77,7 @@ func TestParseExpandSimple(t *testing.T) {
 
 // TestParseExpandWithNestedTop tests parsing $expand with nested $top
 func TestParseExpandWithNestedTop(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($top=5)")
@@ -67,7 +100,7 @@ func TestParseExpandWithNestedTop(t *testing.T) {
 
 // TestParseExpandWithNestedSkip tests parsing $expand with nested $skip
 func TestParseExpandWithNestedSkip(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($skip=2)")
@@ -90,7 +123,7 @@ func TestParseExpandWithNestedSkip(t *testing.T) {
 
 // TestParseExpandWithNestedSelect tests parsing $expand with nested $select
 func TestParseExpandWithNestedSelect(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($select=Title)")
@@ -113,7 +146,7 @@ func TestParseExpandWithNestedSelect(t *testing.T) {
 
 // TestParseExpandWithMultipleNestedOptions tests parsing $expand with multiple nested options
 func TestParseExpandWithMultipleNestedOptions(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($select=Title;$top=3;$skip=1)")
@@ -144,7 +177,7 @@ func TestParseExpandWithMultipleNestedOptions(t *testing.T) {
 
 // TestParseExpandInvalid tests parsing an invalid $expand
 func TestParseExpandInvalid(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "InvalidProperty")
@@ -159,7 +192,7 @@ func TestParseExpandInvalid(t *testing.T) {
 func TestParseExpandMultiple(t *testing.T) {
 	// For this test, we need a more complex entity structure
 	// Since we only have Author->Books, we'll just test the parsing logic
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books")
@@ -176,7 +209,7 @@ func TestParseExpandMultiple(t *testing.T) {
 
 // TestParseExpandWithFilterAndOrderBy tests combining $expand with $filter and $orderby
 func TestParseExpandWithFilterAndOrderBy(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books")
@@ -203,7 +236,7 @@ func TestParseExpandWithFilterAndOrderBy(t *testing.T) {
 
 // TestParseExpandWithCount tests combining $expand with $count
 func TestParseExpandWithCount(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books")
@@ -225,7 +258,7 @@ func TestParseExpandWithCount(t *testing.T) {
 
 // TestParseExpandWithTopAndSkip tests combining $expand with $top and $skip on main entity
 func TestParseExpandWithTopAndSkip(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books")
@@ -252,7 +285,7 @@ func TestParseExpandWithTopAndSkip(t *testing.T) {
 
 // TestParseExpandWithNestedFilter tests parsing $expand with nested $filter
 func TestParseExpandWithNestedFilter(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($filter=Title eq 'Test Book')")
@@ -286,7 +319,7 @@ func TestParseExpandWithNestedFilter(t *testing.T) {
 
 // TestParseExpandWithNestedOrderBy tests parsing $expand with nested $orderby
 func TestParseExpandWithNestedOrderBy(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($orderby=Title desc)")
@@ -317,7 +350,7 @@ func TestParseExpandWithNestedOrderBy(t *testing.T) {
 
 // TestParseExpandWithMultipleNestedFilters tests parsing $expand with complex nested $filter
 func TestParseExpandWithMultipleNestedFilters(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($filter=Title eq 'Book A' or Title eq 'Book B')")
@@ -347,7 +380,7 @@ func TestParseExpandWithMultipleNestedFilters(t *testing.T) {
 
 // TestParseExpandWithAllNestedOptions tests parsing $expand with all nested options
 func TestParseExpandWithAllNestedOptions(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($filter=Title ne 'Archived';$select=Title;$orderby=Title;$top=5;$skip=2)")
@@ -398,6 +431,44 @@ func TestParseExpandWithAllNestedOptions(t *testing.T) {
 	}
 }
 
+func TestParseExpandWithInvalidNestedOptions(t *testing.T) {
+	authorMeta, _ := buildAuthorBookMetadata(t)
+
+	tests := []struct {
+		name        string
+		expandQuery string
+	}{
+		{
+			name:        "Invalid nested select",
+			expandQuery: "Books($select=DoesNotExist)",
+		},
+		{
+			name:        "Invalid nested filter",
+			expandQuery: "Books($filter=DoesNotExist eq 1)",
+		},
+		{
+			name:        "Invalid nested orderby",
+			expandQuery: "Books($orderby=DoesNotExist desc)",
+		},
+		{
+			name:        "Invalid nested compute",
+			expandQuery: "Books($compute=DoesNotExist eq 1 as Total)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := url.Values{}
+			params.Set("$expand", tt.expandQuery)
+
+			_, err := ParseQueryOptions(params, authorMeta)
+			if err == nil {
+				t.Fatalf("Expected error for %s", tt.expandQuery)
+			}
+		})
+	}
+}
+
 // TestSplitExpandParts tests the expand parts splitting logic
 func TestSplitExpandParts(t *testing.T) {
 	tests := []struct {
@@ -440,7 +511,7 @@ func TestSplitExpandParts(t *testing.T) {
 
 // TestParseExpandWithComplexFilter tests parsing $expand with complex nested filters
 func TestParseExpandWithComplexFilter(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	tests := []struct {
 		name        string
@@ -521,6 +592,18 @@ func TestParseExpandWithMultipleLevels(t *testing.T) {
 		t.Fatalf("Failed to analyze entity: %v", err)
 	}
 
+	publisherMeta, err := metadata.AnalyzeEntity(&Publisher{})
+	if err != nil {
+		t.Fatalf("Failed to analyze publisher entity: %v", err)
+	}
+
+	bookMeta, err := metadata.AnalyzeEntity(&TestBook{})
+	if err != nil {
+		t.Fatalf("Failed to analyze book entity: %v", err)
+	}
+
+	setEntitiesRegistry(authorMeta, publisherMeta, bookMeta)
+
 	tests := []struct {
 		name        string
 		expandQuery string
@@ -573,7 +656,7 @@ func TestParseExpandWithMultipleLevels(t *testing.T) {
 
 // TestParseNestedExpand tests parsing of nested $expand syntax
 func TestParseNestedExpand(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($expand=Author)")
@@ -606,7 +689,7 @@ func TestParseNestedExpand(t *testing.T) {
 
 // TestParseNestedExpandWithOptions tests nested expand with additional query options
 func TestParseNestedExpandWithOptions(t *testing.T) {
-	authorMeta, _ := metadata.AnalyzeEntity(&TestAuthor{})
+	authorMeta, _ := buildAuthorBookMetadata(t)
 
 	params := url.Values{}
 	params.Set("$expand", "Books($expand=Author($select=Name);$top=5)")
@@ -672,6 +755,18 @@ func TestParseMultiLevelNestedExpand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to analyze entity: %v", err)
 	}
+
+	memberMeta, err := metadata.AnalyzeEntity(&Member{})
+	if err != nil {
+		t.Fatalf("Failed to analyze member entity: %v", err)
+	}
+
+	clubMeta, err := metadata.AnalyzeEntity(&Club{})
+	if err != nil {
+		t.Fatalf("Failed to analyze club entity: %v", err)
+	}
+
+	setEntitiesRegistry(userMeta, memberMeta, clubMeta)
 
 	params := url.Values{}
 	params.Set("$expand", "Members($expand=Club)")

--- a/internal/query/simple_filter.go
+++ b/internal/query/simple_filter.go
@@ -1,0 +1,31 @@
+package query
+
+import "fmt"
+
+// buildSimpleOperatorCondition builds SQL for a simple operator condition.
+func buildSimpleOperatorCondition(op FilterOperator, fieldName string, value interface{}) (string, []interface{}) {
+	switch op {
+	case OpEqual:
+		return fmt.Sprintf("%s = ?", fieldName), []interface{}{value}
+	case OpNotEqual:
+		return fmt.Sprintf("%s != ?", fieldName), []interface{}{value}
+	case OpGreaterThan:
+		return fmt.Sprintf("%s > ?", fieldName), []interface{}{value}
+	case OpGreaterThanOrEqual:
+		return fmt.Sprintf("%s >= ?", fieldName), []interface{}{value}
+	case OpLessThan:
+		return fmt.Sprintf("%s < ?", fieldName), []interface{}{value}
+	case OpLessThanOrEqual:
+		return fmt.Sprintf("%s <= ?", fieldName), []interface{}{value}
+	case OpContains:
+		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{"%" + fmt.Sprint(value) + "%"}
+	case OpStartsWith:
+		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{fmt.Sprint(value) + "%"}
+	case OpEndsWith:
+		return fmt.Sprintf("%s LIKE ?", fieldName), []interface{}{"%" + fmt.Sprint(value)}
+	case OpHas:
+		return fmt.Sprintf("(%s & ?) = ?", fieldName), []interface{}{value, value}
+	default:
+		return "", nil
+	}
+}

--- a/odata.go
+++ b/odata.go
@@ -870,6 +870,9 @@ func (s *Service) RegisterEntity(entity interface{}) error {
 
 	// Store the metadata
 	s.entities[entityMetadata.EntitySetName] = entityMetadata
+	for _, meta := range s.entities {
+		meta.SetEntitiesRegistry(s.entities)
+	}
 
 	// Create and store the handler
 	handler := handlers.NewEntityHandler(s.db, entityMetadata, s.logger)
@@ -941,6 +944,9 @@ func (s *Service) RegisterSingleton(entity interface{}, singletonName string) er
 
 	// Store the metadata using singleton name as key
 	s.entities[singletonName] = singletonMetadata
+	for _, meta := range s.entities {
+		meta.SetEntitiesRegistry(s.entities)
+	}
 
 	// Create and store the handler (same handler type works for both entities and singletons)
 	handler := handlers.NewEntityHandler(s.db, singletonMetadata, s.logger)
@@ -1017,6 +1023,9 @@ func (s *Service) RegisterVirtualEntity(entity interface{}) error {
 
 	// Store the metadata
 	s.entities[entityMetadata.EntitySetName] = entityMetadata
+	for _, meta := range s.entities {
+		meta.SetEntitiesRegistry(s.entities)
+	}
 
 	// Create and store the handler (no database operations will be performed)
 	handler := handlers.NewEntityHandler(s.db, entityMetadata, s.logger)


### PR DESCRIPTION
### Motivation
- Nested `$expand` options were being parsed and applied without verifying the target entity metadata, allowing invalid `$select`, `$filter`, `$orderby`, and `$compute` to slip through and produce SQL errors or incorrect queries. 
- `$orderby` and `$filter` generation for expanded entities used ad-hoc name conversion, which caused ambiguous or unquoted column references across SQL dialects. 
- Navigation target resolution was not available at parse/apply time, so nested expansions could not be validated or compiled in a metadata-aware way. 
- Compliance tests for invalid nested expand options were missing and needed to be added to enforce strict OData behavior.

### Description
- Added `EntityMetadata.SetEntitiesRegistry(...)` and `EntityMetadata.ResolveNavigationTarget(name string)` to resolve navigation targets using a registry of registered entity metadata. 
- Wired the registry propagation: `EntityHandler.SetEntitiesMetadata(...)` calls `SetEntitiesRegistry`, and the service updates the registry when entities/singletons/virtual entities are registered via `RegisterEntity`, `RegisterSingleton`, and `RegisterVirtualEntity`. 
- Updated `internal/query/expand_parser.go` so `parseSingleExpandCore` resolves the navigation `targetMetadata` and `parseNestedExpandOptionsCore` accepts that `targetMetadata` and validates nested `$select`, `$filter`, `$orderby`, and `$compute` against it (including computed alias support). 
- Updated `internal/query/apply_expand.go` so `applyExpand`/`applyExpandCallback` pass the correct `targetMetadata` during recursion, use `GetColumnName(...)` + dialect-aware quoting for `$orderby` (via `quoteColumnReference`/`quoteIdent`), and delegate nested `$filter` building to the standard metadata-aware `parseFilter`/`applyFilter` pipeline instead of ad-hoc `buildSimpleFilterCondition`. 
- Added a small helper `internal/query/simple_filter.go` containing the simple operator-to-SQL builder used by existing code paths, and added/updated unit and compliance tests to cover invalid nested expand cases and registry wiring. 

### Testing
- Ran `golangci-lint run ./...` and it completed with no issues. 
- Ran `go test ./...` and all packages completed successfully (unit tests and updated expand tests passed). 
- Ran `go build ./...` and the project builds successfully. 
- Added unit tests (`internal/query/expand_test.go`) and compliance checks (`compliance-suite/tests/v4_0/11.2.5.9_nested_expand_options.go`) to verify invalid nested `$expand` usages return errors and to prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966192d862c83288c9139c1eb6ba7b5)