### PR TITLE
Fix bound function URLs with colon in string keys

### DIFF
--- a/compliance-suite/tests/v4_0/11.1_resource_path.go
+++ b/compliance-suite/tests/v4_0/11.1_resource_path.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/nlstn/go-odata/compliance-suite/framework"
 )
@@ -398,6 +399,61 @@ func ResourcePath() *framework.TestSuite {
 			if resp.StatusCode != 404 && resp.StatusCode != 400 && resp.StatusCode != 301 {
 				return fmt.Errorf("empty path segments must return 404, 400, or 301 per OData spec (got %d)", resp.StatusCode)
 			}
+			return nil
+		},
+	)
+
+	// Test 15: Bound function URL with colon inside string key literal
+	suite.AddTest(
+		"test_bound_function_colon_in_string_key",
+		"Bound function path with colon inside quoted key is parsed as a valid OData resource path",
+		func(ctx *framework.TestContext) error {
+			productPath, err := firstEntityPath(ctx, "Products")
+			if err != nil {
+				return err
+			}
+
+			start := strings.Index(productPath, "(")
+			end := strings.LastIndex(productPath, ")")
+			if start == -1 || end == -1 || end <= start+1 {
+				return fmt.Errorf("unexpected product path format: %s", productPath)
+			}
+
+			baseID := productPath[start+1 : end]
+			keyWithColon := fmt.Sprintf("'%s_2026-03-20T19:30:00Z'", baseID)
+			operationPath := "/Products(" + keyWithColon + ")/GetRelatedProducts()"
+
+			resp, err := ctx.GET(operationPath)
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode == 400 {
+				return fmt.Errorf("valid URL shape must not be rejected as invalid URL (got 400)")
+			}
+
+			if resp.StatusCode != 404 && resp.StatusCode != 200 {
+				return fmt.Errorf("expected status 404 for non-existent key or 200 if entity exists, got %d", resp.StatusCode)
+			}
+
+			return nil
+		},
+	)
+
+	// Test 16: Malformed key literal must be rejected
+	suite.AddTest(
+		"test_malformed_key_literal_rejected",
+		"Malformed key literal with unclosed quote returns 400",
+		func(ctx *framework.TestContext) error {
+			resp, err := ctx.GET("/Products(ID='69980427-96ba-474b-b1dc-8c94acd900de_2026-03-20T19:30:00Z)/GetRelatedProducts()")
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode != 400 {
+				return fmt.Errorf("expected status 400 for malformed key literal, got %d", resp.StatusCode)
+			}
+
 			return nil
 		},
 	)

--- a/compliance-suite/tests/v4_0/11.2.10_addressing_operations.go
+++ b/compliance-suite/tests/v4_0/11.2.10_addressing_operations.go
@@ -2,6 +2,7 @@ package v4_0
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/nlstn/go-odata/compliance-suite/framework"
 )
@@ -78,6 +79,42 @@ func AddressingOperations() *framework.TestSuite {
 
 			if resp.StatusCode == 404 || resp.StatusCode == 501 {
 				return fmt.Errorf("operation not addressable (status %d). Missing actions/functions are a compliance failure", resp.StatusCode)
+			}
+
+			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		},
+	)
+
+	// Test 3b: Bound function with colon inside quoted string key literal
+	suite.AddTest(
+		"test_bound_function_colon_in_string_key",
+		"Bound function remains addressable when quoted key literal contains a colon",
+		func(ctx *framework.TestContext) error {
+			productPath, err := firstEntityPath(ctx, "Products")
+			if err != nil {
+				return err
+			}
+
+			start := strings.Index(productPath, "(")
+			end := strings.LastIndex(productPath, ")")
+			if start == -1 || end == -1 || end <= start+1 {
+				return fmt.Errorf("unexpected product path format: %s", productPath)
+			}
+
+			baseID := productPath[start+1 : end]
+			operationPath := fmt.Sprintf("/Products('%s_2026-03-20T19:30:00Z')/GetRelatedProducts()", baseID)
+
+			resp, err := ctx.GET(operationPath)
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode == 400 {
+				return fmt.Errorf("valid bound function URL was rejected as invalid URL")
+			}
+
+			if resp.StatusCode == 200 || resp.StatusCode == 404 {
+				return nil
 			}
 
 			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/nlstn/go-odata/internal/version"
@@ -211,16 +210,11 @@ func ParseODataURLComponents(path string) (*ODataURLComponents, error) {
 		return nil, fmt.Errorf("invalid URL: empty path segments are not allowed per OData specification")
 	}
 
-	u, err := url.Parse(path)
-	if err != nil {
-		return nil, err
-	}
-
 	components := &ODataURLComponents{
 		EntityKeyMap: make(map[string]string),
 	}
 
-	pathParts := strings.Split(u.Path, "/")
+	pathParts := strings.Split(path, "/")
 
 	// Remove leading/trailing empty segments from leading/trailing slashes
 	// We already rejected consecutive slashes above, so any empty segments here

--- a/internal/response/url_parsing_test.go
+++ b/internal/response/url_parsing_test.go
@@ -422,3 +422,42 @@ func TestParseODataURLComponentsEmptyPathSegments(t *testing.T) {
 		})
 	}
 }
+
+func TestParseODataURLComponentsBoundFunctionWithColonInStringKey(t *testing.T) {
+	path := "Events('69980427-96ba-474b-b1dc-8c94acd900de_2026-03-20T19:30:00Z')/GetRSVPCounts()"
+
+	components, err := ParseODataURLComponents(path)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if components.EntitySet != "Events" {
+		t.Fatalf("Expected entity set Events, got %s", components.EntitySet)
+	}
+
+	if components.EntityKey != "69980427-96ba-474b-b1dc-8c94acd900de_2026-03-20T19:30:00Z" {
+		t.Fatalf("Expected parsed string key with colon preserved, got %s", components.EntityKey)
+	}
+
+	if components.NavigationProperty != "GetRSVPCounts()" {
+		t.Fatalf("Expected operation segment GetRSVPCounts(), got %s", components.NavigationProperty)
+	}
+}
+
+func TestParseODataURLComponentsMalformedCompositeKeyWithColonReturnsError(t *testing.T) {
+	path := "Events(ID='69980427-96ba-474b-b1dc-8c94acd900de_2026-03-20T19:30:00Z)/GetRSVPCounts()"
+
+	_, err := ParseODataURLComponents(path)
+	if err == nil {
+		t.Fatal("Expected error for malformed composite key with unclosed quote, got nil")
+	}
+}
+
+func TestParseODataURLComponentsColonInKeyStillRejectsEmptyPathSegments(t *testing.T) {
+	path := "Events('69980427-96ba-474b-b1dc-8c94acd900de_2026-03-20T19:30:00Z')//GetRSVPCounts()"
+
+	_, err := ParseODataURLComponents(path)
+	if err == nil {
+		t.Fatal("Expected error for URL with empty path segment, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- stop parsing OData resource paths with Go's generic URL parser
- preserve valid quoted string keys containing colons in bound function URLs
- add parser regression tests and negative tests for malformed keys and empty segments
- add compliance coverage for resource path and operation addressing sections

## Validation
- go test ./internal/response
- go test ./...
- cd compliance-suite && go test ./...
- cd compliance-suite && go run . -pattern "11.1_resource_path"
- cd compliance-suite && go run . -pattern "11.2.10_addressing_operations"

Closes #600