### PR TITLE
Enforce ETag presence when concurrency metadata declared in conditional requests test

### DIFF
--- a/compliance-suite/tests/v4_0/11.5.1_conditional_requests.go
+++ b/compliance-suite/tests/v4_0/11.5.1_conditional_requests.go
@@ -3,7 +3,6 @@ package v4_0
 import (
 	"encoding/xml"
 	"fmt"
-	"strings"
 
 	"github.com/nlstn/go-odata/compliance-suite/framework"
 )
@@ -71,14 +70,22 @@ func entitySetConcurrencyDeclared(ctx *framework.TestContext, entitySet string) 
 	}
 
 	entityTypeName := ""
+	found := false
 	for _, schema := range doc.DataServices.Schemas {
 		for _, container := range schema.EntityContainers {
 			for _, set := range container.EntitySets {
 				if set.Name == entitySet {
 					entityTypeName = set.EntityType
+					found = true
 					break
 				}
 			}
+			if found {
+				break
+			}
+		}
+		if found {
+			break
 		}
 	}
 	if entityTypeName == "" {
@@ -90,12 +97,7 @@ func entitySetConcurrencyDeclared(ctx *framework.TestContext, entitySet string) 
 		return false, fmt.Errorf("entity type %q not found in metadata", entityTypeName)
 	}
 
-	fullName := entityType.Name
-	if strings.Contains(entityTypeName, ".") {
-		fullName = entityTypeName
-	} else if namespace != "" {
-		fullName = namespace + "." + entityType.Name
-	}
+	fullName := namespace + "." + entityType.Name
 
 	if entityTypeHasConcurrencyToken(entityType) {
 		return true, nil
@@ -215,7 +217,7 @@ func ConditionalRequests() *framework.TestSuite {
 				return nil
 			}
 
-			return framework.NewError("Entity type declares concurrency token; response must include ETag header or @odata.etag payload")
+			return framework.NewError("Products entity type declares concurrency token; response must include ETag header or @odata.etag payload")
 		},
 	)
 


### PR DESCRIPTION
### Motivation

- Ensure the conditional ETag compliance test is strict when the service metadata declares concurrency tokens and does not silently pass when concurrency is not declared.

### Description

- Added XML metadata parsing helpers and types to `compliance-suite/tests/v4_0/11.5.1_conditional_requests.go` to inspect entity sets, entity types, `ConcurrencyMode` attributes, and `Org.OData.Core.V1.OptimisticConcurrency` annotations.
- Implemented `entitySetConcurrencyDeclared`, `findEntityType`, `entityTypeHasConcurrencyToken`, and `metadataHasOptimisticConcurrency` to determine whether an entity set declares concurrency tokens.
- Updated the `test_etag_header` test to call `entitySetConcurrencyDeclared` for `Products`, `Skip` the test with a clear reason when no concurrency metadata is declared, and require either an `ETag` response header or `@odata.etag` in the payload when concurrency is declared.

### Testing

- Ran `go test ./...` and the test suite completed successfully (all package tests passed).
- Ran `go build ./...` and the project built successfully.
- Attempted `golangci-lint run ./... --timeout 5m`, which was started but did not complete in the session and was interrupted; linter status should be re-run in CI or locally before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709d258be883289107c3fac6885284)