### PR TITLE
Fix null property assertion in compliance test

### DIFF
--- a/compliance-suite/tests/v4_0/11.4.14_null_value_handling.go
+++ b/compliance-suite/tests/v4_0/11.4.14_null_value_handling.go
@@ -68,13 +68,17 @@ func NullValueHandling() *framework.TestSuite {
 				return err
 			}
 
-			// Description should be null or absent
-			body := string(resp.Body)
-			if framework.ContainsAny(body, `"Description":null`, `"Description"`) || !framework.ContainsAny(body, `"Description"`) {
-				return nil
+			var data map[string]interface{}
+			if err := ctx.GetJSON(resp, &data); err != nil {
+				return err
 			}
 
-			return framework.NewError("Expected null or absent Description property")
+			description, ok := data["Description"]
+			if ok && description != nil {
+				return framework.NewError("Expected Description to be null when present")
+			}
+
+			return nil
 		},
 	)
 


### PR DESCRIPTION
### Motivation
- The compliance test relied on string matching which could incorrectly pass when the `Description` field existed but was not `null`; the test should explicitly parse JSON and validate that `Description` is either absent or present with a `null` value to enforce correct null-handling behavior.

### Description
- Update `compliance-suite/tests/v4_0/11.4.14_null_value_handling.go` to decode the response into `map[string]interface{}` and assert that `Description` is either absent or `nil`, returning an error if the field is present with a non-null value.

### Testing
- Ran `gofmt -w .`, `golangci-lint run ./...`, `go test ./...`, and `go build ./...`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709d0e0ea88328be7658c55bd78e4d)