### PR TITLE
Add tests for base path context handling

### DIFF
--- a/internal/response/base_path_test.go
+++ b/internal/response/base_path_test.go
@@ -1,0 +1,29 @@
+package response
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetBasePath(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	t.Run("returns empty when missing", func(t *testing.T) {
+		if got := getBasePath(req); got != "" {
+			t.Fatalf("expected empty base path, got %q", got)
+		}
+	})
+
+	t.Run("returns value from context", func(t *testing.T) {
+		ctx := context.WithValue(req.Context(), BasePathContextKey, "/odata")
+		reqWithBasePath := req.WithContext(ctx)
+
+		if got := getBasePath(reqWithBasePath); got != "/odata" {
+			t.Fatalf("expected base path %q, got %q", "/odata", got)
+		}
+	})
+}


### PR DESCRIPTION
### Motivation
- Add unit tests to verify `getBasePath` returns an empty string when the `BasePathContextKey` is not present and returns the configured path when it is present to prevent regressions in response path prefixing.

### Description
- Add `internal/response/base_path_test.go` in package `response` with two tests: one asserting `getBasePath` returns `""` when no `BasePathContextKey` is set and one asserting it returns `"/odata"` when the request context contains `BasePathContextKey`.

### Testing
- Ran `gofmt -w .` (succeeded) and `go build ./...` (succeeded); `golangci-lint run ./...` and `go test ./...` were started in the environment but did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fa91db14832898fc6593b2277044)