### PR TITLE
Potential fix for code scanning alert no. 32: Reflected cross-site scripting

### DIFF
--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -752,7 +753,17 @@ func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.D
 
 // createErrorResponse creates an error response
 func (h *BatchHandler) createErrorResponse(statusCode int, message string) batchResponse {
-	errorBody := fmt.Sprintf(`{"error":{"code":"%d","message":"%s"}}`, statusCode, message)
+	payload := map[string]map[string]string{
+		"error": {
+			"code":    strconv.Itoa(statusCode),
+			"message": message,
+		},
+	}
+	errorBody, err := json.Marshal(payload)
+	if err != nil {
+		errorBody = []byte(`{"error":{"code":"500","message":"Internal Server Error"}}`)
+	}
+
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 	// Use version 4.01 for batch error responses (no request context available)
@@ -761,7 +772,7 @@ func (h *BatchHandler) createErrorResponse(statusCode int, message string) batch
 	return batchResponse{
 		StatusCode: statusCode,
 		Headers:    headers,
-		Body:       []byte(errorBody),
+		Body:       errorBody,
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/NLstn/go-odata/security/code-scanning/32](https://github.com/NLstn/go-odata/security/code-scanning/32)

The best fix is to **stop manually building JSON with string interpolation** and instead serialize structured error payloads with `encoding/json`, which correctly escapes attacker-controlled characters. This preserves functionality (same status/code/message semantics) while removing injection risk.

Single best implementation in shown code:
1. Edit `internal/handlers/batch.go`:
   - Add `strconv` import.
   - In `createErrorResponse`, replace:
     - `fmt.Sprintf(`{"error":{"code":"%d","message":"%s"}}`, statusCode, message)`
     with safe JSON marshalling of a struct/map.
   - If marshalling fails, return a minimal static JSON fallback.
   - Keep existing headers and return type unchanged.

This addresses the tainted path from batch request body → parse error text → response body, which is the substantive source feeding all reported variants that converge at response writes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
