### PR TITLE
Enforce policy query filters on $expand results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ rely on version numbers to reason about compatibility.
 - **Version headers now set automatically in router middleware**: The router now automatically sets the `OData-Version` response header based on client negotiation, eliminating the need for manual header management in most cases.
 - **Version parsing now returns explicit errors**: `parseVersion()` function signature changed from `(int, int)` to `(int, int, error)` for better error handling. Invalid version strings are now validated and rejected with HTTP 400, and versions < 4.0 return HTTP 406 (Not Acceptable).
 - **Compliance suite now enforces optional features**: Removed skip-based leniency in compliance tests so optional OData features (lambda operators, geospatial functions, stream properties, etc.) must be implemented to pass.
+- **Policy filters now apply to expanded navigation results**: Authorization policy query filters are merged into `$expand` filters to ensure expanded navigation properties are filtered the same way as direct navigation queries.
 
 ### Deprecated
 - `handlers.SetODataVersionHeader()` - Use `response.SetODataVersionHeaderFromRequest(w, r)` instead for context-aware version handling. The router middleware handles this automatically in most cases.

--- a/internal/handlers/collection_read.go
+++ b/internal/handlers/collection_read.go
@@ -97,6 +97,10 @@ func (h *EntityHandler) handleGetCollectionOverwrite(w http.ResponseWriter, r *h
 		WriteError(w, r, http.StatusForbidden, "Authorization failed", err.Error())
 		return
 	}
+	if err := applyPolicyFiltersToExpand(r, h.policy, h.metadata, queryOptions.Expand); err != nil {
+		WriteError(w, r, http.StatusForbidden, "Authorization failed", err.Error())
+		return
+	}
 
 	// Create overwrite context
 	ctx := &OverwriteContext{
@@ -164,6 +168,13 @@ func (h *EntityHandler) parseCollectionQueryOptions(w http.ResponseWriter, r *ht
 		queryOptions = h.applyDefaultMaxTop(queryOptions)
 
 		if err := applyPolicyFilter(r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), queryOptions); err != nil {
+			return nil, &collectionRequestError{
+				StatusCode: http.StatusForbidden,
+				ErrorCode:  "Authorization failed",
+				Message:    err.Error(),
+			}
+		}
+		if err := applyPolicyFiltersToExpand(r, h.policy, h.metadata, queryOptions.Expand); err != nil {
 			return nil, &collectionRequestError{
 				StatusCode: http.StatusForbidden,
 				ErrorCode:  "Authorization failed",

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -106,6 +106,14 @@ func (h *EntityHandler) parseSingleEntityQueryOptions(r *http.Request) (*query.Q
 		}
 	}
 
+	if err := applyPolicyFiltersToExpand(r, h.policy, h.metadata, queryOptions.Expand); err != nil {
+		return nil, &requestError{
+			StatusCode: http.StatusForbidden,
+			ErrorCode:  "Authorization failed",
+			Message:    err.Error(),
+		}
+	}
+
 	return queryOptions, nil
 }
 

--- a/internal/handlers/navigation_properties.go
+++ b/internal/handlers/navigation_properties.go
@@ -261,6 +261,13 @@ func (h *EntityHandler) createNavParseQueryOptions(r *http.Request, targetMetada
 				Message:    err.Error(),
 			}
 		}
+		if err := applyPolicyFiltersToExpand(r, h.policy, targetMetadata, queryOptions.Expand); err != nil {
+			return nil, &collectionRequestError{
+				StatusCode: http.StatusForbidden,
+				ErrorCode:  "Authorization failed",
+				Message:    err.Error(),
+			}
+		}
 		return queryOptions, nil
 	}
 }


### PR DESCRIPTION
### Motivation

- Ensure authorization policy query filters are applied to expanded navigation properties so `$expand` results are filtered the same way as direct navigation queries.

### Description

- Add a shared helper `applyPolicyFilterToExpression` and `applyPolicyFiltersToExpand` in `internal/handlers/auth.go` to compute and merge per-navigation policy filters into `query.ExpandOption.Filter` using `query.MergeFilterExpressions`.
- Invoke the new helper from collection, entity and navigation query parsing code by updating `internal/handlers/collection_read.go`, `internal/handlers/entity_helpers.go`, and `internal/handlers/navigation_properties.go` so expands are enriched with policy filters when query options are finalized.
- Centralize policy merge behavior so `HandleNavigationProperty*` and `$expand` share the same enforcement logic and nested expands are processed recursively.
- Add `internal/handlers/relations_test.go::TestExpandAppliesPolicyFilterLikeNavigation` to verify `$expand` results are filtered identically to direct navigation queries, and update `CHANGELOG.md` to document the behavior.

### Testing

- Ran `golangci-lint run ./...` and it completed with no issues.
- Ran `go test ./...` and the full test suite passed (all packages reported `ok`).
- Ran `go build ./...` and the project built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696788bec0848328a59994b15a1a51ff)