### PR TITLE
Align $apply set transformations with OData spec

### DIFF
--- a/compliance-suite/tests/v4_0/11.2.5.4.2_apply_transformation_catalog.go
+++ b/compliance-suite/tests/v4_0/11.2.5.4.2_apply_transformation_catalog.go
@@ -271,6 +271,34 @@ func ApplyTransformationCatalog() *framework.TestSuite {
 	)
 
 	suite.AddTest(
+		"test_apply_toppercent_measure_semantics",
+		"toppercent uses cumulative measure ratio, not row count percentage",
+		func(ctx *framework.TestContext) error {
+			applyExpr := url.QueryEscape("toppercent(50,Price)")
+			resp, err := ctx.GET("/Products?$apply=" + applyExpr)
+			if err != nil {
+				return err
+			}
+			if err := ctx.AssertStatusCode(resp, 200); err != nil {
+				return err
+			}
+
+			names, err := applyProductNames(resp.Body)
+			if err != nil {
+				return err
+			}
+			if len(names) != 2 {
+				return fmt.Errorf("expected 2 products for toppercent(50,Price), got %d", len(names))
+			}
+			if names[0] != "Premium Laptop Pro" || names[1] != "Laptop" {
+				return fmt.Errorf("expected [Premium Laptop Pro Laptop], got %v", names)
+			}
+
+			return nil
+		},
+	)
+
+	suite.AddTest(
 		"test_apply_bottompercent_100",
 		"bottompercent(100,...) returns the full set",
 		func(ctx *framework.TestContext) error {
@@ -301,6 +329,31 @@ func ApplyTransformationCatalog() *framework.TestSuite {
 			}
 			if count != baselineCount {
 				return fmt.Errorf("expected %d items, got %d", baselineCount, count)
+			}
+
+			return nil
+		},
+	)
+
+	suite.AddTest(
+		"test_apply_top_bottom_positive_parameter_validation",
+		"top/bottom count and percent reject non-positive first arguments",
+		func(ctx *framework.TestContext) error {
+			invalidExprs := []string{
+				"topcount(0,Price)",
+				"bottomcount(0,Price)",
+				"toppercent(0,Price)",
+				"bottompercent(0,Price)",
+			}
+
+			for _, expr := range invalidExprs {
+				resp, err := ctx.GET("/Products?$apply=" + url.QueryEscape(expr))
+				if err != nil {
+					return err
+				}
+				if err := ctx.AssertStatusCode(resp, http.StatusBadRequest); err != nil {
+					return fmt.Errorf("%s: %w", expr, err)
+				}
 			}
 
 			return nil

--- a/internal/query/apply_parser.go
+++ b/internal/query/apply_parser.go
@@ -586,7 +586,7 @@ func parseSetTransformation(transStr string, entityMetadata *metadata.EntityMeta
 
 	switch t {
 	case ApplyTypeTopCount, ApplyTypeBottomCount:
-		count, err := parseNonNegativeInt(valueStr, string(t))
+		count, err := parsePositiveInt(valueStr, string(t))
 		if err != nil {
 			return nil, err
 		}
@@ -597,8 +597,8 @@ func parseSetTransformation(transStr string, entityMetadata *metadata.EntityMeta
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s value: %s", t, valueStr)
 		}
-		if (t == ApplyTypeTopPercent || t == ApplyTypeBottomPercent) && (v < 0 || v > 100) {
-			return nil, fmt.Errorf("%s value must be between 0 and 100", t)
+		if (t == ApplyTypeTopPercent || t == ApplyTypeBottomPercent) && (v <= 0 || v > 100) {
+			return nil, fmt.Errorf("%s value must be greater than 0 and less than or equal to 100", t)
 		}
 		set.Parameter = v
 	default:

--- a/internal/query/apply_test.go
+++ b/internal/query/apply_test.go
@@ -684,6 +684,33 @@ func TestParseApply_NewSetTransformations(t *testing.T) {
 	}
 }
 
+func TestParseApply_SetTransformationsRejectNonPositiveFirstArgument(t *testing.T) {
+	meta := getApplyTestMetadata(t)
+
+	tests := []struct {
+		name  string
+		apply string
+	}{
+		{name: "topcount-zero", apply: "topcount(0,Price)"},
+		{name: "bottomcount-zero", apply: "bottomcount(0,Price)"},
+		{name: "topcount-negative", apply: "topcount(-1,Price)"},
+		{name: "bottomcount-negative", apply: "bottomcount(-1,Price)"},
+		{name: "toppercent-zero", apply: "toppercent(0,Price)"},
+		{name: "bottompercent-zero", apply: "bottompercent(0,Price)"},
+		{name: "toppercent-negative", apply: "toppercent(-0.1,Price)"},
+		{name: "bottompercent-negative", apply: "bottompercent(-0.1,Price)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseApply(tt.apply, meta, 0)
+			if err == nil {
+				t.Fatalf("expected parse error for %q", tt.apply)
+			}
+		})
+	}
+}
+
 func TestParseApply_GroupByNestedSequence(t *testing.T) {
 	meta := getApplyTestMetadata(t)
 

--- a/internal/query/apply_transform.go
+++ b/internal/query/apply_transform.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"strings"
 
@@ -163,47 +162,15 @@ func applySetTransformation(db *gorm.DB, transformation ApplyTransformation, ent
 		}
 		return db.Order(clause.OrderByColumn{Column: clause.Column{Raw: true, Name: qualifiedMeasure}, Desc: false}).Limit(*transformation.Set.Count)
 	case ApplyTypeTopPercent:
-		if transformation.Set.Parameter <= 0 {
-			return db.Limit(0)
-		}
 		if transformation.Set.Parameter >= 100 {
 			return db
 		}
-		// Approximate via row count percentage. Precision improvements can be layered
-		// with window functions in a follow-up without changing parser contracts.
-		var n int64
-		countDB := db.Session(&gorm.Session{NewDB: true})
-		if countDB.Statement != nil && countDB.Statement.Model == nil {
-			countDB = countDB.Model(reflect.New(entityMetadata.EntityType).Interface())
-		}
-		if countDB.Count(&n).Error != nil || n <= 0 {
-			return db.Limit(0)
-		}
-		k := int(math.Ceil((transformation.Set.Parameter / 100.0) * float64(n)))
-		if k < 0 {
-			k = 0
-		}
-		return db.Order(clause.OrderByColumn{Column: clause.Column{Raw: true, Name: qualifiedMeasure}, Desc: true}).Limit(k)
+		return applyPercentThresholdSetTransformation(db, qualifiedKey, qualifiedMeasure, transformation.Set.Parameter, true)
 	case ApplyTypeBottomPercent:
-		if transformation.Set.Parameter <= 0 {
-			return db.Limit(0)
-		}
 		if transformation.Set.Parameter >= 100 {
 			return db
 		}
-		var n int64
-		countDB := db.Session(&gorm.Session{NewDB: true})
-		if countDB.Statement != nil && countDB.Statement.Model == nil {
-			countDB = countDB.Model(reflect.New(entityMetadata.EntityType).Interface())
-		}
-		if countDB.Count(&n).Error != nil || n <= 0 {
-			return db.Limit(0)
-		}
-		k := int(math.Ceil((transformation.Set.Parameter / 100.0) * float64(n)))
-		if k < 0 {
-			k = 0
-		}
-		return db.Order(clause.OrderByColumn{Column: clause.Column{Raw: true, Name: qualifiedMeasure}, Desc: false}).Limit(k)
+		return applyPercentThresholdSetTransformation(db, qualifiedKey, qualifiedMeasure, transformation.Set.Parameter, false)
 	case ApplyTypeTopSum:
 		return applySumThresholdSetTransformation(db, qualifiedKey, qualifiedMeasure, transformation.Set.Parameter, true)
 	case ApplyTypeBottomSum:
@@ -211,6 +178,30 @@ func applySetTransformation(db *gorm.DB, transformation ApplyTransformation, ent
 	default:
 		return db
 	}
+}
+
+func applyPercentThresholdSetTransformation(db *gorm.DB, qualifiedKey string, qualifiedMeasure string, percent float64, desc bool) *gorm.DB {
+	if percent <= 0 {
+		return db.Limit(0)
+	}
+
+	var total struct {
+		Total float64
+	}
+	totalDB := db.Session(&gorm.Session{})
+	if err := totalDB.Select(fmt.Sprintf("COALESCE(SUM(%s), 0) as total", qualifiedMeasure)).Scan(&total).Error; err != nil {
+		return db.Limit(0)
+	}
+	if total.Total <= 0 {
+		return db.Limit(0)
+	}
+
+	threshold := (percent / 100.0) * total.Total
+	if threshold <= 0 {
+		return db.Limit(0)
+	}
+
+	return applySumThresholdSetTransformation(db, qualifiedKey, qualifiedMeasure, threshold, desc)
 }
 
 func qualifyMeasureForSetTransformation(dialect string, entityMetadata *metadata.EntityMetadata, measureCol string, measureName string) string {

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -886,6 +886,18 @@ func parseNonNegativeInt(str, paramName string) (int, error) {
 	return value, nil
 }
 
+// parsePositiveInt parses a string as a strictly positive integer.
+func parsePositiveInt(str, paramName string) (int, error) {
+	var value int
+	if _, err := fmt.Sscanf(str, "%d", &value); err != nil {
+		return 0, fmt.Errorf("invalid %s: must be a positive integer", paramName)
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("invalid %s: must be a positive integer", paramName)
+	}
+	return value, nil
+}
+
 // mergeNavigationSelects processes $select with navigation paths and merges them into expand options
 // For example: $select=Product/Name with $expand=Product should result in Product being expanded with $select=Name
 func mergeNavigationSelects(options *QueryOptions) {


### PR DESCRIPTION
Enhance the handling of top and bottom percent transformations to ensure they align with the OData specification by enforcing positive parameters and improving validation. Add tests to verify the correct behavior of these transformations.