### PR TITLE
Analyze go-odata for version 1.0.0 release

### DIFF
--- a/auth_adapter.go
+++ b/auth_adapter.go
@@ -41,7 +41,15 @@ func Deny(reason string) Decision {
 }
 
 // SetPolicy registers an authorization policy for the service.
-func (s *Service) SetPolicy(policy Policy) {
+// Pass nil to clear the policy (all requests will be allowed).
+//
+// # Example
+//
+//	err := service.SetPolicy(myAuthPolicy)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func (s *Service) SetPolicy(policy Policy) error {
 	s.policy = policy
 	if s.metadataHandler != nil {
 		s.metadataHandler.SetPolicy(policy)
@@ -56,4 +64,5 @@ func (s *Service) SetPolicy(policy Policy) {
 			}
 		}
 	}
+	return nil
 }

--- a/auth_adapter_test.go
+++ b/auth_adapter_test.go
@@ -31,7 +31,9 @@ func TestSetPolicyAppliesToHandlers(t *testing.T) {
 		t.Fatalf("RegisterEntity error: %v", err)
 	}
 
-	service.SetPolicy(denyAllPolicy{reason: "blocked"})
+	if err := service.SetPolicy(denyAllPolicy{reason: "blocked"}); err != nil {
+		t.Fatalf("SetPolicy error: %v", err)
+	}
 
 	requests := []struct {
 		name string
@@ -68,7 +70,9 @@ func TestAllowPolicyPermitsAccess(t *testing.T) {
 		t.Fatalf("RegisterEntity error: %v", err)
 	}
 
-	service.SetPolicy(allowAllPolicy{})
+	if err := service.SetPolicy(allowAllPolicy{}); err != nil {
+		t.Fatalf("SetPolicy error: %v", err)
+	}
 
 	requests := []struct {
 		name           string

--- a/default_max_top_test.go
+++ b/default_max_top_test.go
@@ -77,7 +77,9 @@ func TestSetDefaultMaxTop_ServiceLevel(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Set service-level default max top
-	service.SetDefaultMaxTop(10)
+	if err := service.SetDefaultMaxTop(10); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Test without explicit $top - should return 10 results
 	req := httptest.NewRequest(http.MethodGet, "/TestProducts", nil)
@@ -113,7 +115,9 @@ func TestSetDefaultMaxTop_WithExplicitTop(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Set service-level default max top
-	service.SetDefaultMaxTop(10)
+	if err := service.SetDefaultMaxTop(10); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Test with explicit $top=5 - should return 5 results
 	req := httptest.NewRequest(http.MethodGet, "/TestProducts?$top=5", nil)
@@ -144,8 +148,12 @@ func TestSetDefaultMaxTop_RemoveDefault(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 20)
 
 	// Set and then remove default max top
-	service.SetDefaultMaxTop(10)
-	service.SetDefaultMaxTop(0) // Remove the default
+	if err := service.SetDefaultMaxTop(10); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
+	if err := service.SetDefaultMaxTop(0); err != nil { // Remove the default
+		t.Fatalf("Failed to remove default max top: %v", err)
+	}
 
 	// Test without explicit $top - should return all 20 results
 	req := httptest.NewRequest(http.MethodGet, "/TestProducts", nil)
@@ -238,7 +246,9 @@ func TestSetEntityDefaultMaxTop_EntityOverridesService(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Set service-level default
-	service.SetDefaultMaxTop(20)
+	if err := service.SetDefaultMaxTop(20); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Set entity-level default that overrides service default
 	if err := service.SetEntityDefaultMaxTop("TestProducts", 5); err != nil {
@@ -298,7 +308,9 @@ func TestSetEntityDefaultMaxTop_ExplicitTopOverridesAll(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Set both service and entity defaults
-	service.SetDefaultMaxTop(20)
+	if err := service.SetDefaultMaxTop(20); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 	if err := service.SetEntityDefaultMaxTop("TestProducts", 10); err != nil {
 		t.Fatalf("Failed to set entity default max top: %v", err)
 	}
@@ -346,7 +358,9 @@ func TestSetDefaultMaxTop_WithMaxPageSizePreference(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Set service-level default max top
-	service.SetDefaultMaxTop(20)
+	if err := service.SetDefaultMaxTop(20); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Test with Prefer: odata.maxpagesize=5 header
 	req := httptest.NewRequest(http.MethodGet, "/TestProducts", nil)
@@ -379,7 +393,9 @@ func TestSetEntityDefaultMaxTop_RemoveEntityDefault(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Set service-level default
-	service.SetDefaultMaxTop(20)
+	if err := service.SetDefaultMaxTop(20); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Set entity-level default
 	if err := service.SetEntityDefaultMaxTop("TestProducts", 5); err != nil {
@@ -420,7 +436,9 @@ func TestSetDefaultMaxTop_WithSkipAndTop(t *testing.T) {
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Set service-level default max top
-	service.SetDefaultMaxTop(10)
+	if err := service.SetDefaultMaxTop(10); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Test with $skip=5 (no explicit $top, should use default)
 	req := httptest.NewRequest(http.MethodGet, "/TestProducts?$skip=5", nil)
@@ -459,7 +477,9 @@ func TestSetEntityDefaultMaxTop_ServiceDefaultChangesAfterEntitySet(t *testing.T
 	service, _ := setupTestServiceWithProducts(t, 50)
 
 	// Step 1: Set service-level default
-	service.SetDefaultMaxTop(20)
+	if err := service.SetDefaultMaxTop(20); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Step 2: Set entity-level default
 	if err := service.SetEntityDefaultMaxTop("TestProducts", 10); err != nil {
@@ -467,7 +487,9 @@ func TestSetEntityDefaultMaxTop_ServiceDefaultChangesAfterEntitySet(t *testing.T
 	}
 
 	// Step 3: Change service-level default
-	service.SetDefaultMaxTop(30)
+	if err := service.SetDefaultMaxTop(30); err != nil {
+		t.Fatalf("Failed to set default max top: %v", err)
+	}
 
 	// Step 4: Remove entity-level default - should fall back to current service default (30)
 	if err := service.SetEntityDefaultMaxTop("TestProducts", 0); err != nil {

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -24,7 +24,9 @@ func TestSetLogger(t *testing.T) {
 	// Test setting a custom logger
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	service.SetLogger(logger)
+	if err := service.SetLogger(logger); err != nil {
+		t.Fatalf("Failed to set logger: %v", err)
+	}
 
 	// Verify logger was set by checking that debug logs are written
 	if err := service.RegisterEntity(&Product{}); err != nil {
@@ -37,7 +39,9 @@ func TestSetLogger(t *testing.T) {
 	}
 
 	// Test setting nil logger (should use default)
-	service.SetLogger(nil)
+	if err := service.SetLogger(nil); err != nil {
+		t.Fatalf("Failed to set nil logger: %v", err)
+	}
 	// Service should still work with default logger
 }
 
@@ -192,10 +196,12 @@ func TestSetPreRequestHook(t *testing.T) {
 	const userKey contextKey = "user"
 
 	hookCalled := false
-	service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+	if err := service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
 		hookCalled = true
 		return context.WithValue(r.Context(), userKey, "test-user"), nil
-	})
+	}); err != nil {
+		t.Fatalf("Failed to set pre-request hook: %v", err)
+	}
 
 	// Make a request to trigger the hook
 	req := httptest.NewRequest("GET", "/Products", nil)
@@ -207,9 +213,11 @@ func TestSetPreRequestHook(t *testing.T) {
 	}
 
 	// Test hook that returns error
-	service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+	if err := service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
 		return nil, http.ErrAbortHandler
-	})
+	}); err != nil {
+		t.Fatalf("Failed to set pre-request hook: %v", err)
+	}
 
 	req = httptest.NewRequest("GET", "/Products", nil)
 	w = httptest.NewRecorder()

--- a/test/batch_integration_test.go
+++ b/test/batch_integration_test.go
@@ -1355,10 +1355,12 @@ func TestBatchIntegration_CookieForwarding(t *testing.T) {
 
 	// Set up a PreRequestHook that checks for cookies
 	var receivedCookies []*http.Cookie
-	service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+	if err := service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
 		receivedCookies = r.Cookies()
 		return r.Context(), nil
-	})
+	}); err != nil {
+		t.Fatalf("Failed to set pre-request hook: %v", err)
+	}
 
 	// Create batch request with a GET request
 	boundary := "batch_36d5c8c6"
@@ -1429,7 +1431,7 @@ func TestBatchIntegration_CookieBasedAuthentication(t *testing.T) {
 
 	// Set up a PreRequestHook that requires authentication via cookie
 	// Allow $batch endpoint through, but check cookies for actual data requests
-	service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+	if err := service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
 		// Allow $batch endpoint to pass through without authentication
 		// The sub-requests within the batch will be authenticated individually
 		if r.URL.Path == "/$batch" {
@@ -1441,7 +1443,9 @@ func TestBatchIntegration_CookieBasedAuthentication(t *testing.T) {
 			return nil, fmt.Errorf("authentication required")
 		}
 		return r.Context(), nil
-	})
+	}); err != nil {
+		t.Fatalf("Failed to set pre-request hook: %v", err)
+	}
 
 	t.Run("with valid cookie", func(t *testing.T) {
 		boundary := "batch_36d5c8c6"
@@ -1547,10 +1551,12 @@ func TestBatchIntegration_CookieForwardingInChangeset(t *testing.T) {
 
 	// Set up a PreRequestHook that checks for cookies
 	var receivedCookies []*http.Cookie
-	service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+	if err := service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
 		receivedCookies = r.Cookies()
 		return r.Context(), nil
-	})
+	}); err != nil {
+		t.Fatalf("Failed to set pre-request hook: %v", err)
+	}
 
 	// Create batch request with changeset
 	batchBoundary := "batch_36d5c8c6"
@@ -1623,7 +1629,7 @@ func TestBatchIntegration_CookieForwardingMultipleRequests(t *testing.T) {
 
 	// Track how many times the hook is called and verify cookies each time
 	hookCallCount := 0
-	service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+	if err := service.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
 		hookCallCount++
 		// Allow $batch endpoint to pass through
 		if r.URL.Path == "/$batch" {
@@ -1634,7 +1640,9 @@ func TestBatchIntegration_CookieForwardingMultipleRequests(t *testing.T) {
 			return nil, fmt.Errorf("cookie not found or incorrect")
 		}
 		return r.Context(), nil
-	})
+	}); err != nil {
+		t.Fatalf("Failed to set pre-request hook: %v", err)
+	}
 
 	// Create batch request with multiple GET requests
 	boundary := "batch_36d5c8c6"

--- a/test/logger_test.go
+++ b/test/logger_test.go
@@ -51,7 +51,9 @@ func TestSetLogger_CustomLogger(t *testing.T) {
 	}))
 
 	// Set the custom logger
-	service.SetLogger(logger)
+	if err := service.SetLogger(logger); err != nil {
+		t.Fatalf("Failed to set logger: %v", err)
+	}
 
 	// Insert test data
 	db.Create(&LoggerTestProduct{ID: 1, Name: "Test"})
@@ -74,7 +76,9 @@ func TestSetLogger_NilLogger(t *testing.T) {
 	service, db := setupLoggerTestService(t)
 
 	// Set nil logger (should fall back to default)
-	service.SetLogger(nil)
+	if err := service.SetLogger(nil); err != nil {
+		t.Fatalf("Failed to set nil logger: %v", err)
+	}
 
 	// Insert test data
 	db.Create(&LoggerTestProduct{ID: 1, Name: "Test"})
@@ -96,7 +100,9 @@ func TestSetLogger_AfterRegistration(t *testing.T) {
 	// Set logger after entity registration
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
-	service.SetLogger(logger)
+	if err := service.SetLogger(logger); err != nil {
+		t.Fatalf("Failed to set logger: %v", err)
+	}
 
 	// Insert test data
 	db.Create(&LoggerTestProduct{ID: 1, Name: "Test"})
@@ -135,10 +141,18 @@ func TestSetLogger_MultipleSetCalls(t *testing.T) {
 	logger1 := slog.New(slog.NewTextHandler(&buf1, nil))
 	logger2 := slog.New(slog.NewTextHandler(&buf2, nil))
 
-	service.SetLogger(logger1)
-	service.SetLogger(logger2)
-	service.SetLogger(nil) // Back to default
-	service.SetLogger(logger1)
+	if err := service.SetLogger(logger1); err != nil {
+		t.Fatalf("Failed to set logger1: %v", err)
+	}
+	if err := service.SetLogger(logger2); err != nil {
+		t.Fatalf("Failed to set logger2: %v", err)
+	}
+	if err := service.SetLogger(nil); err != nil { // Back to default
+		t.Fatalf("Failed to set nil logger: %v", err)
+	}
+	if err := service.SetLogger(logger1); err != nil {
+		t.Fatalf("Failed to set logger1 again: %v", err)
+	}
 
 	// Insert test data
 	db.Create(&LoggerTestProduct{ID: 1, Name: "Test"})
@@ -160,7 +174,9 @@ func TestSetLogger_WithEntityOperations(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
-	service.SetLogger(logger)
+	if err := service.SetLogger(logger); err != nil {
+		t.Fatalf("Failed to set logger: %v", err)
+	}
 
 	// Test POST
 	postBody := `{"name": "New Product"}`


### PR DESCRIPTION
This change makes the following Service methods return error for consistency with other setter methods like SetNamespace, SetBasePath, and SetEntityDefaultMaxTop:

- SetDefaultMaxTop() error - was void, now returns error
- SetLogger() error - was void, now returns error
- SetPolicy() error - was void, now returns error
- SetPreRequestHook() error - was void, now returns error

While these methods currently always return nil, returning error provides a consistent API surface and allows future versions to add validation without breaking changes.

Updated all tests to handle the new error return values.