### PR TITLE
Fix SQLite REGEXP availability across connection pool

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -3,6 +3,7 @@
 package odata
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 
@@ -26,6 +27,16 @@ func init() {
 // ensureSQLiteRegexp ensures the REGEXP function is registered on SQLite connections.
 // This function is called automatically when creating a service with SQLite,
 // so users don't need to do anything special - just use sqlite.Open() normally.
+//
+// Because mattn/go-sqlite3 registers user-defined functions per-connection (not
+// globally), we must make sure that every connection the OData service uses has
+// REGEXP available. The standard gorm sqlite dialector opens via the default
+// "sqlite3" driver, which does not expose a ConnectHook. To guarantee REGEXP is
+// present on any connection drawn from the pool we pin the pool to a single
+// connection (max open = max idle = 1, no idle-timeout) and register REGEXP on
+// that single connection. Single-connection SQLite pools are also the common
+// recommendation for SQLite because writes are serialized and in-memory
+// databases are not shared between connections.
 func ensureSQLiteRegexp(db *gorm.DB) error {
 	if db.Name() != "sqlite" {
 		return nil
@@ -37,18 +48,26 @@ func ensureSQLiteRegexp(db *gorm.DB) error {
 		return err
 	}
 
-	// Register REGEXP on a connection from the pool. This will be called
-	// on every new connection via the ConnectHook if using the sqlite3_regexp driver.
-	// For users with standard sqlite3, attempt to register it here.
-	conn, err := sqlDB.Conn(db.Statement.Context)
+	// Pin the pool to a single connection so the REGEXP function we register
+	// below is available for every query. Without this, new connections
+	// created by database/sql would not have the function and any
+	// matchesPattern() filter would fail with "no such function: REGEXP".
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	sqlDB.SetConnMaxIdleTime(0)
+	sqlDB.SetConnMaxLifetime(0)
+
+	ctx := db.Statement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	conn, err := sqlDB.Conn(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Close() //nolint:errcheck
 
-	// Try to register REGEXP; if the driver already has it via ConnectHook, this is a no-op
-	//nolint:errcheck
-	conn.Raw(func(driverConn interface{}) error {
+	return conn.Raw(func(driverConn interface{}) error {
 		sqliteConn, ok := driverConn.(*sqlite3.SQLiteConn)
 		if !ok {
 			return nil
@@ -57,6 +76,4 @@ func ensureSQLiteRegexp(db *gorm.DB) error {
 			return regexp.MatchString(pattern, s)
 		}, true)
 	})
-
-	return nil
 }


### PR DESCRIPTION
## Summary
Fixes intermittent SQLite compliance failures where `matchesPattern` queries returned `no such function: REGEXP`.

The root cause is that `mattn/go-sqlite3` registers custom functions per connection, while `database/sql` may open additional pooled connections that do not have `REGEXP` registered.

## Changes
- Update SQLite setup in `ensureSQLiteRegexp` to pin the pool to a single connection:
  - `SetMaxOpenConns(1)`
  - `SetMaxIdleConns(1)`
  - disable conn idle/lifetime expiration
- Register `REGEXP` on that persistent connection
- Add context fallback (`context.Background()`) when `db.Statement.Context` is nil
- Expand inline comments to explain the SQLite connection/function behavior

## Validation
- `go test ./...`
- `golangci-lint run ./...`
- `go run ./compliance-suite -db sqlite` (passes; 149/149 suites, 1069 passing tests, 0 failing)