### PR TITLE
Handle annotation qualifiers in registration

### DIFF
--- a/internal/metadata/annotations.go
+++ b/internal/metadata/annotations.go
@@ -322,7 +322,20 @@ func ParseAnnotationTag(tag string) (Annotation, error) {
 }
 
 // ParseAnnotationTerm parses an annotation term with optional qualifiers and expands aliases.
+// It returns an error if the term contains an embedded value (e.g., "Core.Description=SomeValue"),
+// since the value should be provided separately by the caller.
 func ParseAnnotationTerm(term string) (string, string, error) {
+	// Check if term contains an embedded value (term=value format)
+	// We need to distinguish between "term=value" and "term;qualifier=X"
+	// Split by semicolon first to separate term from qualifier segments
+	segments := strings.Split(term, ";")
+	termPart := strings.TrimSpace(segments[0])
+	
+	// Check if the main term part (before any semicolons) contains a value
+	if strings.Contains(termPart, "=") {
+		return "", "", fmt.Errorf("annotation term should not contain a value; got %q", term)
+	}
+	
 	annotation, err := ParseAnnotationTag(term)
 	if err != nil {
 		return "", "", err

--- a/internal/metadata/annotations_test.go
+++ b/internal/metadata/annotations_test.go
@@ -628,6 +628,11 @@ func TestParseAnnotationTerm(t *testing.T) {
 			term:        "#Qualifier",
 			expectError: true,
 		},
+		{
+			name:        "term with embedded value",
+			term:        "Core.Description=SomeValue",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/odata.go
+++ b/odata.go
@@ -1956,23 +1956,19 @@ func (s *Service) RegisterEntityAnnotation(entitySetName string, term string, va
 	if entityMeta.Annotations == nil {
 		entityMeta.Annotations = metadata.NewAnnotationCollection()
 	}
-	entityMeta.Annotations.Add(metadata.Annotation{
+	annotation := metadata.Annotation{
 		Term:      parsedTerm,
 		Qualifier: qualifier,
 		Value:     value,
-	})
+	}
+	entityMeta.Annotations.Add(annotation)
 
 	// Clear metadata cache since annotations changed
 	s.metadataHandler.ClearCache()
 
-	qualifiedTerm := parsedTerm
-	if qualifier != "" {
-		qualifiedTerm = parsedTerm + "#" + qualifier
-	}
-
 	s.logger.Debug("Registered entity annotation",
 		"entitySet", entitySetName,
-		"term", qualifiedTerm)
+		"term", annotation.QualifiedTerm())
 	return nil
 }
 
@@ -2023,25 +2019,21 @@ func (s *Service) RegisterPropertyAnnotation(entitySetName string, propertyName 
 	if prop.Annotations == nil {
 		prop.Annotations = metadata.NewAnnotationCollection()
 	}
-	prop.Annotations.Add(metadata.Annotation{
+	ann := metadata.Annotation{
 		Term:      parsedTerm,
 		Qualifier: qualifier,
 		Value:     value,
-	})
+	}
+	prop.Annotations.Add(ann)
 	entityMeta.Properties[propIndex] = prop
 
 	// Clear metadata cache since annotations changed
 	s.metadataHandler.ClearCache()
 
-	qualifiedTerm := parsedTerm
-	if qualifier != "" {
-		qualifiedTerm = parsedTerm + "#" + qualifier
-	}
-
 	s.logger.Debug("Registered property annotation",
 		"entitySet", entitySetName,
 		"property", propertyName,
-		"term", qualifiedTerm)
+		"term", ann.QualifiedTerm())
 	return nil
 }
 


### PR DESCRIPTION
### Motivation
- Registration functions should accept annotation terms that include qualifiers (e.g., `#Short` or `;qualifier=Short`) and store the qualifier separately instead of embedding it into the term.
- Metadata output (especially XML) must be able to emit `Term="..."` and `Qualifier="..."` for qualified annotations.

### Description
- Added `ParseAnnotationTerm` in `internal/metadata/annotations.go` which reuses `ParseAnnotationTag` to split term and qualifier and expand aliases.
- Updated `RegisterEntityAnnotation` and `RegisterPropertyAnnotation` in `odata.go` to call `ParseAnnotationTerm`, store `metadata.Annotation{Term:, Qualifier:, Value:}` and log the qualified term consistently.
- Added `TestParseAnnotationTerm` in `internal/metadata/annotations_test.go` to cover parsing of hash qualifiers and `;qualifier=` segments and error cases.
- Because qualifiers are now stored separately on `metadata.Annotation`, the existing XML builder emits `Term="..."` plus `Qualifier="..."` for qualified annotations.

### Testing
- Ran linter with `golangci-lint run ./...` which returned `0 issues`.
- Ran unit and package tests with `go test ./...` and all tests passed (`ok` across packages).
- Verified build with `go build ./...` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700018883c8328bf991ff15cb292f0)