### PR TITLE
Add action/function operation metadata to CSDL

### DIFF
--- a/cmd/complianceserver/actions_functions.go
+++ b/cmd/complianceserver/actions_functions.go
@@ -64,10 +64,9 @@ func registerFunctions(service *odata.Service, db *gorm.DB) {
 			category := params["category"].(string)
 
 			var products []entities.Product
-			if err := db.Model(&entities.Product{}).
-				Joins("Category").
-				Where("Category.Name = ?", category).
-				Order("Products.Price DESC").
+			if err := db.
+				Where("category_id IN (?)", db.Model(&entities.Category{}).Select("id").Where("name = ?", category)).
+				Order("price DESC").
 				Limit(int(count)).
 				Find(&products).Error; err != nil {
 				return nil, err

--- a/cmd/complianceserver/actions_functions.go
+++ b/cmd/complianceserver/actions_functions.go
@@ -64,9 +64,10 @@ func registerFunctions(service *odata.Service, db *gorm.DB) {
 			category := params["category"].(string)
 
 			var products []entities.Product
-			if err := db.Joins("JOIN categories ON categories.id = products.category_id").
-				Where("categories.name = ?", category).
-				Order("products.price DESC").
+			if err := db.Model(&entities.Product{}).
+				Joins("Category").
+				Where("Category.Name = ?", category).
+				Order("Products.Price DESC").
 				Limit(int(count)).
 				Find(&products).Error; err != nil {
 				return nil, err

--- a/internal/handlers/metadata_handler.go
+++ b/internal/handlers/metadata_handler.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/nlstn/go-odata/internal/actions"
 	"github.com/nlstn/go-odata/internal/auth"
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/response"
@@ -45,7 +46,9 @@ import (
 // - Namespace reads: Single RLock (fast path in namespaceOrDefault)
 // - Namespace writes: Single Lock + cache clear (rare operation)
 type MetadataHandler struct {
-	entities map[string]*metadata.EntityMetadata
+	entities  map[string]*metadata.EntityMetadata
+	actions   map[string][]*actions.ActionDefinition
+	functions map[string][]*actions.FunctionDefinition
 	// Lock-free cached metadata documents by version (key: version string)
 	cachedXML            sync.Map     // map[string]string
 	cachedJSON           sync.Map     // map[string][]byte
@@ -60,10 +63,19 @@ type MetadataHandler struct {
 
 const defaultNamespace = "ODataService"
 
-// NewMetadataHandler creates a new metadata handler
+// NewMetadataHandler creates a new metadata handler.
+//
+// It keeps backward compatibility for callers that don't need operation metadata.
 func NewMetadataHandler(entities map[string]*metadata.EntityMetadata) *MetadataHandler {
+	return NewMetadataHandlerWithOperations(entities, nil, nil)
+}
+
+// NewMetadataHandlerWithOperations creates a new metadata handler with action/function metadata support.
+func NewMetadataHandlerWithOperations(entities map[string]*metadata.EntityMetadata, actions map[string][]*actions.ActionDefinition, functions map[string][]*actions.FunctionDefinition) *MetadataHandler {
 	h := &MetadataHandler{
 		entities:  entities,
+		actions:   actions,
+		functions: functions,
 		namespace: defaultNamespace,
 		logger:    slog.Default(),
 	}
@@ -306,6 +318,8 @@ func (h *MetadataHandler) newMetadataModel() metadataModel {
 	model := metadataModel{
 		namespace:            h.namespaceOrDefault(),
 		entities:             h.entities,
+		actions:              h.actions,
+		functions:            h.functions,
 		containerAnnotations: h.containerAnnotations,
 	}
 	model.buildEntityTypeToSetNameMap()
@@ -315,6 +329,8 @@ func (h *MetadataHandler) newMetadataModel() metadataModel {
 type metadataModel struct {
 	namespace              string
 	entities               map[string]*metadata.EntityMetadata
+	actions                map[string][]*actions.ActionDefinition
+	functions              map[string][]*actions.FunctionDefinition
 	containerAnnotations   *metadata.AnnotationCollection
 	entityTypeToSetNameMap map[string]string // Cache for EntityName -> EntitySetName lookups
 }

--- a/internal/handlers/metadata_json.go
+++ b/internal/handlers/metadata_json.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/nlstn/go-odata/internal/actions"
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/version"
 )
@@ -109,6 +110,8 @@ func (h *MetadataHandler) buildMetadataJSON(model metadataModel, ver version.Ver
 	csdl[model.namespace] = odataService
 
 	h.addJSONEnumTypes(model, odataService)
+	h.addJSONFunctionTypes(model, odataService)
+	h.addJSONActionTypes(model, odataService)
 
 	for _, entityMeta := range model.entities {
 		entityType := h.buildJSONEntityType(model, entityMeta)
@@ -133,6 +136,114 @@ func (h *MetadataHandler) addJSONEnumTypes(model metadataModel, odataService map
 		enumType := h.buildJSONEnumType(definition.info)
 		odataService[definition.name] = enumType
 	}
+}
+
+func (h *MetadataHandler) addJSONFunctionTypes(model metadataModel, odataService map[string]interface{}) {
+	for funcName, funcDefs := range model.functions {
+		overloads := make([]map[string]interface{}, 0, len(funcDefs))
+		for _, funcDef := range funcDefs {
+			overloads = append(overloads, h.buildJSONFunctionType(model, funcDef))
+		}
+		if len(overloads) == 1 {
+			odataService[funcName] = overloads[0]
+		} else {
+			odataService[funcName] = overloads
+		}
+	}
+}
+
+func (h *MetadataHandler) addJSONActionTypes(model metadataModel, odataService map[string]interface{}) {
+	for actionName, actionDefs := range model.actions {
+		overloads := make([]map[string]interface{}, 0, len(actionDefs))
+		for _, actionDef := range actionDefs {
+			overloads = append(overloads, h.buildJSONActionType(model, actionDef))
+		}
+		if len(overloads) == 1 {
+			odataService[actionName] = overloads[0]
+		} else {
+			odataService[actionName] = overloads
+		}
+	}
+}
+
+func (h *MetadataHandler) buildJSONFunctionType(model metadataModel, funcDef *actions.FunctionDefinition) map[string]interface{} {
+	funcType := map[string]interface{}{
+		"$Kind":    "Function",
+		"$IsBound": funcDef.IsBound,
+	}
+
+	params := make([]map[string]interface{}, 0, len(funcDef.Parameters)+1)
+	if funcDef.IsBound {
+		params = append(params, map[string]interface{}{
+			"$Name":     "bindingParameter",
+			"$Type":     h.operationBindingType(model, funcDef.EntitySet),
+			"$Nullable": false,
+		})
+	}
+
+	if funcDef.ReturnType != nil {
+		returnType := h.getEdmTypeName(funcDef.ReturnType)
+		funcType["$ReturnType"] = map[string]interface{}{
+			"$Type": returnType,
+		}
+	}
+
+	if len(funcDef.Parameters) > 0 {
+		for _, param := range funcDef.Parameters {
+			paramType := h.getEdmTypeName(param.Type)
+			paramDef := map[string]interface{}{
+				"$Name":     param.Name,
+				"$Type":     paramType,
+				"$Nullable": !param.Required,
+			}
+			params = append(params, paramDef)
+		}
+	}
+	if len(params) > 0 {
+		funcType["$Parameter"] = params
+	}
+
+	return funcType
+}
+
+func (h *MetadataHandler) buildJSONActionType(model metadataModel, actionDef *actions.ActionDefinition) map[string]interface{} {
+	actionType := map[string]interface{}{
+		"$Kind":    "Action",
+		"$IsBound": actionDef.IsBound,
+	}
+
+	params := make([]map[string]interface{}, 0, len(actionDef.Parameters)+1)
+	if actionDef.IsBound {
+		params = append(params, map[string]interface{}{
+			"$Name":     "bindingParameter",
+			"$Type":     h.operationBindingType(model, actionDef.EntitySet),
+			"$Nullable": false,
+		})
+	}
+
+	if actionDef.ReturnType != nil {
+		returnType := h.getEdmTypeName(actionDef.ReturnType)
+		actionType["$ReturnType"] = map[string]interface{}{
+			"$Type": returnType,
+		}
+	}
+
+	if len(actionDef.Parameters) > 0 {
+		for _, param := range actionDef.Parameters {
+			paramType := h.getEdmTypeName(param.Type)
+			paramDef := map[string]interface{}{
+				"$Name":     param.Name,
+				"$Type":     paramType,
+				"$Nullable": !param.Required,
+			}
+			params = append(params, paramDef)
+		}
+	}
+	if len(params) > 0 {
+		actionType["$Parameter"] = params
+	}
+
+	return actionType
 }
 
 func (h *MetadataHandler) buildJSONEnumType(info *enumTypeInfo) map[string]interface{} {
@@ -352,6 +463,44 @@ func (h *MetadataHandler) buildJSONEntityContainer(model metadataModel) map[stri
 			}
 
 			container[entitySetName] = entitySet
+		}
+	}
+
+	// Add FunctionImport elements for unbound functions
+	seenFunctionImports := make(map[string]struct{})
+	for funcName, funcDefs := range model.functions {
+		for _, funcDef := range funcDefs {
+			if funcDef.IsBound {
+				continue
+			}
+			if _, exists := seenFunctionImports[funcName]; exists {
+				continue
+			}
+			seenFunctionImports[funcName] = struct{}{}
+			funcImport := map[string]interface{}{
+				"$Kind":     "FunctionImport",
+				"$Function": fmt.Sprintf("%s.%s", model.namespace, funcName),
+			}
+			container[funcName] = funcImport
+		}
+	}
+
+	// Add ActionImport elements for unbound actions
+	seenActionImports := make(map[string]struct{})
+	for actionName, actionDefs := range model.actions {
+		for _, actionDef := range actionDefs {
+			if actionDef.IsBound {
+				continue
+			}
+			if _, exists := seenActionImports[actionName]; exists {
+				continue
+			}
+			seenActionImports[actionName] = struct{}{}
+			actionImport := map[string]interface{}{
+				"$Kind":   "ActionImport",
+				"$Action": fmt.Sprintf("%s.%s", model.namespace, actionName),
+			}
+			container[actionName] = actionImport
 		}
 	}
 

--- a/internal/handlers/metadata_operations_test.go
+++ b/internal/handlers/metadata_operations_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/actions"
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+type metadataOperationProduct struct {
+	ID   int `odata:"key"`
+	Name string
+}
+
+func TestMetadataIncludesOperationElementsXML(t *testing.T) {
+	entityMeta, err := metadata.AnalyzeEntity(metadataOperationProduct{})
+	if err != nil {
+		t.Fatalf("failed to analyze entity: %v", err)
+	}
+
+	entities := map[string]*metadata.EntityMetadata{
+		entityMeta.EntitySetName: entityMeta,
+	}
+
+	functions := map[string][]*actions.FunctionDefinition{
+		"GetTopProducts": {
+			{
+				Name:       "GetTopProducts",
+				IsBound:    false,
+				Parameters: []actions.ParameterDefinition{{Name: "count", Type: reflect.TypeOf(int64(0)), Required: true}},
+				ReturnType: reflect.TypeOf([]metadataOperationProduct{}),
+			},
+		},
+		"GetRelatedProducts": {
+			{
+				Name:       "GetRelatedProducts",
+				IsBound:    true,
+				EntitySet:  entityMeta.EntitySetName,
+				ReturnType: reflect.TypeOf([]metadataOperationProduct{}),
+			},
+		},
+	}
+
+	actionsMap := map[string][]*actions.ActionDefinition{
+		"ResetProducts": {
+			{
+				Name:    "ResetProducts",
+				IsBound: false,
+			},
+		},
+		"ApplyDiscount": {
+			{
+				Name:       "ApplyDiscount",
+				IsBound:    true,
+				EntitySet:  entityMeta.EntitySetName,
+				Parameters: []actions.ParameterDefinition{{Name: "percentage", Type: reflect.TypeOf(float64(0)), Required: true}},
+			},
+		},
+	}
+
+	handler := NewMetadataHandlerWithOperations(entities, actionsMap, functions)
+
+	req := httptest.NewRequest(http.MethodGet, "/$metadata", nil)
+	w := httptest.NewRecorder()
+	handler.HandleMetadata(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", w.Code)
+	}
+
+	body := w.Body.String()
+	checks := []string{
+		`<Function Name="GetTopProducts" IsBound="false">`,
+		`<Function Name="GetRelatedProducts" IsBound="true">`,
+		`<Action Name="ResetProducts" IsBound="false">`,
+		`<Action Name="ApplyDiscount" IsBound="true">`,
+		`<FunctionImport Name="GetTopProducts" Function="ODataService.GetTopProducts" />`,
+		`<ActionImport Name="ResetProducts" Action="ODataService.ResetProducts" />`,
+		`<ReturnType Type="Collection(ODataService.metadataOperationProduct)" />`,
+		`<Parameter Name="bindingParameter" Type="ODataService.metadataOperationProduct" Nullable="false" />`,
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metadata XML missing expected fragment: %s\nBody:\n%s", want, body)
+		}
+	}
+
+	if strings.Contains(body, `<FunctionImport Name="GetRelatedProducts"`) {
+		t.Fatalf("bound function should not be exposed as FunctionImport")
+	}
+	if strings.Contains(body, `<ActionImport Name="ApplyDiscount"`) {
+		t.Fatalf("bound action should not be exposed as ActionImport")
+	}
+}
+
+func TestMetadataIncludesOperationElementsJSON(t *testing.T) {
+	entityMeta, err := metadata.AnalyzeEntity(metadataOperationProduct{})
+	if err != nil {
+		t.Fatalf("failed to analyze entity: %v", err)
+	}
+
+	entities := map[string]*metadata.EntityMetadata{
+		entityMeta.EntitySetName: entityMeta,
+	}
+
+	functions := map[string][]*actions.FunctionDefinition{
+		"GetTopProducts": {
+			{
+				Name:       "GetTopProducts",
+				IsBound:    false,
+				Parameters: []actions.ParameterDefinition{{Name: "count", Type: reflect.TypeOf(int64(0)), Required: true}},
+				ReturnType: reflect.TypeOf([]metadataOperationProduct{}),
+			},
+		},
+	}
+
+	actionsMap := map[string][]*actions.ActionDefinition{
+		"ResetProducts": {
+			{
+				Name:    "ResetProducts",
+				IsBound: false,
+			},
+		},
+	}
+
+	handler := NewMetadataHandlerWithOperations(entities, actionsMap, functions)
+
+	req := httptest.NewRequest(http.MethodGet, "/$metadata?$format=json", nil)
+	w := httptest.NewRecorder()
+	handler.HandleMetadata(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", w.Code)
+	}
+
+	body := w.Body.String()
+	checks := []string{
+		`"$Kind": "Function"`,
+		`"$Kind": "Action"`,
+		`"$Kind": "FunctionImport"`,
+		`"$Kind": "ActionImport"`,
+		`"$Function": "ODataService.GetTopProducts"`,
+		`"$Action": "ODataService.ResetProducts"`,
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metadata JSON missing expected fragment: %s\nBody:\n%s", want, body)
+		}
+	}
+}

--- a/internal/handlers/metadata_xml.go
+++ b/internal/handlers/metadata_xml.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -110,6 +111,8 @@ func (h *MetadataHandler) buildMetadataDocument(model metadataModel, ver version
 
 	builder.WriteString(h.buildEnumTypes(model))
 	builder.WriteString(h.buildEntityTypes(model))
+	builder.WriteString(h.buildFunctionTypes(model))
+	builder.WriteString(h.buildActionTypes(model))
 	builder.WriteString(h.buildEntityContainer(model))
 	builder.WriteString(h.buildAnnotations(model))
 
@@ -118,6 +121,51 @@ func (h *MetadataHandler) buildMetadataDocument(model metadataModel, ver version
 </edmx:Edmx>`)
 
 	return builder.String()
+}
+
+func (h *MetadataHandler) getEdmTypeName(t reflect.Type) string {
+	if t == nil {
+		return "Edm.String"
+	}
+
+	// Handle pointer types
+	if t.Kind() == reflect.Ptr {
+		return h.getEdmTypeName(t.Elem())
+	}
+
+	// Handle slice/array types (Collection)
+	if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
+		elemType := h.getEdmTypeName(t.Elem())
+		return fmt.Sprintf("Collection(%s)", elemType)
+	}
+
+	// Handle basic types
+	switch t.Kind() {
+	case reflect.String:
+		return "Edm.String"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		return "Edm.Int32"
+	case reflect.Int64:
+		return "Edm.Int64"
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return "Edm.Int32"
+	case reflect.Uint64:
+		return "Edm.Int64"
+	case reflect.Float32:
+		return "Edm.Single"
+	case reflect.Float64:
+		return "Edm.Double"
+	case reflect.Bool:
+		return "Edm.Boolean"
+	case reflect.Struct:
+		// Check for time.Time
+		if t.String() == "time.Time" {
+			return "Edm.DateTimeOffset"
+		}
+		return fmt.Sprintf("%s.%s", h.namespaceOrDefault(), t.Name())
+	default:
+		return "Edm.String"
+	}
 }
 
 func (h *MetadataHandler) buildEnumTypes(model metadataModel) string {
@@ -167,6 +215,90 @@ func (h *MetadataHandler) buildEntityTypes(model metadataModel) string {
 	for _, entityMeta := range model.entities {
 		builder.WriteString(h.buildEntityType(model, entityMeta))
 	}
+	return builder.String()
+}
+
+func (h *MetadataHandler) buildFunctionTypes(model metadataModel) string {
+	if len(model.functions) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+
+	// Group functions by name (for overload signatures)
+	for funcName, funcDefs := range model.functions {
+		for _, funcDef := range funcDefs {
+			builder.WriteString(fmt.Sprintf(`      <Function Name="%s" IsBound="%v">`+"\n", funcName, funcDef.IsBound))
+
+			if funcDef.IsBound {
+				bindingType := h.operationBindingType(model, funcDef.EntitySet)
+				builder.WriteString(fmt.Sprintf(`        <Parameter Name="bindingParameter" Type="%s" Nullable="false" />`+"\n", bindingType))
+			}
+
+			// Add parameters
+			if len(funcDef.Parameters) > 0 {
+				for _, param := range funcDef.Parameters {
+					paramType := h.getEdmTypeName(param.Type)
+					nullable := "false"
+					if !param.Required {
+						nullable = "true"
+					}
+					builder.WriteString(fmt.Sprintf(`        <Parameter Name="%s" Type="%s" Nullable="%s" />
+`, param.Name, paramType, nullable))
+				}
+			}
+
+			if funcDef.ReturnType != nil {
+				returnType := h.getEdmTypeName(funcDef.ReturnType)
+				builder.WriteString(fmt.Sprintf(`        <ReturnType Type="%s" />`+"\n", returnType))
+			}
+
+			builder.WriteString(`      </Function>` + "\n")
+		}
+	}
+
+	return builder.String()
+}
+
+func (h *MetadataHandler) buildActionTypes(model metadataModel) string {
+	if len(model.actions) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+
+	// Group actions by name (for overload signatures)
+	for actionName, actionDefs := range model.actions {
+		for _, actionDef := range actionDefs {
+			builder.WriteString(fmt.Sprintf(`      <Action Name="%s" IsBound="%v">`+"\n", actionName, actionDef.IsBound))
+
+			if actionDef.IsBound {
+				bindingType := h.operationBindingType(model, actionDef.EntitySet)
+				builder.WriteString(fmt.Sprintf(`        <Parameter Name="bindingParameter" Type="%s" Nullable="false" />`+"\n", bindingType))
+			}
+
+			// Add parameters
+			if len(actionDef.Parameters) > 0 {
+				for _, param := range actionDef.Parameters {
+					paramType := h.getEdmTypeName(param.Type)
+					nullable := "false"
+					if !param.Required {
+						nullable = "true"
+					}
+					builder.WriteString(fmt.Sprintf(`        <Parameter Name="%s" Type="%s" Nullable="%s" />
+`, param.Name, paramType, nullable))
+				}
+			}
+
+			if actionDef.ReturnType != nil {
+				returnType := h.getEdmTypeName(actionDef.ReturnType)
+				builder.WriteString(fmt.Sprintf(`        <ReturnType Type="%s" />`+"\n", returnType))
+			}
+
+			builder.WriteString(`      </Action>` + "\n")
+		}
+	}
+
 	return builder.String()
 }
 
@@ -314,9 +446,47 @@ func (h *MetadataHandler) buildEntityContainer(model metadataModel) string {
 		}
 	}
 
+	// Add FunctionImport elements for unbound functions
+	seenFunctionImports := make(map[string]struct{})
+	for funcName, funcDefs := range model.functions {
+		for _, funcDef := range funcDefs {
+			if funcDef.IsBound {
+				continue
+			}
+			if _, exists := seenFunctionImports[funcName]; exists {
+				continue
+			}
+			seenFunctionImports[funcName] = struct{}{}
+			builder.WriteString(fmt.Sprintf(`        <FunctionImport Name="%s" Function="%s.%s" />`+"\n", funcName, model.namespace, funcName))
+		}
+	}
+
+	// Add ActionImport elements for unbound actions
+	seenActionImports := make(map[string]struct{})
+	for actionName, actionDefs := range model.actions {
+		for _, actionDef := range actionDefs {
+			if actionDef.IsBound {
+				continue
+			}
+			if _, exists := seenActionImports[actionName]; exists {
+				continue
+			}
+			seenActionImports[actionName] = struct{}{}
+			builder.WriteString(fmt.Sprintf(`        <ActionImport Name="%s" Action="%s.%s" />`+"\n", actionName, model.namespace, actionName))
+		}
+	}
+
 	builder.WriteString(`      </EntityContainer>
 `)
 	return builder.String()
+}
+
+func (h *MetadataHandler) operationBindingType(model metadataModel, entitySetName string) string {
+	entityMeta, ok := model.entities[entitySetName]
+	if !ok || entityMeta == nil {
+		return "Edm.String"
+	}
+	return model.qualifiedTypeName(entityMeta.EntityName)
 }
 
 // buildAnnotations builds the Annotations sections for all annotated targets

--- a/internal/service/router/router.go
+++ b/internal/service/router/router.go
@@ -153,6 +153,24 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	switch req.Method {
 	case http.MethodGet, http.MethodHead:
+		if !strings.Contains(path, "(") && !strings.Contains(path, ")") {
+			if _, exists := r.functions[path]; exists {
+				supportsNoParens := negotiatedVersion.Major > 4 || (negotiatedVersion.Major == 4 && negotiatedVersion.Minor >= 1)
+				if !supportsNoParens {
+					if writeErr := response.WriteError(w, req, http.StatusBadRequest, "Invalid function invocation",
+						"Function invocations without parentheses require OData 4.01 negotiation; use parentheses syntax (FunctionName())"); writeErr != nil {
+						r.logger.Error("Error writing error response", "error", writeErr)
+					}
+					return
+				}
+
+				if r.hasUnboundParameterlessFunction(path) && !hasNonSystemQueryParams(req.URL.Query()) {
+					r.actionInvoker(w, req, path, "", false, "")
+					return
+				}
+			}
+		}
+
 		if strings.Contains(path, "(") && strings.Contains(path, ")") {
 			pathWithoutParams := path
 			if idx := strings.Index(path, "("); idx != -1 {
@@ -223,6 +241,33 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	r.routeRequest(w, req, handler, components)
+}
+
+func (r *Router) hasUnboundParameterlessFunction(name string) bool {
+	defs, ok := r.functions[name]
+	if !ok {
+		return false
+	}
+
+	for _, def := range defs {
+		if def == nil {
+			continue
+		}
+		if !def.IsBound && len(def.Parameters) == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasNonSystemQueryParams(values map[string][]string) bool {
+	for key := range values {
+		if !strings.HasPrefix(key, "$") {
+			return true
+		}
+	}
+	return false
 }
 
 // SetAsyncMonitor configures the router to delegate monitor requests to the async manager.

--- a/internal/service/router/router_additional_test.go
+++ b/internal/service/router/router_additional_test.go
@@ -138,6 +138,77 @@ func TestRouter_HeadUnboundFunction_InvokesActionInvoker(t *testing.T) {
 	}
 }
 
+func TestRouter_GetUnboundParameterlessFunction_NoParens_401Invokes(t *testing.T) {
+	invoked := false
+	invoker := func(_ http.ResponseWriter, _ *http.Request, name, key string, isBound bool, entitySet string) {
+		invoked = true
+		if name != "TopProducts" || key != "" || isBound || entitySet != "" {
+			t.Fatalf("unexpected invocation parameters: name=%s key=%s bound=%v set=%s", name, key, isBound, entitySet)
+		}
+	}
+
+	r := newTestRouter(nil, nil, map[string][]*actions.FunctionDefinition{
+		"TopProducts": []*actions.FunctionDefinition{
+			{Name: "TopProducts", IsBound: false, Parameters: nil},
+		},
+	}, invoker)
+
+	req := httptest.NewRequest(http.MethodGet, "/TopProducts", nil)
+	req.Header.Set("OData-MaxVersion", "4.01")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if !invoked {
+		t.Fatal("expected action invoker to be called for OData 4.01 shorthand function call")
+	}
+}
+
+func TestRouter_GetUnboundParameterlessFunction_NoParens_40Rejected(t *testing.T) {
+	invoked := false
+	r := newTestRouter(nil, nil, map[string][]*actions.FunctionDefinition{
+		"TopProducts": []*actions.FunctionDefinition{
+			{Name: "TopProducts", IsBound: false, Parameters: nil},
+		},
+	}, func(http.ResponseWriter, *http.Request, string, string, bool, string) {
+		invoked = true
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/TopProducts", nil)
+	req.Header.Set("OData-MaxVersion", "4.0")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+	if invoked {
+		t.Fatal("expected action invoker not to be called for OData 4.0 shorthand function call")
+	}
+	if !strings.Contains(strings.ToLower(rec.Body.String()), "parentheses") {
+		t.Fatalf("expected error response to mention parentheses, got %q", rec.Body.String())
+	}
+}
+
+func TestRouter_GetUnboundFunction_NoParensWithFunctionParams_NotInvoked(t *testing.T) {
+	invoked := false
+	r := newTestRouter(nil, nil, map[string][]*actions.FunctionDefinition{
+		"TopProducts": []*actions.FunctionDefinition{
+			{Name: "TopProducts", IsBound: false, Parameters: []actions.ParameterDefinition{{Name: "count", Required: true}}},
+		},
+	}, func(http.ResponseWriter, *http.Request, string, string, bool, string) {
+		invoked = true
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/TopProducts?count=3", nil)
+	req.Header.Set("OData-MaxVersion", "4.01")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if invoked {
+		t.Fatal("expected shorthand invocation without parentheses not to invoke function with explicit parameters")
+	}
+}
+
 func TestRouter_StreamPropertyRefRejected(t *testing.T) {
 	handler := newStubEntityHandler()
 	handler.streamProps["Photo"] = true

--- a/odata.go
+++ b/odata.go
@@ -495,15 +495,18 @@ func NewServiceWithConfig(db *gorm.DB, cfg ServiceConfig) (*Service, error) {
 		maxBatchSize = DefaultMaxBatchSize
 	}
 
+	actionsMap := make(map[string][]*actions.ActionDefinition)
+	functionsMap := make(map[string][]*actions.FunctionDefinition)
+
 	s := &Service{
 		db:                         db,
 		entities:                   entities,
 		entityContainerAnnotations: metadata.NewAnnotationCollection(),
 		handlers:                   handlersMap,
-		metadataHandler:            handlers.NewMetadataHandler(entities),
+		actions:                    actionsMap,
+		functions:                  functionsMap,
+		metadataHandler:            handlers.NewMetadataHandlerWithOperations(entities, actionsMap, functionsMap),
 		serviceDocumentHandler:     handlers.NewServiceDocumentHandler(entities, logger),
-		actions:                    make(map[string][]*actions.ActionDefinition),
-		functions:                  make(map[string][]*actions.FunctionDefinition),
 		namespace:                  DefaultNamespace,
 		deltaTracker:               tracker,
 		changeTrackingPersistent:   cfg.PersistentChangeTracking,


### PR DESCRIPTION
## Summary
- add action/function definitions to XML and JSON CSDL metadata generation
- emit FunctionImport/ActionImport for unbound operations in the entity container
- pass registered operations into metadata handler wiring
- add focused tests validating operation discoverability in 

## Validation
- go test ./internal/handlers -run MetadataIncludesOperationElements -v
- go test ./...
- go build ./...
- golangci-lint run ./...