### PR TITLE
Tighten action parameter error expectations

### DIFF
--- a/compliance-suite/tests/v4_0/11.4.13_action_function_parameters.go
+++ b/compliance-suite/tests/v4_0/11.4.13_action_function_parameters.go
@@ -108,12 +108,11 @@ func ActionFunctionParameters() *framework.TestSuite {
 				return err
 			}
 
-			// Should return 400 or 500
 			if err := ctx.AssertStatusCode(resp, 400); err != nil {
-				return ctx.AssertStatusCode(resp, 500)
+				return err
 			}
 
-			return nil
+			return ctx.AssertJSONField(resp, "error")
 		},
 	)
 
@@ -135,12 +134,11 @@ func ActionFunctionParameters() *framework.TestSuite {
 				return err
 			}
 
-			// Should return 400 or 500
 			if err := ctx.AssertStatusCode(resp, 400); err != nil {
-				return ctx.AssertStatusCode(resp, 500)
+				return err
 			}
 
-			return nil
+			return ctx.AssertJSONField(resp, "error")
 		},
 	)
 


### PR DESCRIPTION
### Motivation
- Enforce strict OData v4 behavior for action parameter validation by requiring a 400 response and ensuring error payloads follow the OData error structure.

### Description
- Update `test_action_missing_param` and `test_action_invalid_param_type` in `compliance-suite/tests/v4_0/11.4.13_action_function_parameters.go` to only accept `400` and assert the presence of the top-level `error` field via `AssertJSONField`, removing the previous fallback to `500`.

### Testing
- Ran formatting and checks with `gofmt -w .`, `golangci-lint run ./... --timeout=5m`, executed `go test ./...`, and built with `go build ./...`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709d121da8832891ff262ffdc20e0f)