### PR TITLE
Use cached navigation metadata for lambda filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ rely on version numbers to reason about compatibility.
 - **Policy filters now apply to expanded navigation results**: Authorization policy query filters are merged into `$expand` filters to ensure expanded navigation properties are filtered the same way as direct navigation queries.
 - **Navigation $orderby now validates and joins single-entity paths**: `$orderby` expressions like `Nav/Field` now validate the target property and add the required JOINs with qualified column references for correct SQL generation.
 - **Navigation links included for selected navigation properties in minimal metadata**: `$select=NavProp` now emits `NavProp@odata.navigationLink` without requiring `$expand` when minimal metadata is requested.
+- Lambda filter navigation targets now resolve through the cached entity registry, reducing repeated metadata analysis during lambda predicate evaluation.
 
 ### Deprecated
 - `handlers.SetODataVersionHeader()` - Use `response.SetODataVersionHeaderFromRequest(w, r)` instead for context-aware version handling. The router middleware handles this automatically in most cases.


### PR DESCRIPTION
### Motivation
- Reduce repeated runtime metadata analysis when building SQL for lambda operators by using the entity registry cache for navigation target resolution.
- Ensure lambda predicate evaluation uses consistent, cached metadata and avoid reflect-based `AnalyzeEntity` calls per invocation.

### Description
- Replaced ad-hoc `metadata.AnalyzeEntity` usage in lambda handling with a cached lookup via `entityMetadata.ResolveNavigationTarget` and threaded `entityMetadata` into `getNavigationTargetMetadata` and `buildLambdaCondition` for consistent cache usage.
- Updated `getNavigationTargetMetadata` signature to accept the parent `entityMetadata` and return the resolved target metadata from the registry.
- Adjusted `internal/query/lambda_applier_test.go` to register test entities in an entities registry, added a `Locale` column and `odata:"key"` tags to the description fixture, and added `TestLambdaApplier_CustomColumnRegistryLookup` to guard registry-based lookups (validates custom column `locale_code`).
- Added a changelog entry noting the lambda registry lookup change and formatted affected files.

### Testing
- Ran `gofmt -w` on modified files and ensured formatting applied.
- Ran `golangci-lint run ./...` with zero lint issues reported (success).
- Ran `go test ./...` and the full test suite passed (internal query tests including new lambda tests succeeded).
- Ran `go build ./...` to verify the repository builds without errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696788d61c608328a228234b6976ad44)