### PR TITLE
Validate $expand parentheses handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ rely on version numbers to reason about compatibility.
 ### Fixed
 - Nested `$expand` options now reject negative `$top` and `$skip` values using the same non-negative validation as top-level query options.
 - Collection `$expand` now applies `$top/$skip/$orderby` per parent instead of using global preload limits, ensuring consistent pagination semantics across supported dialects.
+- Unbalanced parentheses in `$expand` now return clear parsing errors instead of being silently accepted.
 - **Lambda any/all operators now support composite key relationships**: Fixed lambda operators (any/all) to properly join on all key properties when filtering by collection navigation properties. Previously, only the first key property was used in the join condition, which caused incorrect results for entities with composite keys. The fix handles comma-separated foreign keys in GORM tags and builds proper join predicates across all key columns.
 - **Lambda any/all joins honor key column mappings**: Fixed lambda join SQL to use the key property column names from metadata, ensuring composite keys with custom `gorm:"column:..."` mappings generate correct parent-side join predicates.
 - **`isof()` fallback behavior without discriminator**: Fixed spec deviation where `isof('EntityType')` returned `1 = 1` (matching all entities) when no type discriminator was configured. Now returns `1 = 0` (matching no entities) since correct type filtering cannot be performed without a discriminator. This prevents incorrect results in inheritance scenarios and ensures spec compliance.


### PR DESCRIPTION
### Motivation
- Ensure `$expand` parsing detects unbalanced parentheses and returns a clear OData parsing error instead of silently accepting invalid input.

### Description
- Change `splitExpandParts` to return `([]string, error)` and track parentheses depth, returning an error on an unexpected `)` or if depth != 0 at the end. 
- Propagate the error from `splitExpandParts` into `parseExpandWithConfig` so `$expand` parsing fails with a descriptive error. 
- Add unit tests: update `TestSplitExpandParts` to assert error cases and add `TestParseExpandUnbalancedParentheses` to validate parsing rejects extra or missing `)` in `$expand` queries. 
- Update `CHANGELOG.md` to note the parsing fix.

### Testing
- Ran `go test ./...` and all tests completed successfully. 
- Ran `go build ./...` and the project built successfully. 
- Attempted `golangci-lint run ./...` as required by project policy but the linter invocation did not complete in the environment during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f8ab41408328a7bf7ee971d612ec)