### PR TITLE
Support multi-hop navigation paths in filters and ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ rely on version numbers to reason about compatibility.
 - **Compliance suite now enforces optional features**: Removed skip-based leniency in compliance tests so optional OData features (lambda operators, geospatial functions, stream properties, etc.) must be implemented to pass.
 - **Policy filters now apply to expanded navigation results**: Authorization policy query filters are merged into `$expand` filters to ensure expanded navigation properties are filtered the same way as direct navigation queries.
 - **Navigation $orderby now validates and joins single-entity paths**: `$orderby` expressions like `Nav/Field` now validate the target property and add the required JOINs with qualified column references for correct SQL generation.
+- **Multi-segment navigation path validation and joins**: `$filter` and `$orderby` now validate multi-hop single-entity navigation paths and generate JOINs with stable aliases to avoid table name collisions when chaining navigation segments.
 - **Navigation links included for selected navigation properties in minimal metadata**: `$select=NavProp` now emits `NavProp@odata.navigationLink` without requiring `$expand` when minimal metadata is requested.
 - Lambda filter navigation targets now resolve through the cached entity registry, reducing repeated metadata analysis during lambda predicate evaluation.
 

--- a/internal/query/apply_transform.go
+++ b/internal/query/apply_transform.go
@@ -538,22 +538,7 @@ func addOrderByNavigationJoins(db *gorm.DB, orderBy []OrderByItem, entityMetadat
 
 	joinedNavProps := make(map[string]bool)
 	for _, item := range orderBy {
-		if !entityMetadata.IsSingleEntityNavigationPath(item.Property) {
-			continue
-		}
-
-		segments := strings.Split(item.Property, "/")
-		if len(segments) < 2 {
-			continue
-		}
-
-		navPropName := strings.TrimSpace(segments[0])
-		if navPropName == "" || joinedNavProps[navPropName] {
-			continue
-		}
-
-		joinedNavProps[navPropName] = true
-		db = addNavigationJoin(db, navPropName, entityMetadata)
+		db = addNavigationJoinsForProperty(db, item.Property, entityMetadata, joinedNavProps)
 	}
 
 	return db

--- a/internal/query/orderby_navigation_test.go
+++ b/internal/query/orderby_navigation_test.go
@@ -16,8 +16,15 @@ type testOrderNav struct {
 }
 
 type testCustomerNav struct {
+	ID       int           `json:"ID" odata:"key"`
+	Name     string        `json:"Name"`
+	RegionID int           `json:"RegionID"`
+	Region   testRegionNav `json:"Region" gorm:"foreignKey:RegionID"`
+}
+
+type testRegionNav struct {
 	ID   int    `json:"ID" odata:"key"`
-	Name string `json:"Name"`
+	Name string `json:"Name" gorm:"column:region_name"`
 }
 
 func (testOrderNav) TableName() string {
@@ -26,6 +33,10 @@ func (testOrderNav) TableName() string {
 
 func (testCustomerNav) TableName() string {
 	return "customers"
+}
+
+func (testRegionNav) TableName() string {
+	return "regions"
 }
 
 func TestApplyOrderByNavigationPropertySQL(t *testing.T) {
@@ -44,9 +55,15 @@ func TestApplyOrderByNavigationPropertySQL(t *testing.T) {
 		t.Fatalf("Failed to analyze customer entity: %v", err)
 	}
 
+	regionMeta, err := metadata.AnalyzeEntity(testRegionNav{})
+	if err != nil {
+		t.Fatalf("Failed to analyze region entity: %v", err)
+	}
+
 	orderMeta.SetEntitiesRegistry(map[string]*metadata.EntityMetadata{
 		orderMeta.EntityName:    orderMeta,
 		customerMeta.EntityName: customerMeta,
+		regionMeta.EntityName:   regionMeta,
 	})
 
 	orderBy := []OrderByItem{
@@ -58,12 +75,64 @@ func TestApplyOrderByNavigationPropertySQL(t *testing.T) {
 	stmt := query.Find(&orders).Statement
 	sql := stmt.SQL.String()
 
-	expectedJoin := `LEFT JOIN "customers" ON "orders"."customer_id" = "customers"."id"`
+	expectedJoin := `LEFT JOIN "customers" AS "nav_customer" ON "orders"."customer_id" = "nav_customer"."id"`
 	if !strings.Contains(sql, expectedJoin) {
 		t.Fatalf("expected join clause %q in SQL: %s", expectedJoin, sql)
 	}
 
-	expectedOrder := `ORDER BY "customers"."name" DESC`
+	expectedOrder := `ORDER BY "nav_customer"."name" DESC`
+	if !strings.Contains(sql, expectedOrder) {
+		t.Fatalf("expected order by clause %q in SQL: %s", expectedOrder, sql)
+	}
+}
+
+func TestApplyOrderByMultiHopNavigationPropertySQL(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{DryRun: true})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+
+	orderMeta, err := metadata.AnalyzeEntity(testOrderNav{})
+	if err != nil {
+		t.Fatalf("Failed to analyze order entity: %v", err)
+	}
+
+	customerMeta, err := metadata.AnalyzeEntity(testCustomerNav{})
+	if err != nil {
+		t.Fatalf("Failed to analyze customer entity: %v", err)
+	}
+
+	regionMeta, err := metadata.AnalyzeEntity(testRegionNav{})
+	if err != nil {
+		t.Fatalf("Failed to analyze region entity: %v", err)
+	}
+
+	orderMeta.SetEntitiesRegistry(map[string]*metadata.EntityMetadata{
+		orderMeta.EntityName:    orderMeta,
+		customerMeta.EntityName: customerMeta,
+		regionMeta.EntityName:   regionMeta,
+	})
+
+	orderBy := []OrderByItem{
+		{Property: "Customer/Region/Name", Descending: false},
+	}
+
+	query := applyOrderBy(db.Model(&testOrderNav{}), orderBy, orderMeta)
+	var orders []testOrderNav
+	stmt := query.Find(&orders).Statement
+	sql := stmt.SQL.String()
+
+	expectedCustomerJoin := `LEFT JOIN "customers" AS "nav_customer" ON "orders"."customer_id" = "nav_customer"."id"`
+	if !strings.Contains(sql, expectedCustomerJoin) {
+		t.Fatalf("expected join clause %q in SQL: %s", expectedCustomerJoin, sql)
+	}
+
+	expectedRegionJoin := `LEFT JOIN "regions" AS "nav_customer_region" ON "nav_customer"."region_id" = "nav_customer_region"."id"`
+	if !strings.Contains(sql, expectedRegionJoin) {
+		t.Fatalf("expected join clause %q in SQL: %s", expectedRegionJoin, sql)
+	}
+
+	expectedOrder := `ORDER BY "nav_customer_region"."region_name"`
 	if !strings.Contains(sql, expectedOrder) {
 		t.Fatalf("expected order by clause %q in SQL: %s", expectedOrder, sql)
 	}

--- a/internal/query/orderby_parser.go
+++ b/internal/query/orderby_parser.go
@@ -37,16 +37,8 @@ func parseOrderBy(orderByStr string, entityMetadata *metadata.EntityMetadata, co
 		// Validate property exists (either in entity metadata or as a computed alias)
 		if !computedAliases[item.Property] {
 			if entityMetadata != nil && entityMetadata.IsSingleEntityNavigationPath(item.Property) {
-				segments := strings.Split(item.Property, "/")
-				navPropName := strings.TrimSpace(segments[0])
-				targetProperty := strings.TrimSpace(segments[1])
-
-				targetMetadata, err := entityMetadata.ResolveNavigationTarget(navPropName)
+				_, _, _, _, err := resolveNavigationPropertyPath(item.Property, entityMetadata)
 				if err != nil {
-					return nil, fmt.Errorf("property '%s' does not exist", item.Property)
-				}
-
-				if !propertyExists(targetProperty, targetMetadata) {
 					return nil, fmt.Errorf("property '%s' does not exist", item.Property)
 				}
 			} else if !propertyExists(item.Property, entityMetadata) {

--- a/test/single_entity_navigation_filter_test.go
+++ b/test/single_entity_navigation_filter_test.go
@@ -260,16 +260,14 @@ func TestMultiLevelNavigationPathRejection(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	// This should return an error because multi-level paths are not supported
-	if w.Code != http.StatusBadRequest {
+	// Multi-level navigation paths are supported for single-valued navigation chains.
+	if w.Code != http.StatusOK {
 		t.Errorf("Expected status %d for multi-level navigation path, got %d. Body: %s",
-			http.StatusBadRequest, w.Code, w.Body.String())
+			http.StatusOK, w.Code, w.Body.String())
 	}
 
-	// The error message will say "property does not exist" which is acceptable
-	// since multi-level paths are validated by only accepting exactly 2 segments
 	bodyStr := w.Body.String()
-	if !strings.Contains(bodyStr, "does not exist") && !strings.Contains(bodyStr, "not supported") {
-		t.Errorf("Error message should indicate the path is invalid. Body: %s", bodyStr)
+	if !strings.Contains(bodyStr, "@odata.context") {
+		t.Errorf("Expected response to include context. Body: %s", bodyStr)
 	}
 }


### PR DESCRIPTION
### Motivation

- Single-valued navigation path handling only supported a single navigation segment which prevented validating and generating JOINs for multi-hop single-entity chains (e.g., `Team/Club/Name`).
- Queries referencing properties on chained navigation targets produced incorrect column resolution or required brittle fallbacks; stable aliasing is required to avoid table name collisions when chaining joins.

### Description

- Add `ResolveSingleEntityNavigationPath` to `internal/metadata` and extend `IsSingleEntityNavigationPath` to validate multi-segment single-valued navigation chains and reuse the entity registry when resolving targets.
- Add `resolveNavigationPropertyPath` and `navigationAliasForPath` helpers in `internal/query/helpers.go` and update `GetColumnName` to resolve a navigation chain and produce aliased column references.
- Update column resolution (`getQuotedColumnName`) and JOIN logic (`addNavigationJoins`, `addNavigationJoinsForProperty`, `addNavigationJoin`) in `internal/query/apply_filter.go` to walk navigation segments, add LEFT JOINs per segment with stable aliases, and preserve correct parent/child aliasing to avoid collisions.
- Update order-by handling to add multi-hop joins and validate multi-segment paths by walking the navigation chain (`internal/query/orderby_parser.go` and `internal/query/apply_transform.go`).
- Add and update tests to cover multi-hop behavior and aliasing: `internal/query/orderby_navigation_test.go`, `internal/query/apply_filter_test.go`, and `test/single_entity_navigation_filter_test.go` and document the change in `CHANGELOG.md`.

### Testing

- Ran the linter with `golangci-lint run ./...` and the run completed with no issues.
- Ran unit and integration tests with `go test ./...` and all packages (including updated navigation tests) passed.
- Verified the project builds with `go build ./...` with no build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a2a4ba9883288551efdb5fb9276f)