### PR TITLE
Add RegisterEnumType edge-case tests and allow alias enum values

### DIFF
--- a/internal/metadata/enum_registry.go
+++ b/internal/metadata/enum_registry.go
@@ -40,7 +40,6 @@ func RegisterEnumMembers(enumType reflect.Type, members []EnumMember) error {
 
 	// Validate members: ensure unique names and deterministic ordering.
 	seenNames := make(map[string]struct{})
-	seenValues := make(map[int64]struct{})
 	normalized := make([]EnumMember, len(members))
 	for i, member := range members {
 		if member.Name == "" {
@@ -50,11 +49,6 @@ func RegisterEnumMembers(enumType reflect.Type, members []EnumMember) error {
 			return fmt.Errorf("enum type %s has duplicate member name %s", baseType.Name(), member.Name)
 		}
 		seenNames[member.Name] = struct{}{}
-
-		if _, exists := seenValues[member.Value]; exists {
-			return fmt.Errorf("enum type %s has duplicate member value %d", baseType.Name(), member.Value)
-		}
-		seenValues[member.Value] = struct{}{}
 
 		normalized[i] = member
 	}


### PR DESCRIPTION
### Motivation

- Improve coverage for `RegisterEnumType` by validating error cases and pointer inputs and ensure metadata generation for enums works end-to-end. 
- Support alias enum members (different names sharing the same numeric value) so metadata is deterministic and can represent common enum aliases.

### Description

- Add a table-driven root-level test `TestRegisterEnumType` in `odata_test.go` that covers `enumValue == nil`, empty `members`, pointer enum input, and duplicate numeric values ordering verification via `$metadata` generation. 
- Remove the duplicate-value rejection in `internal/metadata/enum_registry.go` so multiple member names may share the same numeric `Value` while still enforcing non-empty and unique member names, and keep deterministic sorting by `(Value, Name)`. 
- Add `TestRegisterEnumMembersAllowsDuplicateValuesAndSortsByValueThenName` in `internal/metadata/enum_registry_test.go` to assert duplicate numeric values are accepted and members are sorted by value then name.

### Testing

- Ran `golangci-lint run ./...` and the linter returned `0 issues`. 
- Ran `go test ./...` and all packages passed (including the new tests). 
- Ran `go build ./...` and the project built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1fb7877883288793936f15913a72)