### PR TITLE
Tighten missing Content-Type compliance assertion

### DIFF
--- a/compliance-suite/tests/v4_0/11.4.15_data_validation.go
+++ b/compliance-suite/tests/v4_0/11.4.15_data_validation.go
@@ -1,6 +1,9 @@
 package v4_0
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/nlstn/go-odata/compliance-suite/framework"
 )
 
@@ -76,9 +79,27 @@ func DataValidation() *framework.TestSuite {
 				return err
 			}
 
-			// Should return 415 or 400
 			if err := ctx.AssertStatusCode(resp, 415); err != nil {
-				return ctx.AssertStatusCode(resp, 400)
+				return err
+			}
+
+			if err := ctx.AssertJSONField(resp, "error"); err != nil {
+				return err
+			}
+
+			var payload map[string]interface{}
+			if err := ctx.GetJSON(resp, &payload); err != nil {
+				return err
+			}
+
+			errorValue, ok := payload["error"].(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("error field is not an object")
+			}
+
+			message, ok := errorValue["message"].(string)
+			if !ok || strings.TrimSpace(message) == "" {
+				return fmt.Errorf("error.message is missing or empty")
 			}
 
 			return nil


### PR DESCRIPTION
### Motivation
- Ensure the compliance test for missing `Content-Type` enforces the OData requirement to return `415` rather than allowing a fallback to `400`.
- Validate that the error response follows the OData error payload shape and includes a non-empty `message` to improve spec compliance.

### Description
- Updated `compliance-suite/tests/v4_0/11.4.15_data_validation.go` to require `415` for `test_missing_content_type` and removed the fallback to `400`.
- Added JSON assertions using `AssertJSONField` and `GetJSON` to verify the response includes an `error` object and that `error.message` is present and non-empty.
- Imported `fmt` and `strings` to perform payload shape validation and whitespace checks.

### Testing
- Ran `gofmt -w` on the modified file to ensure formatting (no issues reported).
- Ran `golangci-lint run ./...` which returned `0 issues`.
- Ran `go test ./...` and `go build ./...`, and all tests and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709d1946fc83289c874e60979c3a8b)