### PR TITLE
Fix missing logger argument in lambda_applier_test.go

### DIFF
--- a/internal/query/lambda_applier_test.go
+++ b/internal/query/lambda_applier_test.go
@@ -520,7 +520,7 @@ func TestLambdaApplier_CompositeKeyColumnNamesInJoin(t *testing.T) {
 		}
 
 		query := db.Session(&gorm.Session{DryRun: true}).Model(&CompositeParent{})
-		query = ApplyFilterOnly(query, filterExpr, entityMetadata)
+		query = ApplyFilterOnly(query, filterExpr, entityMetadata, nil)
 		result := query.Find(&[]CompositeParent{})
 		if result.Error != nil {
 			t.Fatalf("Failed to build SQL: %v", result.Error)


### PR DESCRIPTION
Add missing nil logger argument to ApplyFilterOnly call in TestLambdaApplier_CompositeKeyColumnNamesInJoin test.