### PR TITLE
Enhance caching documentation and add tests for key-based entity reads

### DIFF
--- a/documentation/caching.md
+++ b/documentation/caching.md
@@ -66,13 +66,13 @@ service.RegisterEntity(&Category{}, odata.EntityCacheConfig{
 
 The cache is invalidated automatically whenever a write operation succeeds:
 
-| HTTP method | Operation        | Cache invalidated? |
-|-------------|------------------|--------------------|
-| `POST`      | Create entity    | ✓                  |
-| `PATCH`     | Update entity    | ✓                  |
-| `PUT`       | Replace entity   | ✓                  |
-| `DELETE`    | Delete entity    | ✓                  |
-| `GET`       | Read collection  | ✗ (read-only)      |
+| HTTP method | Operation           | Cache invalidated? |
+|-------------|---------------------|--------------------|
+| `POST`      | Create entity       | ✓                  |
+| `PATCH`     | Update entity       | ✓                  |
+| `PUT`       | Replace entity      | ✓                  |
+| `DELETE`    | Delete entity       | ✓                  |
+| `GET`       | Read (collection/key) | ✗ (read-only)    |
 
 After invalidation the very next read re-fetches the full dataset from the primary database
 and repopulates the cache.
@@ -118,6 +118,7 @@ service.RegisterEntity(&Category{}, odata.EntityCacheConfig{
 http.ListenAndServe(":8080", service)
 ```
 
-All GET requests to `/Categories` (including `$filter`, `$orderby`, `$top`, `$skip`) will
-be served from memory. POST, PATCH, PUT, and DELETE requests still reach the primary
-database and automatically refresh the cache on success.
+All GET requests to `/Categories` and `/Categories(<key>)` (including collection query
+options like `$filter`, `$orderby`, `$top`, `$skip`) are served from the local cache when
+it is warm. POST, PATCH, PUT, and DELETE requests still reach the primary database and
+invalidate the cache on success.

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -121,12 +121,22 @@ func (h *EntityHandler) parseSingleEntityQueryOptions(r *http.Request) (*query.Q
 func (h *EntityHandler) fetchEntityByKey(ctx context.Context, entityKey string, queryOptions *query.QueryOptions, scopes []func(*gorm.DB) *gorm.DB) (interface{}, error) {
 	result := reflect.New(h.metadata.EntityType).Interface()
 
-	db := h.db.WithContext(ctx)
+	// Use the cache database when available, otherwise the primary database.
+	db, usingCache, release := h.readDB(ctx)
+	defer release()
 
 	if len(scopes) > 0 {
 		db = db.Scopes(scopes...)
 	}
 	baseDB := db
+	if usingCache {
+		// Expand queries may require related tables that are not present in the cache DB.
+		// Run per-parent expand lookups against the primary database.
+		baseDB = h.db.WithContext(ctx)
+		if len(scopes) > 0 {
+			baseDB = baseDB.Scopes(scopes...)
+		}
+	}
 
 	db, err := h.buildKeyQuery(db, entityKey)
 	if err != nil {
@@ -134,7 +144,7 @@ func (h *EntityHandler) fetchEntityByKey(ctx context.Context, entityKey string, 
 	}
 
 	// Apply expand (preload navigation properties) if specified
-	if len(queryOptions.Expand) > 0 {
+	if len(queryOptions.Expand) > 0 && !usingCache {
 		db = query.ApplyExpandOnly(db, queryOptions.Expand, h.metadata, h.logger)
 	}
 

--- a/test/caching_test.go
+++ b/test/caching_test.go
@@ -461,3 +461,130 @@ func TestEntityCaching_DefaultTTLUsedWhenZero(t *testing.T) {
 		t.Fatalf("GET failed after zero TTL setup: %d %s", w.Code, w.Body.String())
 	}
 }
+
+// TestEntityCaching_KeyReadUsesCache verifies that key-based entity reads are served
+// from the cache once it is warm.
+func TestEntityCaching_KeyReadUsesCache(t *testing.T) {
+	db, service := setupCacheTestService(t, odata.EntityCacheConfig{
+		Level: odata.CacheLevelFull,
+		TTL:   time.Hour,
+	})
+
+	// Warm the cache through a key read.
+	keyReq := httptest.NewRequest(http.MethodGet, "/CachedCategories(1)", nil)
+	keyW := httptest.NewRecorder()
+	service.ServeHTTP(keyW, keyReq)
+	if keyW.Code != http.StatusOK {
+		t.Fatalf("initial key GET failed: %d %s", keyW.Code, keyW.Body.String())
+	}
+
+	// Mutate the primary DB directly so cache is not invalidated.
+	if err := db.Model(&CachedCategory{}).Where("id = ?", 1).Update("name", "Changed In DB").Error; err != nil {
+		t.Fatalf("direct DB update failed: %v", err)
+	}
+
+	// A second key read should still return cached data.
+	keyReq2 := httptest.NewRequest(http.MethodGet, "/CachedCategories(1)", nil)
+	keyW2 := httptest.NewRecorder()
+	service.ServeHTTP(keyW2, keyReq2)
+	if keyW2.Code != http.StatusOK {
+		t.Fatalf("second key GET failed: %d %s", keyW2.Code, keyW2.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(keyW2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse key response: %v", err)
+	}
+
+	if got, ok := resp["Name"].(string); !ok || got != "Electronics" {
+		t.Fatalf("expected cached Name='Electronics', got %v", resp["Name"])
+	}
+}
+
+// TestEntityCaching_KeyReadInvalidatedAfterPatch verifies that key-based reads
+// observe updates after write-triggered cache invalidation.
+func TestEntityCaching_KeyReadInvalidatedAfterPatch(t *testing.T) {
+	_, service := setupCacheTestService(t, odata.EntityCacheConfig{
+		Level: odata.CacheLevelFull,
+		TTL:   time.Hour,
+	})
+
+	// Warm cache through key read.
+	warmReq := httptest.NewRequest(http.MethodGet, "/CachedCategories(1)", nil)
+	warmW := httptest.NewRecorder()
+	service.ServeHTTP(warmW, warmReq)
+	if warmW.Code != http.StatusOK {
+		t.Fatalf("initial key GET failed: %d %s", warmW.Code, warmW.Body.String())
+	}
+
+	patchReq := httptest.NewRequest(http.MethodPatch, "/CachedCategories(1)", strings.NewReader(`{"Name":"Patched Name"}`))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchW := httptest.NewRecorder()
+	service.ServeHTTP(patchW, patchReq)
+	if patchW.Code != http.StatusNoContent && patchW.Code != http.StatusOK {
+		t.Fatalf("PATCH failed: %d %s", patchW.Code, patchW.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/CachedCategories(1)", nil)
+	getW := httptest.NewRecorder()
+	service.ServeHTTP(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GET after PATCH failed: %d %s", getW.Code, getW.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(getW.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse key response: %v", err)
+	}
+
+	if got, ok := resp["Name"].(string); !ok || got != "Patched Name" {
+		t.Fatalf("expected Name='Patched Name', got %v", resp["Name"])
+	}
+}
+
+// TestEntityCaching_KeyReadTTLExpiry verifies that key-based reads refresh from
+// primary DB when cache TTL expires.
+func TestEntityCaching_KeyReadTTLExpiry(t *testing.T) {
+	db, service := setupCacheTestService(t, odata.EntityCacheConfig{
+		Level: odata.CacheLevelFull,
+		TTL:   100 * time.Millisecond,
+	})
+
+	// Warm cache through key read.
+	warmReq := httptest.NewRequest(http.MethodGet, "/CachedCategories(1)", nil)
+	warmW := httptest.NewRecorder()
+	service.ServeHTTP(warmW, warmReq)
+	if warmW.Code != http.StatusOK {
+		t.Fatalf("initial key GET failed: %d %s", warmW.Code, warmW.Body.String())
+	}
+
+	// Mutate primary DB directly to avoid explicit cache invalidation.
+	if err := db.Model(&CachedCategory{}).Where("id = ?", 1).Update("name", "TTL Refreshed Name").Error; err != nil {
+		t.Fatalf("direct DB update failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for key read cache TTL refresh")
+		}
+
+		getReq := httptest.NewRequest(http.MethodGet, "/CachedCategories(1)", nil)
+		getW := httptest.NewRecorder()
+		service.ServeHTTP(getW, getReq)
+		if getW.Code != http.StatusOK {
+			t.Fatalf("key GET failed during TTL wait: %d %s", getW.Code, getW.Body.String())
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(getW.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to parse key response: %v", err)
+		}
+
+		if got, ok := resp["Name"].(string); ok && got == "TTL Refreshed Name" {
+			break
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Improve documentation regarding caching behavior and add tests to verify that key-based entity reads utilize the cache effectively. The changes ensure that reads from the cache occur when available and that updates to the primary database are reflected after cache invalidation.