### PR TITLE
Add tests for policy handling and action binding

### DIFF
--- a/auth_adapter_test.go
+++ b/auth_adapter_test.go
@@ -1,0 +1,49 @@
+package odata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type denyAllPolicy struct {
+	reason string
+}
+
+func (p denyAllPolicy) Authorize(ctx AuthContext, resource ResourceDescriptor, operation Operation) Decision {
+	return Deny(p.reason)
+}
+
+func TestSetPolicyAppliesToHandlers(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(db)
+
+	if err := service.RegisterEntity(Product{}); err != nil {
+		t.Fatalf("RegisterEntity error: %v", err)
+	}
+
+	service.SetPolicy(denyAllPolicy{reason: "blocked"})
+
+	requests := []struct {
+		name string
+		path string
+	}{
+		{name: "service document", path: "/"},
+		{name: "metadata", path: "/$metadata"},
+		{name: "collection", path: "/Products"},
+	}
+
+	for _, reqCase := range requests {
+		t.Run(reqCase.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, reqCase.path, nil)
+			req.Header.Set("Authorization", "Bearer test")
+			w := httptest.NewRecorder()
+
+			service.ServeHTTP(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("expected status %d, got %d", http.StatusForbidden, w.Code)
+			}
+		})
+	}
+}

--- a/internal/actions/bind_test.go
+++ b/internal/actions/bind_test.go
@@ -1,0 +1,111 @@
+package actions
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	publicactions "github.com/nlstn/go-odata/actions"
+)
+
+type testParams struct {
+	Percentage float64 `mapstructure:"percentage"`
+	Note       *string `json:"note,omitempty"`
+	Ignored    string  `mapstructure:"-"`
+}
+
+func TestParameterDefinitionsFromStruct(t *testing.T) {
+	defs, err := ParameterDefinitionsFromStruct(reflect.TypeOf(testParams{}))
+	if err != nil {
+		t.Fatalf("ParameterDefinitionsFromStruct error: %v", err)
+	}
+
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 definitions, got %d", len(defs))
+	}
+
+	if defs[0].Name != "percentage" {
+		t.Fatalf("first definition name = %q, want percentage", defs[0].Name)
+	}
+	if defs[0].Type != reflect.TypeOf(float64(0)) {
+		t.Fatalf("first definition type = %v, want float64", defs[0].Type)
+	}
+	if !defs[0].Required {
+		t.Fatalf("first definition should be required")
+	}
+
+	if defs[1].Name != "note" {
+		t.Fatalf("second definition name = %q, want note", defs[1].Name)
+	}
+	if defs[1].Type != reflect.TypeOf((*string)(nil)) {
+		t.Fatalf("second definition type = %v, want *string", defs[1].Type)
+	}
+	if defs[1].Required {
+		t.Fatalf("second definition should be optional")
+	}
+}
+
+func TestParameterDefinitionsFromStructPointer(t *testing.T) {
+	defs, err := ParameterDefinitionsFromStruct(reflect.TypeOf(&testParams{}))
+	if err != nil {
+		t.Fatalf("ParameterDefinitionsFromStruct pointer error: %v", err)
+	}
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 definitions, got %d", len(defs))
+	}
+}
+
+func TestParameterDefinitionsFromStruct_InvalidType(t *testing.T) {
+	_, err := ParameterDefinitionsFromStruct(reflect.TypeOf(42))
+	if err == nil {
+		t.Fatal("expected error for non-struct type, got nil")
+	}
+	if !strings.Contains(err.Error(), "parameter binding target") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBindStructToParams(t *testing.T) {
+	t.Run("nil type", func(t *testing.T) {
+		params := map[string]interface{}{"percentage": 10.0}
+		if err := bindStructToParams(params, nil); err != nil {
+			t.Fatalf("bindStructToParams nil type error: %v", err)
+		}
+		if _, ok := params[publicactions.BoundStructKey]; ok {
+			t.Fatal("expected no bound struct for nil type")
+		}
+	})
+
+	t.Run("missing required", func(t *testing.T) {
+		params := map[string]interface{}{"note": "seasonal"}
+		err := bindStructToParams(params, reflect.TypeOf(testParams{}))
+		if err == nil {
+			t.Fatal("expected error for missing required parameter, got nil")
+		}
+		if !strings.Contains(err.Error(), "required parameter 'percentage' is missing") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("binds struct", func(t *testing.T) {
+		params := map[string]interface{}{"percentage": 12.5, "note": "seasonal"}
+		if err := bindStructToParams(params, reflect.TypeOf(testParams{})); err != nil {
+			t.Fatalf("bindStructToParams error: %v", err)
+		}
+
+		bound, ok := params[publicactions.BoundStructKey]
+		if !ok {
+			t.Fatal("expected bound struct in params")
+		}
+		boundParams, ok := bound.(*testParams)
+		if !ok {
+			t.Fatalf("expected bound type *testParams, got %T", bound)
+		}
+		if boundParams.Percentage != 12.5 {
+			t.Fatalf("bound percentage = %v, want 12.5", boundParams.Percentage)
+		}
+		if boundParams.Note == nil || *boundParams.Note != "seasonal" {
+			t.Fatalf("bound note = %#v, want seasonal", boundParams.Note)
+		}
+	})
+}


### PR DESCRIPTION
### Motivation
- Increase test coverage and validate that authorization policies are applied consistently across service entry points.
- Exercise internal action parameter binding logic to catch regressions in parameter extraction and struct binding.
- Provide targeted unit tests that are safe to run in CI and do not require external services.

### Description
- Add `auth_adapter_test.go` which registers a denying policy and asserts the service document, metadata, and collection endpoints return `HTTP 403` via `TestSetPolicyAppliesToHandlers`.
- Add `internal/actions/bind_test.go` which exercises `ParameterDefinitionsFromStruct` and `bindStructToParams` including pointer, `omitempty`, required-parameter validation, and `BoundStructKey` caching behavior.
- Tests are placed in appropriate packages: `odata` for service-level behavior and `internal/actions` for binding internals, and they rely only on the in-memory SQLite test DB helper (`setupTestDB`).

### Testing
- Formatted sources with `gofmt -w .` and ran the linter with `golangci-lint run ./...`, which reported `0 issues`.
- Ran the full test suite with `go test ./...`, and all packages completed successfully (`go test` returned OK for all packages).
- Verified `go build ./...` completes without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a89ffea48328b6b9597e04486715)