### PR TITLE
Add metadata key generator name tests

### DIFF
--- a/internal/metadata/key_generators_test.go
+++ b/internal/metadata/key_generators_test.go
@@ -1,0 +1,59 @@
+package metadata
+
+import "testing"
+
+func resetKeyGeneratorNames(t *testing.T) {
+	t.Helper()
+
+	keyGeneratorNamesMu.Lock()
+	original := make(map[string]struct{}, len(keyGeneratorNames))
+	for name := range keyGeneratorNames {
+		original[name] = struct{}{}
+	}
+	keyGeneratorNames = make(map[string]struct{})
+	keyGeneratorNamesMu.Unlock()
+
+	t.Cleanup(func() {
+		keyGeneratorNamesMu.Lock()
+		keyGeneratorNames = make(map[string]struct{}, len(original))
+		for name := range original {
+			keyGeneratorNames[name] = struct{}{}
+		}
+		keyGeneratorNamesMu.Unlock()
+	})
+}
+
+func TestRegisterKeyGeneratorNameNormalizesAndIgnoresEmpty(t *testing.T) {
+	resetKeyGeneratorNames(t)
+
+	RegisterKeyGeneratorName("  FoO  ")
+	RegisterKeyGeneratorName("")
+	RegisterKeyGeneratorName("   ")
+
+	if !KnownKeyGeneratorName("foo") {
+		t.Fatalf("expected normalized name to be registered")
+	}
+
+	keyGeneratorNamesMu.RLock()
+	defer keyGeneratorNamesMu.RUnlock()
+
+	if len(keyGeneratorNames) != 1 {
+		t.Fatalf("expected 1 registered name, got %d", len(keyGeneratorNames))
+	}
+	if _, ok := keyGeneratorNames["foo"]; !ok {
+		t.Fatalf("expected normalized name to be stored")
+	}
+}
+
+func TestKnownKeyGeneratorNameMatchesCaseInsensitive(t *testing.T) {
+	resetKeyGeneratorNames(t)
+
+	RegisterKeyGeneratorName("CuStOm")
+
+	if !KnownKeyGeneratorName(" custom ") {
+		t.Fatalf("expected case-insensitive name match")
+	}
+	if KnownKeyGeneratorName("unknown") {
+		t.Fatalf("expected unknown name to return false")
+	}
+}


### PR DESCRIPTION
### Motivation
- Ensure the key generator name registry behaves correctly (normalizes input, ignores empty strings) and that tests do not contaminate global registry state.

### Description
- Add `internal/metadata/key_generators_test.go` with tests that verify `RegisterKeyGeneratorName` lowercases/trims input and ignores empty strings and that `KnownKeyGeneratorName` matches case-insensitive names and rejects unknowns.
- Reset and restore the `keyGeneratorNames` map under `keyGeneratorNamesMu` in `resetKeyGeneratorNames` and use `t.Cleanup` to avoid cross-test contamination.

### Testing
- Ran `golangci-lint run ./...` with no issues; ran `go test ./...` which succeeded; and `go build ./...` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e8714de88328b2bf4e1ebc0295c4)