### PR TITLE
feat: support custom OData error.code across hooks and operations (fixes #611)

### DIFF
--- a/documentation/actions-and-functions.md
+++ b/documentation/actions-and-functions.md
@@ -557,16 +557,26 @@ Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params ma
 }
 ```
 
-**`*odata.HookError`** — lightweight typed error with status code and message:
+**`*odata.HookError`** — lightweight typed error with status code and optional OData payload fields (`Code`, `Target`, `Details`):
 
 ```go
 Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
     if rateLimitExceeded(r) {
-        return odata.NewHookError(http.StatusTooManyRequests, "Rate limit exceeded")
+        return &odata.HookError{
+            StatusCode: http.StatusTooManyRequests,
+            Code:       "RATE_LIMIT_EXCEEDED",
+            Message:    "Rate limit exceeded",
+            Target:     "requests",
+            Details: []odata.HookErrorDetail{
+                {Code: "Quota", Target: "requests", Message: "Too many requests for current plan"},
+            },
+        }
     }
     return nil
 }
 ```
+
+If `Code` is omitted, the response falls back to the HTTP status as a string (for example `"429"`).
 
 **Sentinel errors** — use `odata.MapErrorToHTTPStatus` to translate a sentinel error into the appropriate status code, or return one directly and let the framework fall back to HTTP 500 for unknown errors:
 

--- a/documentation/advanced-features.md
+++ b/documentation/advanced-features.md
@@ -711,6 +711,42 @@ Client receives:
 }
 ```
 
+For machine-readable client handling, hooks can return typed errors:
+
+- `odata.HookError` for lightweight control
+- `odata.ODataError` for full OData payload control
+
+`odata.HookError` supports:
+
+- `StatusCode` for HTTP status
+- `Code` for custom `error.code` (for example `INVITE_ALREADY_PENDING`)
+- `Message` for `error.message`
+- `Target` for `error.target`
+- `Details` for additional structured error details
+
+When `Code` is empty, the service uses a backward-compatible numeric fallback (`"400"`, `"403"`, and so on).
+
+```go
+func (p *Product) ODataBeforeCreate(_ context.Context, _ *http.Request) error {
+    if productAlreadyInvited(p) {
+        return &odata.HookError{
+            StatusCode: http.StatusConflict,
+            Code:       "INVITE_ALREADY_PENDING",
+            Message:    "invite already pending",
+            Target:     "invite",
+            Details: []odata.HookErrorDetail{
+                {
+                    Code:    "Membership",
+                    Target:  "invite",
+                    Message: "an invite already exists for this user",
+                },
+            },
+        }
+    }
+    return nil
+}
+```
+
 ### Read Hooks
 
 Read hooks let you shape read behavior without forking handlers:

--- a/documentation/virtual-entities.md
+++ b/documentation/virtual-entities.md
@@ -475,20 +475,27 @@ Create: func(ctx *odata.OverwriteContext, entity interface{}) (interface{}, erro
 
 ### Using HookError
 
-Similar to entity hooks, overwrite handlers can return `odata.HookError` for custom status codes:
+Similar to entity hooks, overwrite handlers can return `odata.HookError` for custom status codes and optional machine-readable OData fields (`Code`, `Target`, `Details`):
 
 ```go
 GetEntity: func(ctx *odata.OverwriteContext) (interface{}, error) {
     entity, err := externalAPI.GetEntity(ctx.EntityKey)
     if err != nil {
         if errors.Is(err, externalAPI.ErrNotFound) {
-            return nil, odata.NewHookError(http.StatusNotFound, "Entity not found")
+            return nil, &odata.HookError{
+                StatusCode: http.StatusNotFound,
+                Code:       "EXTERNAL_ENTITY_NOT_FOUND",
+                Message:    "Entity not found",
+                Target:     "entityKey",
+            }
         }
         return nil, odata.NewHookError(http.StatusBadGateway, "External service unavailable")
     }
     return entity, nil
 }
 ```
+
+If `Code` is empty, `error.code` defaults to the HTTP status as a string.
 
 ## Implementing Pagination for Virtual Entities
 

--- a/hook_error.go
+++ b/hook_error.go
@@ -3,7 +3,12 @@ package odata
 import "github.com/nlstn/go-odata/internal/hookerrors"
 
 // HookError is an error type that can be returned from lifecycle hooks
-// to specify a custom HTTP status code and error message.
+// to specify a custom HTTP status code and OData error payload values.
+//
+// Optional fields:
+//   - Code: custom machine-readable OData error code
+//   - Target: request segment/property associated with the error
+//   - Details: additional structured OData error details
 //
 // Example usage in a BeforeReadEntity hook:
 //
@@ -17,6 +22,9 @@ import "github.com/nlstn/go-odata/internal/hookerrors"
 //	    return nil, nil
 //	}
 type HookError = hookerrors.HookError
+
+// HookErrorDetail represents additional structured detail entries for HookError.
+type HookErrorDetail = hookerrors.ErrorDetail
 
 // NewHookError creates a new HookError with the specified status code and message.
 func NewHookError(statusCode int, message string) *HookError {

--- a/hook_error_test.go
+++ b/hook_error_test.go
@@ -29,11 +29,27 @@ func (EmployeeWithCustomHook) TableName() string {
 
 // ODataBeforeReadEntity returns a 401 Unauthorized status code
 func (e *EmployeeWithCustomHook) ODataBeforeReadEntity(ctx context.Context, r *http.Request, opts *odata.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error) {
+	if r.Header.Get("X-Use-ODataError") == "1" {
+		return nil, &odata.ODataError{
+			StatusCode: http.StatusConflict,
+			Code:       "INVITE_ALREADY_MEMBER",
+			Message:    "invite already exists",
+			Target:     "members",
+			Details: []odata.ErrorDetail{{
+				Code:    "Membership",
+				Target:  "members",
+				Message: "user is already a member",
+			}},
+		}
+	}
+
 	// Simulate checking if user is authenticated by checking a header
 	if r.Header.Get("Authorization") == "" {
 		return nil, &odata.HookError{
 			StatusCode: http.StatusUnauthorized,
+			Code:       "AUTH_REQUIRED",
 			Message:    "User is not authenticated",
+			Target:     "Authorization",
 		}
 	}
 	return nil, nil
@@ -93,6 +109,12 @@ func TestHookError_CustomStatusCodes(t *testing.T) {
 		}
 
 		errorObj := errorResp["error"].(map[string]interface{})
+		if errorObj["code"] != "AUTH_REQUIRED" {
+			t.Errorf("Expected code 'AUTH_REQUIRED', got %v", errorObj["code"])
+		}
+		if errorObj["target"] != "Authorization" {
+			t.Errorf("Expected target 'Authorization', got %v", errorObj["target"])
+		}
 		if errorObj["message"] != "User is not authenticated" {
 			t.Errorf("Expected message 'User is not authenticated', got %s", errorObj["message"])
 		}
@@ -107,6 +129,48 @@ func TestHookError_CustomStatusCodes(t *testing.T) {
 
 		if w.Code != http.StatusOK {
 			t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("BeforeReadEntity propagates ODataError code and details", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/EmployeeWithCustomHooks(1)", nil)
+		req.Header.Set("X-Use-ODataError", "1")
+		w := httptest.NewRecorder()
+
+		service.ServeHTTP(w, req)
+
+		if w.Code != http.StatusConflict {
+			t.Errorf("Expected status %d, got %d", http.StatusConflict, w.Code)
+		}
+
+		body, _ := io.ReadAll(w.Body)
+		var errorResp map[string]interface{}
+		if err := json.Unmarshal(body, &errorResp); err != nil {
+			t.Fatalf("Failed to parse error response: %v", err)
+		}
+
+		errorObj := errorResp["error"].(map[string]interface{})
+		if errorObj["code"] != "INVITE_ALREADY_MEMBER" {
+			t.Errorf("Expected code 'INVITE_ALREADY_MEMBER', got %v", errorObj["code"])
+		}
+		if errorObj["message"] != "invite already exists" {
+			t.Errorf("Expected message 'invite already exists', got %v", errorObj["message"])
+		}
+		if errorObj["target"] != "members" {
+			t.Errorf("Expected target 'members', got %v", errorObj["target"])
+		}
+
+		details, ok := errorObj["details"].([]interface{})
+		if !ok || len(details) != 1 {
+			t.Fatalf("Expected one detail entry, got %#v", errorObj["details"])
+		}
+
+		detail := details[0].(map[string]interface{})
+		if detail["code"] != "Membership" {
+			t.Errorf("Expected detail code 'Membership', got %v", detail["code"])
+		}
+		if detail["target"] != "members" {
+			t.Errorf("Expected detail target 'members', got %v", detail["target"])
 		}
 	})
 

--- a/internal/handlers/collection_executor.go
+++ b/internal/handlers/collection_executor.go
@@ -113,14 +113,6 @@ func (h *EntityHandler) handleCollectionError(w http.ResponseWriter, r *http.Req
 		return false
 	}
 
-	// Check for HookError first (public API error type)
-	if isHookErr, status, message, details := extractHookErrorDetails(err, defaultStatus, defaultCode); isHookErr {
-		if writeErr := response.WriteError(w, r, status, message, details); writeErr != nil {
-			h.logger.Error("Error writing error response", "error", writeErr)
-		}
-		return false
-	}
-
 	var reqErr *collectionRequestError
 	if errors.As(err, &reqErr) {
 		status := reqErr.StatusCode
@@ -139,7 +131,8 @@ func (h *EntityHandler) handleCollectionError(w http.ResponseWriter, r *http.Req
 		return false
 	}
 
-	if writeErr := response.WriteError(w, r, defaultStatus, defaultCode, err.Error()); writeErr != nil {
+	status, odataErr := response.BuildODataErrorResponse(err, defaultStatus, defaultCode)
+	if writeErr := response.WriteODataError(w, r, status, odataErr); writeErr != nil {
 		h.logger.Error("Error writing error response", "error", writeErr)
 	}
 	return false

--- a/internal/handlers/collection_executor_test.go
+++ b/internal/handlers/collection_executor_test.go
@@ -107,6 +107,7 @@ func TestExecuteCollectionQueryErrors(t *testing.T) {
 			ParseQueryOptions: func() (*query.QueryOptions, error) {
 				return nil, &hookerrors.HookError{
 					StatusCode: http.StatusConflict,
+					Code:       "COLLECTION_CONFLICT",
 					Message:    "Hook failed",
 					Err:        errors.New("hook detail"),
 				}
@@ -126,8 +127,8 @@ func TestExecuteCollectionQueryErrors(t *testing.T) {
 		}
 
 		resp := decodeODataError(t, recorder)
-		if resp.Error.Code != "409" {
-			t.Fatalf("expected code 409, got %q", resp.Error.Code)
+		if resp.Error.Code != "COLLECTION_CONFLICT" {
+			t.Fatalf("expected code COLLECTION_CONFLICT, got %q", resp.Error.Code)
 		}
 		if resp.Error.Message != "Hook failed" {
 			t.Fatalf("expected message %q, got %q", "Hook failed", resp.Error.Message)

--- a/internal/handlers/hook_error_helper.go
+++ b/internal/handlers/hook_error_helper.go
@@ -44,9 +44,9 @@ func (h *EntityHandler) writeHookError(w http.ResponseWriter, r *http.Request, e
 		return
 	}
 
-	_, status, message, details := extractHookErrorDetails(err, defaultStatus, defaultCode)
+	status, odataErr := response.BuildODataErrorResponse(err, defaultStatus, defaultCode)
 
-	if writeErr := response.WriteError(w, r, status, message, details); writeErr != nil {
+	if writeErr := response.WriteODataError(w, r, status, odataErr); writeErr != nil {
 		h.logger.Error("Error writing error response", "error", writeErr)
 	}
 }

--- a/internal/hookerrors/hook_error.go
+++ b/internal/hookerrors/hook_error.go
@@ -2,6 +2,18 @@ package hookerrors
 
 import "fmt"
 
+// ErrorDetail represents additional error information in a HookError.
+type ErrorDetail struct {
+	// Code is a service-defined error code for this detail.
+	Code string
+
+	// Target identifies the specific part of the request causing this error.
+	Target string
+
+	// Message is a human-readable description of this specific error.
+	Message string
+}
+
 // HookError is an error type that can be returned from lifecycle hooks
 // to specify a custom HTTP status code and error message.
 type HookError struct {
@@ -9,8 +21,18 @@ type HookError struct {
 	// If not specified, defaults to 403 Forbidden.
 	StatusCode int
 
+	// Code is an optional OData error code.
+	// When empty, handlers fall back to using the HTTP status code as a string.
+	Code string
+
 	// Message is the error message to return in the response.
 	Message string
+
+	// Target optionally identifies the request part causing this error.
+	Target string
+
+	// Details provides additional OData error detail entries.
+	Details []ErrorDetail
 
 	// Err is an optional wrapped error for additional context.
 	Err error

--- a/internal/response/error_mapper.go
+++ b/internal/response/error_mapper.go
@@ -1,0 +1,118 @@
+package response
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/nlstn/go-odata/internal/hookerrors"
+	"github.com/nlstn/go-odata/internal/odataerrors"
+)
+
+// BuildODataErrorResponse maps an error into an HTTP status and OData error payload.
+//
+// Precedence:
+//  1. *odataerrors.ODataError
+//  2. *hookerrors.HookError
+//  3. generic error fallback
+func BuildODataErrorResponse(err error, defaultStatus int, defaultMessage string) (int, *ODataError) {
+	status := defaultStatus
+	if status == 0 {
+		status = http.StatusInternalServerError
+	}
+
+	var odataErr *odataerrors.ODataError
+	if errors.As(err, &odataErr) {
+		if odataErr.StatusCode != 0 {
+			status = odataErr.StatusCode
+		}
+
+		code := string(odataErr.Code)
+		if code == "" {
+			code = fmt.Sprintf("%d", status)
+		}
+
+		message := odataErr.Message
+		if message == "" {
+			message = defaultMessage
+		}
+
+		respErr := &ODataError{
+			Code:    code,
+			Message: message,
+			Target:  odataErr.Target,
+		}
+
+		for _, d := range odataErr.Details {
+			respErr.Details = append(respErr.Details, ODataErrorDetail{
+				Code:    d.Code,
+				Target:  d.Target,
+				Message: d.Message,
+			})
+		}
+
+		return status, respErr
+	}
+
+	var hookErr *hookerrors.HookError
+	if errors.As(err, &hookErr) {
+		if hookErr.StatusCode != 0 {
+			status = hookErr.StatusCode
+		}
+
+		code := hookErr.Code
+		if code == "" {
+			code = fmt.Sprintf("%d", status)
+		}
+
+		message := hookErr.Message
+		if message == "" {
+			message = defaultMessage
+		}
+
+		respErr := &ODataError{
+			Code:    code,
+			Message: message,
+			Target:  hookErr.Target,
+		}
+
+		for _, d := range hookErr.Details {
+			respErr.Details = append(respErr.Details, ODataErrorDetail{
+				Code:    d.Code,
+				Target:  d.Target,
+				Message: d.Message,
+			})
+		}
+
+		if len(respErr.Details) == 0 && hookErr.Err != nil {
+			respErr.Details = []ODataErrorDetail{{
+				Code:    code,
+				Message: hookErr.Err.Error(),
+			}}
+		}
+
+		return status, respErr
+	}
+
+	code := fmt.Sprintf("%d", status)
+	message := defaultMessage
+	if message == "" {
+		message = http.StatusText(status)
+		if message == "" {
+			message = "Error"
+		}
+	}
+
+	respErr := &ODataError{
+		Code:    code,
+		Message: message,
+	}
+	if err != nil {
+		respErr.Details = []ODataErrorDetail{{
+			Code:    code,
+			Message: err.Error(),
+		}}
+	}
+
+	return status, respErr
+}

--- a/internal/response/error_mapper_test.go
+++ b/internal/response/error_mapper_test.go
@@ -1,0 +1,100 @@
+package response
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/hookerrors"
+	"github.com/nlstn/go-odata/internal/odataerrors"
+)
+
+func TestBuildODataErrorResponse_ODataError(t *testing.T) {
+	status, errPayload := BuildODataErrorResponse(&odataerrors.ODataError{
+		StatusCode: http.StatusBadRequest,
+		Code:       odataerrors.ErrorCodeBadRequest,
+		Message:    "validation failed",
+		Target:     "Products(1)/Name",
+		Details: []odataerrors.ErrorDetail{{
+			Code:    "Required",
+			Target:  "Name",
+			Message: "Name is required",
+		}},
+	}, http.StatusInternalServerError, "Internal error")
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+	if errPayload.Code != "BadRequest" {
+		t.Fatalf("code = %q, want %q", errPayload.Code, "BadRequest")
+	}
+	if errPayload.Target != "Products(1)/Name" {
+		t.Fatalf("target = %q, want %q", errPayload.Target, "Products(1)/Name")
+	}
+	if len(errPayload.Details) != 1 || errPayload.Details[0].Code != "Required" {
+		t.Fatalf("details = %#v, expected mapped detail", errPayload.Details)
+	}
+}
+
+func TestBuildODataErrorResponse_HookErrorCustomCode(t *testing.T) {
+	status, errPayload := BuildODataErrorResponse(&hookerrors.HookError{
+		StatusCode: http.StatusConflict,
+		Code:       "INVITE_ALREADY_MEMBER",
+		Message:    "already a member",
+		Target:     "members",
+		Details: []hookerrors.ErrorDetail{{
+			Code:    "MEMBERSHIP",
+			Target:  "members",
+			Message: "already present",
+		}},
+	}, http.StatusForbidden, "Authorization failed")
+
+	if status != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", status, http.StatusConflict)
+	}
+	if errPayload.Code != "INVITE_ALREADY_MEMBER" {
+		t.Fatalf("code = %q, want %q", errPayload.Code, "INVITE_ALREADY_MEMBER")
+	}
+	if errPayload.Target != "members" {
+		t.Fatalf("target = %q, want %q", errPayload.Target, "members")
+	}
+	if len(errPayload.Details) != 1 || errPayload.Details[0].Code != "MEMBERSHIP" {
+		t.Fatalf("details = %#v, expected hook details", errPayload.Details)
+	}
+}
+
+func TestBuildODataErrorResponse_HookErrorFallback(t *testing.T) {
+	status, errPayload := BuildODataErrorResponse(&hookerrors.HookError{
+		Err: errors.New("wrapped detail"),
+	}, http.StatusUnauthorized, "Unauthorized")
+
+	if status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", status, http.StatusUnauthorized)
+	}
+	if errPayload.Code != "401" {
+		t.Fatalf("code = %q, want %q", errPayload.Code, "401")
+	}
+	if errPayload.Message != "Unauthorized" {
+		t.Fatalf("message = %q, want %q", errPayload.Message, "Unauthorized")
+	}
+	if len(errPayload.Details) != 1 || errPayload.Details[0].Message != "wrapped detail" {
+		t.Fatalf("details = %#v, expected wrapped detail", errPayload.Details)
+	}
+}
+
+func TestBuildODataErrorResponse_GenericFallback(t *testing.T) {
+	status, errPayload := BuildODataErrorResponse(errors.New("boom"), http.StatusBadRequest, "Invalid query options")
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+	if errPayload.Code != "400" {
+		t.Fatalf("code = %q, want %q", errPayload.Code, "400")
+	}
+	if errPayload.Message != "Invalid query options" {
+		t.Fatalf("message = %q, want %q", errPayload.Message, "Invalid query options")
+	}
+	if len(errPayload.Details) != 1 || errPayload.Details[0].Message != "boom" {
+		t.Fatalf("details = %#v, expected boom detail", errPayload.Details)
+	}
+}

--- a/internal/service/operations/handler.go
+++ b/internal/service/operations/handler.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,9 +9,7 @@ import (
 	"github.com/nlstn/go-odata/internal/actions"
 	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/handlers"
-	"github.com/nlstn/go-odata/internal/hookerrors"
 	"github.com/nlstn/go-odata/internal/metadata"
-	"github.com/nlstn/go-odata/internal/odataerrors"
 	"github.com/nlstn/go-odata/internal/response"
 )
 
@@ -192,63 +189,10 @@ func (h *Handler) writeError(w http.ResponseWriter, r *http.Request, invErr *inv
 }
 
 // writeHandlerError writes an appropriate OData error response for errors returned
-// from action or function handlers. It respects typed errors:
-//   - *odataerrors.ODataError: uses the error's StatusCode, Code, Message (falling back to fallbackMessage if empty), Target, and Details
-//   - *hookerrors.HookError: uses the error's StatusCode and Message (falling back to fallbackMessage if empty)
-//   - all other errors: falls back to HTTP 500 with the provided fallbackMessage
+// from action or function handlers.
 func (h *Handler) writeHandlerError(w http.ResponseWriter, r *http.Request, err error, fallbackMessage string) {
-	var odataErr *odataerrors.ODataError
-	if errors.As(err, &odataErr) {
-		statusCode := odataErr.StatusCode
-		if statusCode == 0 {
-			statusCode = http.StatusInternalServerError
-		}
-		code := string(odataErr.Code)
-		if code == "" {
-			code = fmt.Sprintf("%d", statusCode)
-		}
-		respErr := &response.ODataError{
-			Code:    code,
-			Message: odataErr.Message,
-			Target:  odataErr.Target,
-		}
-		if respErr.Message == "" {
-			respErr.Message = fallbackMessage
-		}
-		for _, d := range odataErr.Details {
-			respErr.Details = append(respErr.Details, response.ODataErrorDetail{
-				Code:    d.Code,
-				Target:  d.Target,
-				Message: d.Message,
-			})
-		}
-		if writeErr := response.WriteODataError(w, r, statusCode, respErr); writeErr != nil {
-			h.logError("Error writing error response", writeErr)
-		}
-		return
-	}
-
-	var hookErr *hookerrors.HookError
-	if errors.As(err, &hookErr) {
-		statusCode := hookErr.StatusCode
-		if statusCode == 0 {
-			statusCode = http.StatusInternalServerError
-		}
-		message := hookErr.Message
-		if message == "" {
-			message = fallbackMessage
-		}
-		details := ""
-		if hookErr.Err != nil {
-			details = hookErr.Err.Error()
-		}
-		if writeErr := response.WriteError(w, r, statusCode, message, details); writeErr != nil {
-			h.logError("Error writing error response", writeErr)
-		}
-		return
-	}
-
-	if writeErr := response.WriteError(w, r, http.StatusInternalServerError, fallbackMessage, err.Error()); writeErr != nil {
+	statusCode, respErr := response.BuildODataErrorResponse(err, http.StatusInternalServerError, fallbackMessage)
+	if writeErr := response.WriteODataError(w, r, statusCode, respErr); writeErr != nil {
 		h.logError("Error writing error response", writeErr)
 	}
 }

--- a/internal/service/operations/handler_typed_error_test.go
+++ b/internal/service/operations/handler_typed_error_test.go
@@ -115,6 +115,7 @@ func TestHandleActionOrFunction_ActionHookError(t *testing.T) {
 		name           string
 		returnErr      error
 		expectedStatus int
+		expectedCode   string
 		expectedMsg    string
 	}{
 		{
@@ -124,6 +125,7 @@ func TestHandleActionOrFunction_ActionHookError(t *testing.T) {
 				Message:    "bad input from hook",
 			},
 			expectedStatus: http.StatusBadRequest,
+			expectedCode:   "400",
 			expectedMsg:    "bad input from hook",
 		},
 		{
@@ -133,7 +135,19 @@ func TestHandleActionOrFunction_ActionHookError(t *testing.T) {
 				Message:    "rate limit exceeded",
 			},
 			expectedStatus: http.StatusTooManyRequests,
+			expectedCode:   "429",
 			expectedMsg:    "rate limit exceeded",
+		},
+		{
+			name: "HookError with custom code",
+			returnErr: &hookerrors.HookError{
+				StatusCode: http.StatusConflict,
+				Code:       "INVITE_ALREADY_PENDING",
+				Message:    "invite already pending",
+			},
+			expectedStatus: http.StatusConflict,
+			expectedCode:   "INVITE_ALREADY_PENDING",
+			expectedMsg:    "invite already pending",
 		},
 		{
 			name: "HookError with zero StatusCode defaults to 500",
@@ -141,6 +155,7 @@ func TestHandleActionOrFunction_ActionHookError(t *testing.T) {
 				Message: "hook error no status",
 			},
 			expectedStatus: http.StatusInternalServerError,
+			expectedCode:   "500",
 			expectedMsg:    "hook error no status",
 		},
 	}
@@ -175,6 +190,9 @@ func TestHandleActionOrFunction_ActionHookError(t *testing.T) {
 			}
 
 			resp := decodeODataError(t, rec.Body.Bytes())
+			if resp.Error.Code != tt.expectedCode {
+				t.Errorf("code = %q, want %q", resp.Error.Code, tt.expectedCode)
+			}
 			if resp.Error.Message != tt.expectedMsg {
 				t.Errorf("message = %q, want %q", resp.Error.Message, tt.expectedMsg)
 			}
@@ -259,6 +277,7 @@ func TestHandleActionOrFunction_FunctionHookError(t *testing.T) {
 		name           string
 		returnErr      error
 		expectedStatus int
+		expectedCode   string
 		expectedMsg    string
 	}{
 		{
@@ -268,6 +287,7 @@ func TestHandleActionOrFunction_FunctionHookError(t *testing.T) {
 				Message:    "not allowed",
 			},
 			expectedStatus: http.StatusForbidden,
+			expectedCode:   "403",
 			expectedMsg:    "not allowed",
 		},
 		{
@@ -277,7 +297,19 @@ func TestHandleActionOrFunction_FunctionHookError(t *testing.T) {
 				Message:    "service unavailable",
 			},
 			expectedStatus: http.StatusServiceUnavailable,
+			expectedCode:   "503",
 			expectedMsg:    "service unavailable",
+		},
+		{
+			name: "HookError function custom code",
+			returnErr: &hookerrors.HookError{
+				StatusCode: http.StatusBadRequest,
+				Code:       "INVALID_FILTER_DOMAIN",
+				Message:    "invalid filter domain",
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedCode:   "INVALID_FILTER_DOMAIN",
+			expectedMsg:    "invalid filter domain",
 		},
 	}
 
@@ -311,6 +343,9 @@ func TestHandleActionOrFunction_FunctionHookError(t *testing.T) {
 			}
 
 			resp := decodeODataError(t, rec.Body.Bytes())
+			if resp.Error.Code != tt.expectedCode {
+				t.Errorf("code = %q, want %q", resp.Error.Code, tt.expectedCode)
+			}
 			if resp.Error.Message != tt.expectedMsg {
 				t.Errorf("message = %q, want %q", resp.Error.Message, tt.expectedMsg)
 			}


### PR DESCRIPTION
## Summary
- implement a shared error mapper for OData responses to unify behavior across entity hooks and actions/functions
- extend HookError with optional `Code`, `Target`, and `Details` fields for machine-readable payload control
- preserve backward-compatible fallback where `error.code` defaults to the HTTP status string when custom code is not provided
- wire entity hook and operations handler paths to the shared mapper
- add tests for HookError custom code propagation and ODataError propagation from hooks
- document the new behavior in advanced features, actions/functions, and virtual entities docs

## Validation
- `gofmt -w $(git ls-files '*.go')`
- `golangci-lint run ./...`
- `go test ./...`
- `go build ./...`
- `cd compliance-suite && go run . -version 4.0`

Fixes #611
