### PR TITLE
Validate nested $expand options against target metadata

### DIFF
--- a/compliance-suite/tests/v4_0/11.2.5.9_nested_expand_options.go
+++ b/compliance-suite/tests/v4_0/11.2.5.9_nested_expand_options.go
@@ -131,5 +131,19 @@ func NestedExpandOptions() *framework.TestSuite {
 		},
 	)
 
+	// Test 9: Expand with invalid nested $orderby
+	suite.AddTest(
+		"test_expand_invalid_nested_orderby",
+		"Expand with invalid nested $orderby returns 400",
+		func(ctx *framework.TestContext) error {
+			expand := url.QueryEscape("Descriptions($orderby=DoesNotExist)")
+			resp, err := ctx.GET("/Products?$expand=" + expand)
+			if err != nil {
+				return err
+			}
+			return ctx.AssertStatusCode(resp, 400)
+		},
+	)
+
 	return suite
 }

--- a/odata.go
+++ b/odata.go
@@ -870,8 +870,13 @@ func (s *Service) RegisterEntity(entity interface{}) error {
 
 	// Store the metadata
 	s.entities[entityMetadata.EntitySetName] = entityMetadata
+	// Set the entities registry for the newly registered entity metadata
+	entityMetadata.SetEntitiesRegistry(s.entities)
+	// Add the new entity to the navigation target index of all existing entities
 	for _, meta := range s.entities {
-		meta.SetEntitiesRegistry(s.entities)
+		if meta != entityMetadata {
+			meta.AddEntityToRegistry(entityMetadata)
+		}
 	}
 
 	// Create and store the handler
@@ -944,8 +949,13 @@ func (s *Service) RegisterSingleton(entity interface{}, singletonName string) er
 
 	// Store the metadata using singleton name as key
 	s.entities[singletonName] = singletonMetadata
+	// Set the entities registry for the newly registered singleton
+	singletonMetadata.SetEntitiesRegistry(s.entities)
+	// Add the new singleton to the navigation target index of all existing entities
 	for _, meta := range s.entities {
-		meta.SetEntitiesRegistry(s.entities)
+		if meta != singletonMetadata {
+			meta.AddEntityToRegistry(singletonMetadata)
+		}
 	}
 
 	// Create and store the handler (same handler type works for both entities and singletons)
@@ -1023,8 +1033,13 @@ func (s *Service) RegisterVirtualEntity(entity interface{}) error {
 
 	// Store the metadata
 	s.entities[entityMetadata.EntitySetName] = entityMetadata
+	// Set the entities registry for the newly registered virtual entity
+	entityMetadata.SetEntitiesRegistry(s.entities)
+	// Add the new virtual entity to the navigation target index of all existing entities
 	for _, meta := range s.entities {
-		meta.SetEntitiesRegistry(s.entities)
+		if meta != entityMetadata {
+			meta.AddEntityToRegistry(entityMetadata)
+		}
 	}
 
 	// Create and store the handler (no database operations will be performed)


### PR DESCRIPTION
### Motivation
- Nested `$expand` options were being parsed and applied without verifying the target entity metadata, allowing invalid `$select`, `$filter`, `$orderby`, and `$compute` to slip through and produce SQL errors or incorrect queries. 
- `$orderby` and `$filter` generation for expanded entities used ad-hoc name conversion, which caused ambiguous or unquoted column references across SQL dialects. 
- Navigation target resolution was not available at parse/apply time, so nested expansions could not be validated or compiled in a metadata-aware way. 
- Compliance tests for invalid nested expand options were missing and needed to be added to enforce strict OData behavior.

### Description
- Added `EntityMetadata.SetEntitiesRegistry(...)` and `EntityMetadata.ResolveNavigationTarget(name string)` to resolve navigation targets using a registry of registered entity metadata. 
- Wired the registry propagation: `EntityHandler.SetEntitiesMetadata(...)` calls `SetEntitiesRegistry`, and the service updates the registry when entities/singletons/virtual entities are registered via `RegisterEntity`, `RegisterSingleton`, and `RegisterVirtualEntity`. 
- Updated `internal/query/expand_parser.go` so `parseSingleExpandCore` resolves the navigation `targetMetadata` and `parseNestedExpandOptionsCore` accepts that `targetMetadata` and validates nested `$select`, `$filter`, `$orderby`, and `$compute` against it (including computed alias support). 
- Updated `internal/query/apply_expand.go` so `applyExpand`/`applyExpandCallback` pass the correct `targetMetadata` during recursion, use `GetColumnName(...)` + dialect-aware quoting for `$orderby` (via `quoteColumnReference`/`quoteIdent`), and delegate nested `$filter` building to the standard metadata-aware `parseFilter`/`applyFilter` pipeline instead of ad-hoc `buildSimpleFilterCondition`. 
- Added a small helper `internal/query/simple_filter.go` containing the simple operator-to-SQL builder used by existing code paths, and added/updated unit and compliance tests to cover invalid nested expand cases and registry wiring. 

### Testing
- Ran `golangci-lint run ./...` and it completed with no issues. 
- Ran `go test ./...` and all packages completed successfully (unit tests and updated expand tests passed). 
- Ran `go build ./...` and the project builds successfully. 
- Added unit tests (`internal/query/expand_test.go`) and compliance checks (`compliance-suite/tests/v4_0/11.2.5.9_nested_expand_options.go`) to verify invalid nested `$expand` usages return errors and to prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966192d862c83288c9139c1eb6ba7b5)