### PR TITLE
Add OData 4.01 compliance coverage and fix async AsyncResult behavior

### DIFF
--- a/compliance-suite/README.md
+++ b/compliance-suite/README.md
@@ -123,10 +123,13 @@ Individual Tests:
 
 Current v4.01 suites include:
 
+- 8.2.8.6 Preference omit-values
+- 8.3.1 Header AsyncResult
 - 11.2.5.8 Query Compute
 - 11.2.5.9 Nested Expand Options ($count and $levels)
 - 11.2.5.11 OrderBy Computed Properties
 - 11.2.5.13 Query Index
+- 11.2.12 Query Schemaversion
 - 12.2 Function and Action Overloading
 
 ## Vocabulary Test Suites

--- a/compliance-suite/main.go
+++ b/compliance-suite/main.go
@@ -714,6 +714,16 @@ func main() {
 			Suite:   v4_01.NestedExpandOptions,
 		})
 		testSuites = append(testSuites, TestSuiteInfo{
+			Name:    "8.2.8.6_preference_omit_values",
+			Version: "4.01",
+			Suite:   v4_01.PreferenceOmitValues,
+		})
+		testSuites = append(testSuites, TestSuiteInfo{
+			Name:    "8.3.1_header_async_result",
+			Version: "4.01",
+			Suite:   v4_01.HeaderAsyncResult,
+		})
+		testSuites = append(testSuites, TestSuiteInfo{
 			Name:    "11.2.5.1_filter_in_operator",
 			Version: "4.01",
 			Suite:   v4_01.InOperator,
@@ -732,6 +742,11 @@ func main() {
 			Name:    "11.2.5.13_query_index",
 			Version: "4.01",
 			Suite:   v4_01.QueryIndex,
+		})
+		testSuites = append(testSuites, TestSuiteInfo{
+			Name:    "11.2.12_query_schemaversion",
+			Version: "4.01",
+			Suite:   v4_01.QuerySchemaVersion,
 		})
 		testSuites = append(testSuites, TestSuiteInfo{
 			Name:    "11.2.17_case_insensitive_system_query_options",

--- a/compliance-suite/tests/v4_01/11.2.12_query_schemaversion.go
+++ b/compliance-suite/tests/v4_01/11.2.12_query_schemaversion.go
@@ -1,0 +1,122 @@
+package v4_01
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/nlstn/go-odata/compliance-suite/framework"
+)
+
+// QuerySchemaVersion creates the 11.2.12 $schemaversion query option test suite.
+func QuerySchemaVersion() *framework.TestSuite {
+	suite := framework.NewTestSuite(
+		"11.2.12 System Query Option $schemaversion",
+		"Validates OData 4.01 $schemaversion behavior when schema versioning is advertised.",
+		"https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionschemaversion",
+	)
+
+	var cachedVersion string
+
+	getSchemaVersion := func(ctx *framework.TestContext) (string, error) {
+		if cachedVersion != "" {
+			return cachedVersion, nil
+		}
+
+		resp, err := ctx.GET("/$metadata")
+		if err != nil {
+			return "", err
+		}
+		if err := ctx.AssertStatusCode(resp, 200); err != nil {
+			return "", err
+		}
+
+		metadata := string(resp.Body)
+		if !strings.Contains(metadata, "Core.SchemaVersion") {
+			return "", ctx.Skip("service metadata does not advertise Core.SchemaVersion; $schemaversion version-binding semantics are not applicable")
+		}
+
+		re := regexp.MustCompile(`Core\.SchemaVersion\"\s+String=\"([^\"]+)\"|Core\.SchemaVersion\"\s+AnnotationPath=\"([^\"]+)\"|Term=\"Core\.SchemaVersion\"\s+String=\"([^\"]+)\"`)
+		match := re.FindStringSubmatch(metadata)
+		if len(match) == 0 {
+			return "", ctx.Skip("Core.SchemaVersion is present but no concrete String value was found in metadata")
+		}
+
+		for i := 1; i < len(match); i++ {
+			if strings.TrimSpace(match[i]) != "" {
+				cachedVersion = strings.TrimSpace(match[i])
+				return cachedVersion, nil
+			}
+		}
+
+		return "", ctx.Skip("Core.SchemaVersion annotation value could not be extracted")
+	}
+
+	suite.AddTest(
+		"test_metadata_wildcard_schemaversion",
+		"$metadata accepts $schemaversion=*",
+		func(ctx *framework.TestContext) error {
+			_, err := getSchemaVersion(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := ctx.GET("/$metadata?$schemaversion=*")
+			if err != nil {
+				return err
+			}
+
+			if err := ctx.AssertStatusCode(resp, 200); err != nil {
+				return framework.NewError(fmt.Sprintf("$metadata?$schemaversion=* must succeed when schema versioning is advertised: %v", err))
+			}
+
+			return ctx.AssertBodyContains(resp, "Core.SchemaVersion")
+		},
+	)
+
+	suite.AddTest(
+		"test_data_request_with_current_schemaversion",
+		"Data request succeeds with advertised $schemaversion value",
+		func(ctx *framework.TestContext) error {
+			version, err := getSchemaVersion(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := ctx.GET(fmt.Sprintf("/Products?$schemaversion=%s&$top=1", version))
+			if err != nil {
+				return err
+			}
+
+			if err := ctx.AssertStatusCode(resp, 200); err != nil {
+				return framework.NewError(fmt.Sprintf("request with advertised $schemaversion should succeed: %v", err))
+			}
+
+			return nil
+		},
+	)
+
+	suite.AddTest(
+		"test_missing_schemaversion_returns_404",
+		"Unknown $schemaversion value returns 404 Not Found",
+		func(ctx *framework.TestContext) error {
+			_, err := getSchemaVersion(ctx)
+			if err != nil {
+				return err
+			}
+
+			resp, err := ctx.GET("/Products?$schemaversion=__nonexistent_schema_version__&$top=1")
+			if err != nil {
+				return err
+			}
+
+			if err := ctx.AssertStatusCode(resp, 404); err != nil {
+				return framework.NewError(fmt.Sprintf("unknown $schemaversion should return 404: %v", err))
+			}
+
+			return nil
+		},
+	)
+
+	return suite
+}

--- a/compliance-suite/tests/v4_01/8.2.8.6_preference_omit_values.go
+++ b/compliance-suite/tests/v4_01/8.2.8.6_preference_omit_values.go
@@ -1,0 +1,88 @@
+package v4_01
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nlstn/go-odata/compliance-suite/framework"
+)
+
+// PreferenceOmitValues creates the 8.2.8.6 omit-values preference test suite.
+func PreferenceOmitValues() *framework.TestSuite {
+	suite := framework.NewTestSuite(
+		"8.2.8.6 Preference omit-values",
+		"Validates OData 4.01 omit-values preference behavior and compatibility with the OData 4.0 prefixed form.",
+		"https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_Preferenceomitvalues",
+	)
+
+	suite.AddTest(
+		"test_omit_values_unprefixed_is_accepted",
+		"Prefer: omit-values=nulls is accepted on data requests",
+		func(ctx *framework.TestContext) error {
+			resp, err := ctx.GET("/Products?$top=3", framework.Header{Key: "Prefer", Value: "omit-values=nulls"})
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode < http.StatusOK || resp.StatusCode >= 300 {
+				return framework.NewError(fmt.Sprintf("expected 2xx for omit-values request, got %d", resp.StatusCode))
+			}
+
+			if err := ctx.AssertJSONField(resp, "value"); err != nil {
+				return framework.NewError(fmt.Sprintf("response must remain a valid collection payload: %v", err))
+			}
+
+			return nil
+		},
+	)
+
+	suite.AddTest(
+		"test_omit_values_prefixed_alias_is_accepted",
+		"Prefer: odata.omit-values=nulls is accepted for 4.0 compatibility",
+		func(ctx *framework.TestContext) error {
+			resp, err := ctx.GET("/Products?$top=3", framework.Header{Key: "Prefer", Value: "odata.omit-values=nulls"})
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode < http.StatusOK || resp.StatusCode >= 300 {
+				return framework.NewError(fmt.Sprintf("expected 2xx for odata.omit-values request, got %d", resp.StatusCode))
+			}
+
+			if err := ctx.AssertJSONField(resp, "value"); err != nil {
+				return framework.NewError(fmt.Sprintf("response must remain a valid collection payload: %v", err))
+			}
+
+			return nil
+		},
+	)
+
+	suite.AddTest(
+		"test_omit_values_preference_applied_is_consistent",
+		"If Preference-Applied is returned, it echoes the applied omit-values form",
+		func(ctx *framework.TestContext) error {
+			resp, err := ctx.GET("/Products?$top=3", framework.Header{Key: "Prefer", Value: "omit-values=defaults"})
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode < http.StatusOK || resp.StatusCode >= 300 {
+				return framework.NewError(fmt.Sprintf("expected 2xx for omit-values=defaults request, got %d", resp.StatusCode))
+			}
+
+			applied := resp.Headers.Get("Preference-Applied")
+			if applied == "" {
+				return nil
+			}
+
+			if !strings.Contains(applied, "omit-values=defaults") && !strings.Contains(applied, "odata.omit-values=defaults") {
+				return framework.NewError(fmt.Sprintf("unexpected Preference-Applied value for omit-values: %q", applied))
+			}
+
+			return nil
+		},
+	)
+
+	return suite
+}

--- a/compliance-suite/tests/v4_01/8.3.1_header_async_result.go
+++ b/compliance-suite/tests/v4_01/8.3.1_header_async_result.go
@@ -1,0 +1,104 @@
+package v4_01
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nlstn/go-odata/compliance-suite/framework"
+)
+
+// HeaderAsyncResult creates the 8.3.1 AsyncResult header test suite.
+func HeaderAsyncResult() *framework.TestSuite {
+	suite := framework.NewTestSuite(
+		"8.3.1 Header AsyncResult",
+		"Validates that OData 4.01 asynchronous final responses include the AsyncResult header.",
+		"https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_HeaderAsyncResult",
+	)
+
+	suite.AddTest(
+		"test_final_async_response_includes_async_result",
+		"If status monitor returns 200 for async completion, it includes AsyncResult",
+		func(ctx *framework.TestContext) error {
+			initialResp, err := ctx.GET(
+				"/Products?$top=1",
+				framework.Header{Key: "Prefer", Value: "respond-async"},
+				framework.Header{Key: "OData-MaxVersion", Value: "4.01"},
+				framework.Header{Key: "Accept", Value: "application/json"},
+			)
+			if err != nil {
+				return err
+			}
+
+			if initialResp.StatusCode == http.StatusOK {
+				return ctx.Skip("service chose synchronous processing for this request; AsyncResult requirement applies to asynchronous final responses")
+			}
+
+			if err := ctx.AssertStatusCode(initialResp, http.StatusAccepted); err != nil {
+				return framework.NewError(fmt.Sprintf("expected 202 for async processing or 200 for sync, got %d", initialResp.StatusCode))
+			}
+
+			location := initialResp.Headers.Get("Location")
+			if location == "" {
+				return framework.NewError("202 response missing Location header for status monitor resource")
+			}
+
+			statusPath := location
+			if strings.HasPrefix(statusPath, ctx.ServerURL()) {
+				statusPath = strings.TrimPrefix(statusPath, ctx.ServerURL())
+			}
+			if !strings.HasPrefix(statusPath, "/") {
+				statusPath = "/" + strings.TrimPrefix(statusPath, "/")
+			}
+
+			var finalResp *framework.HTTPResponse
+			for i := 0; i < 10; i++ {
+				finalResp, err = ctx.GET(
+					statusPath,
+					framework.Header{Key: "OData-MaxVersion", Value: "4.01"},
+					framework.Header{Key: "Accept", Value: "application/json"},
+				)
+				if err != nil {
+					return err
+				}
+
+				if finalResp.StatusCode != http.StatusAccepted {
+					break
+				}
+
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			if finalResp == nil {
+				return framework.NewError("failed to retrieve status monitor response")
+			}
+
+			if finalResp.StatusCode == http.StatusAccepted {
+				return ctx.Skip("status monitor remained in 202 Accepted state during polling window")
+			}
+
+			if finalResp.StatusCode != http.StatusOK {
+				return ctx.Skip(fmt.Sprintf("status monitor returned terminal status %d; AsyncResult assertion in this test applies when monitor response is 200", finalResp.StatusCode))
+			}
+
+			asyncResult := finalResp.Headers.Get("AsyncResult")
+			if asyncResult == "" {
+				return framework.NewError("final async status monitor response missing AsyncResult header")
+			}
+
+			statusCode, err := strconv.Atoi(asyncResult)
+			if err != nil {
+				return framework.NewError(fmt.Sprintf("AsyncResult header is not an integer status code: %q", asyncResult))
+			}
+			if statusCode < 100 || statusCode > 599 {
+				return framework.NewError(fmt.Sprintf("AsyncResult header out of HTTP status code range: %d", statusCode))
+			}
+
+			return nil
+		},
+	)
+
+	return suite
+}

--- a/internal/async/manager.go
+++ b/internal/async/manager.go
@@ -516,6 +516,7 @@ func (m *Manager) ServeMonitor(w http.ResponseWriter, r *http.Request) {
 
 func writeStoredResponse(w http.ResponseWriter, resp *StoredResponse, includeBody bool) {
 	if resp == nil {
+		w.Header().Set("AsyncResult", strconv.Itoa(http.StatusOK))
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -523,6 +524,9 @@ func writeStoredResponse(w http.ResponseWriter, resp *StoredResponse, includeBod
 	status := resp.StatusCode
 	if status == 0 {
 		status = http.StatusOK
+	}
+	if w.Header().Get("AsyncResult") == "" {
+		w.Header().Set("AsyncResult", strconv.Itoa(status))
 	}
 	w.WriteHeader(status)
 	if includeBody && len(resp.Body) > 0 {

--- a/internal/service/runtime/runtime.go
+++ b/internal/service/runtime/runtime.go
@@ -238,7 +238,7 @@ func (rt *Runtime) tryHandleAsync(w http.ResponseWriter, r *http.Request) bool {
 		jobOpts = append(jobOpts, async.WithRetryAfter(rt.defaultRetryInterval))
 	}
 
-	job, err := rt.asyncManager.StartJob(r.Context(), handler, jobOpts...)
+	job, err := rt.asyncManager.StartJob(context.WithoutCancel(r.Context()), handler, jobOpts...)
 	if err != nil {
 		restoreRequestBody(r, body)
 		queueToken.release()


### PR DESCRIPTION
## Summary
- add new OData 4.01 compliance suites for:
  - 8.2.8.6 preference omit-values
  - 8.3.1 AsyncResult header
  - 11.2.12 
- register new v4.01 suites in the compliance runner and README
- fix async runtime job context to avoid cancellation when request context ends
- ensure async monitor terminal responses include the AsyncResult header

## Validation
- go test ./...
- compliance-suite: go run . -version 4.01 -pattern 8.3.1_header_async_result