### PR TITLE
Cache metadataAdapter to reduce per-request allocations

### DIFF
--- a/internal/handlers/collection_response.go
+++ b/internal/handlers/collection_response.go
@@ -56,7 +56,7 @@ func (h *EntityHandler) collectionResponseWriter(w http.ResponseWriter, r *http.
 
 		selectedNavProps := selectedNavigationProps(queryOptions.Select, h.metadata)
 
-		metadataProvider := newMetadataAdapter(h.metadata, h.namespace)
+		metadataProvider := h.getMetadataAdapter()
 		if err := response.WriteODataCollectionWithNavigationAndDelta(w, r, h.metadata.EntitySetName, results, totalCount, nextLink, deltaLink, metadataProvider, queryOptions.Expand, selectedNavProps, h.metadata); err != nil {
 			h.logger.Error("Error writing OData response", "error", err)
 		}

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/nlstn/go-odata/internal/auth"
@@ -31,6 +32,10 @@ type EntityHandler struct {
 	defaultMaxTop        *int
 	// propertyMap provides O(1) property lookup by field name instead of O(n) iteration
 	propertyMap map[string]*metadata.PropertyMetadata
+	// cachedAdapter is created once (after all setup calls) and reused on every request
+	// to avoid reallocating property slices and maps per response.
+	cachedAdapterOnce sync.Once
+	cachedAdapter     *metadataAdapter
 	// observability holds the OpenTelemetry configuration for tracing and metrics
 	observability *observability.Config
 	// geospatialEnabled indicates if geospatial features are enabled.
@@ -118,6 +123,16 @@ func (h *EntityHandler) SetNamespace(namespace string) {
 		trimmed = defaultNamespace
 	}
 	h.namespace = trimmed
+}
+
+// getMetadataAdapter returns a cached metadataAdapter for this handler.
+// The adapter is created once on first call (after all setup is complete) and
+// reused on every subsequent request, avoiding per-request property slice/map allocations.
+func (h *EntityHandler) getMetadataAdapter() *metadataAdapter {
+	h.cachedAdapterOnce.Do(func() {
+		h.cachedAdapter = newMetadataAdapter(h.metadata, h.namespace)
+	})
+	return h.cachedAdapter
 }
 
 func (h *EntityHandler) namespaceOrDefault() string {


### PR DESCRIPTION
## Summary
This change introduces caching of the `metadataAdapter` instance in the `EntityHandler` to avoid redundant allocations on every request. The adapter is now created once during the first request and reused for all subsequent requests.

## Key Changes
- Added `sync.Once` and `cachedAdapter` fields to `EntityHandler` to store the cached adapter instance
- Introduced `getMetadataAdapter()` method that lazily initializes the adapter on first call using `sync.Once`
- Updated `collectionResponseWriter` to use the cached adapter via `getMetadataAdapter()` instead of creating a new instance with `newMetadataAdapter()`

## Implementation Details
- The adapter is created after all setup calls are complete, ensuring the handler's metadata and namespace are fully initialized
- Using `sync.Once` ensures thread-safe lazy initialization without requiring explicit synchronization on every request
- This optimization eliminates per-request property slice and map allocations, improving performance for high-throughput scenarios

https://claude.ai/code/session_018S16EER1kzSwnWrcvGhXCh