### PR TITLE
Handle quoted commas in $expand parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ rely on version numbers to reason about compatibility.
 - **Cache eviction prevents unbounded memory growth**: Metadata cache now limited to 10 entries with automatic eviction keeping 5 most common versions (4.0, 4.01 prioritized).
 
 ### Fixed
+- `$expand` parsing now ignores commas inside single-quoted string literals, preventing incorrect splitting of expand items when nested filters include commas.
 - Nested `$expand` options now reject negative `$top` and `$skip` values using the same non-negative validation as top-level query options.
 - Collection `$expand` now applies `$top/$skip/$orderby` per parent instead of using global preload limits, ensuring consistent pagination semantics across supported dialects.
 - Unbalanced parentheses in `$expand` now return clear parsing errors instead of being silently accepted.


### PR DESCRIPTION
### Motivation
- The `$expand` parser previously split on commas without regard for single-quoted string literals, causing nested options with comma-containing string literals (e.g., `contains(Field,'a,b')`) to be split incorrectly.
- This change aims to make `$expand` splitting compliant with OData string literal quoting rules by treating single-quoted literals as atomic, including support for doubled single-quote escaping.
- Tests were added to ensure parsing correctness for both top-level and nested `$expand` cases that include commas inside string literals.

### Description
- Updated `splitExpandParts` in `internal/query/expand_parser.go` to use a `strings.Builder` and track single-quoted string state, treating commas inside single-quoted literals as regular characters and supporting doubled single-quote escapes (`''`).
- Added a missing-quote error when a string literal is not closed, and preserved existing parentheses depth validation logic in `splitExpandParts`.
- Added tests in `internal/query/expand_test.go` (`TestParseExpandWithFilterContainingComma`, `TestParseNestedExpandWithFilterContainingComma`) and extended `TestSplitExpandParts` to cover `$expand=Books($filter=contains(Title,'a,b'))` and nested variants.
- Documented the fix in `CHANGELOG.md` under the "Fixed" section.

### Testing
- Ran formatting with `gofmt -w .` and static analysis with `golangci-lint run ./...`, both completed with no issues.
- Executed `go test ./...` and all tests, including the new expand tests, passed successfully.
- Verified `go build ./...` completed without build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a2bd0098832890938d1f2af0b350)