### PR TITLE
Increase code coverage for handlers package

### DIFF
--- a/internal/handlers/entity_coverage_test.go
+++ b/internal/handlers/entity_coverage_test.go
@@ -80,9 +80,9 @@ func TestEntityMatchesType(t *testing.T) {
 			"name": "test",
 		}
 		result := handler.entityMatchesType(entity, "OtherType")
-		// Might still match by entity name
+		// The entity name is "Product", so "OtherType" should not match
 		if result {
-			t.Log("Entity matched by name fallback")
+			t.Error("Expected entity to not match OtherType")
 		}
 	})
 
@@ -604,13 +604,7 @@ func createTestHandler() *EntityHandler {
 		metadata: &metadata.EntityMetadata{
 			EntityName: "TestEntity",
 		},
-		logger: createNilLogger(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	return handler
-}
-
-// Helper function to create a nil logger
-func createNilLogger() *slog.Logger {
-	// Return a logger that discards output instead of nil
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }

--- a/internal/handlers/overwrite_coverage_test.go
+++ b/internal/handlers/overwrite_coverage_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -458,8 +460,10 @@ func TestGetNamespace(t *testing.T) {
 		adapter := newMetadataAdapter(handler.metadata, handler.namespace)
 		ns := adapter.GetNamespace()
 
-		// Should return empty string or default
-		t.Logf("Namespace: %s", ns)
+		// GetNamespace returns defaultNamespace when namespace is empty
+		if ns != "ODataService" {
+			t.Errorf("Expected default namespace 'ODataService', got %s", ns)
+		}
 	})
 }
 
@@ -483,7 +487,7 @@ func createTestHandlerWithMetadata() *EntityHandler {
 				},
 			},
 		},
-		logger:    createNilLogger(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 		namespace: "TestNamespace",
 	}
 }

--- a/internal/handlers/simple_coverage_test.go
+++ b/internal/handlers/simple_coverage_test.go
@@ -91,7 +91,7 @@ func TestHasEntityLevelDefaultMaxTop(t *testing.T) {
 	handler.metadata.DefaultMaxTop = &maxTop
 	has = handler.HasEntityLevelDefaultMaxTop()
 	if !has {
-		t.Error("Expected HasEntityLevelDefaultMaxTop to return true")
+		t.Error("Expected HasEntityLevelDefaultMaxTop to return true after setting DefaultMaxTop")
 	}
 }
 
@@ -101,13 +101,13 @@ func TestIsGeospatialEnabled(t *testing.T) {
 
 	enabled := handler.IsGeospatialEnabled()
 	if enabled {
-		t.Log("Geospatial is enabled")
+		t.Error("Expected geospatial to be disabled by default")
 	}
 
 	handler.SetGeospatialEnabled(true)
 	enabled = handler.IsGeospatialEnabled()
 	if !enabled {
-		t.Error("Expected geospatial to be enabled")
+		t.Error("Expected geospatial to be enabled after setting to true")
 	}
 }
 
@@ -121,13 +121,13 @@ func TestIsSingleton(t *testing.T) {
 
 	isSingleton := handler.IsSingleton()
 	if isSingleton {
-		t.Error("Expected IsSingleton to return false")
+		t.Error("Expected IsSingleton to return false by default")
 	}
 
 	handler.metadata.IsSingleton = true
 	isSingleton = handler.IsSingleton()
 	if !isSingleton {
-		t.Error("Expected IsSingleton to return true")
+		t.Error("Expected IsSingleton to return true after setting to true")
 	}
 }
 
@@ -170,30 +170,39 @@ func TestOverwriteHasChecks(t *testing.T) {
 func TestSetObservability(t *testing.T) {
 	handler := NewEntityHandler(nil, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
+	// Call SetObservability with nil to test it doesn't panic
 	handler.SetObservability(nil)
 
-	// Should not panic
-	t.Log("Observability set")
+	// Verify the call completed successfully (no panic)
+	if handler == nil {
+		t.Error("Handler should not be nil after SetObservability")
+	}
 }
 
 // TestSetMaxInClauseSize tests max IN clause size setting
 func TestSetMaxInClauseSize(t *testing.T) {
 	handler := NewEntityHandler(nil, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
+	// Call SetMaxInClauseSize to test it doesn't panic
 	handler.SetMaxInClauseSize(500)
 
-	// Should not panic
-	t.Log("Max IN clause size set")
+	// Verify the call completed successfully (no panic)
+	if handler == nil {
+		t.Error("Handler should not be nil after SetMaxInClauseSize")
+	}
 }
 
 // TestSetMaxExpandDepth tests max expand depth setting
 func TestSetMaxExpandDepth(t *testing.T) {
 	handler := NewEntityHandler(nil, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
+	// Call SetMaxExpandDepth to test it doesn't panic
 	handler.SetMaxExpandDepth(5)
 
-	// Should not panic
-	t.Log("Max expand depth set")
+	// Verify the call completed successfully (no panic)
+	if handler == nil {
+		t.Error("Handler should not be nil after SetMaxExpandDepth")
+	}
 }
 
 // TestGetParserConfig tests parser config retrieval


### PR DESCRIPTION
This commit adds extensive test coverage targeting previously uncovered areas of the internal/handlers package:

- entity_coverage_test.go: Tests for FetchEntity, entity type matching, discriminator handling, type name candidates, unique strings, and SetOverwrite functionality

- overwrite_coverage_test.go: Tests for overwrite handlers including GET/DELETE/UPDATE/POST operations, ETag property handling, error scenarios, and metadata adapter functions

- simple_coverage_test.go: Tests for namespace handling, qualified type names, OPTIONS handlers, method disabling, geospatial features, singleton checks, observability settings, and parser configuration

These tests target many functions with 0% or low coverage, including:
- Entity type matching and discriminator logic
- Overwrite handler execution paths
- Configuration and setting methods
- Error handling functions