### PR TITLE
[codex] support OData preference variants

### DIFF
--- a/internal/handlers/collection_response.go
+++ b/internal/handlers/collection_response.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nlstn/go-odata/internal/preference"
 	"github.com/nlstn/go-odata/internal/query"
 	"github.com/nlstn/go-odata/internal/response"
+	"github.com/nlstn/go-odata/internal/version"
 )
 
 func (h *EntityHandler) collectionResponseWriter(w http.ResponseWriter, r *http.Request, pref *preference.Preference) func(*query.QueryOptions, interface{}, *int64, *string) error {
@@ -60,6 +61,10 @@ func (h *EntityHandler) collectionResponseWriter(w http.ResponseWriter, r *http.
 		// The annotation filtering is applied during response serialization in the response package.
 		if pref.IncludeAnnotations != nil {
 			pref.ApplyIncludeAnnotations()
+		}
+
+		if pref.OmitValues != nil {
+			pref.ApplyOmitValues(version.GetVersion(r.Context()).Supports("unprefixed-preferences"))
 		}
 
 		if applied := pref.GetPreferenceApplied(); applied != "" {

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nlstn/go-odata/internal/preference"
 	"github.com/nlstn/go-odata/internal/query"
 	"github.com/nlstn/go-odata/internal/response"
+	"github.com/nlstn/go-odata/internal/version"
 	"gorm.io/gorm"
 )
 
@@ -193,6 +194,9 @@ func (h *EntityHandler) writeEntityResponseWithETag(w http.ResponseWriter, r *ht
 	}
 	if pref.AllowEntityReferences {
 		pref.ApplyAllowEntityReferences()
+	}
+	if pref.OmitValues != nil {
+		pref.ApplyOmitValues(version.GetVersion(r.Context()).Supports("unprefixed-preferences"))
 	}
 	if applied := pref.GetPreferenceApplied(); applied != "" {
 		w.Header().Set(HeaderPreferenceApplied, applied)

--- a/internal/preference/preference.go
+++ b/internal/preference/preference.go
@@ -15,20 +15,24 @@ type Preference struct {
 	RespondAsyncRequested bool
 	AllowEntityReferences bool    // odata.allow-entityreferences preference (OData v4.0, §8.2.8.1)
 	IncludeAnnotations    *string // odata.include-annotations preference value (OData v4.0, §8.2.8.4)
+	OmitValues            *string // omit-values / odata.omit-values preference value (OData v4.01, §8.2.8.6)
+	OmitValuesPrefixed    bool
 
 	trackChangesApplied       bool
 	respondAsyncApplied       bool
 	allowEntityRefsApplied    bool
 	includeAnnotationsApplied bool
+	omitValuesApplied         bool
 }
 
 // ParsePrefer parses the Prefer header from an HTTP request
 // According to OData v4 spec, the Prefer header can contain:
 // - return=representation: requests the service to return the created/updated entity
 // - return=minimal: requests the service to return minimal or no content (default for PATCH/PUT)
-// - odata.maxpagesize=n: requests the service to limit page size to n items
+// - odata.maxpagesize=n / maxpagesize=n: requests the service to limit page size to n items
 // - odata.allow-entityreferences: allows service to return @odata.id references (OData v4.0, §8.2.8.1)
 // - odata.include-annotations: controls which instance annotations are included (OData v4.0, §8.2.8.4)
+// - odata.omit-values / omit-values: controls omitted default/null values (OData v4.01, §8.2.8.6)
 func ParsePrefer(r *http.Request) *Preference {
 	pref := &Preference{}
 
@@ -51,21 +55,25 @@ func ParsePrefer(r *http.Request) *Preference {
 			pref.ReturnMinimal = true
 		case "respond-async":
 			pref.RespondAsyncRequested = true
-		case "odata.allow-entityreferences":
+		case "odata.allow-entityreferences", "allow-entityreferences":
 			pref.AllowEntityReferences = true
 		default:
 			// Check for odata.maxpagesize preference
-			if strings.HasPrefix(pLower, "odata.maxpagesize=") {
-				maxPageSizeStr := strings.TrimPrefix(p, "odata.maxpagesize=")
-				maxPageSizeStr = strings.TrimPrefix(maxPageSizeStr, "odata.maxPageSize=")
-				maxPageSizeStr = strings.TrimPrefix(maxPageSizeStr, "odata.MaxPageSize=")
+			if value, ok := preferenceValue(p, pLower, "odata.maxpagesize"); ok {
+				maxPageSizeStr := value
 				if maxPageSize, err := strconv.Atoi(maxPageSizeStr); err == nil && maxPageSize > 0 {
 					pref.MaxPageSize = &maxPageSize
 				}
 				continue
 			}
+			if value, ok := preferenceValue(p, pLower, "maxpagesize"); ok {
+				if maxPageSize, err := strconv.Atoi(value); err == nil && maxPageSize > 0 {
+					pref.MaxPageSize = &maxPageSize
+				}
+				continue
+			}
 
-			if strings.HasPrefix(pLower, "odata.track-changes") {
+			if strings.HasPrefix(pLower, "odata.track-changes") || strings.HasPrefix(pLower, "track-changes") {
 				pref.TrackChangesRequested = true
 				continue
 			}
@@ -75,19 +83,46 @@ func ParsePrefer(r *http.Request) *Preference {
 			//   odata.include-annotations="*"
 			//   odata.include-annotations=*
 			//   odata.include-annotations="*,-Org.OData.Core.V1.Description"
-			if strings.HasPrefix(pLower, "odata.include-annotations=") {
-				val := p[len("odata.include-annotations="):]
-				// Strip surrounding quotes if present
-				if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
-					val = val[1 : len(val)-1]
-				}
+			if val, ok := preferenceValue(p, pLower, "odata.include-annotations"); ok {
+				val = trimPreferenceQuotes(val)
 				pref.IncludeAnnotations = &val
+				continue
+			}
+			if val, ok := preferenceValue(p, pLower, "include-annotations"); ok {
+				val = trimPreferenceQuotes(val)
+				pref.IncludeAnnotations = &val
+				continue
+			}
+			if val, ok := preferenceValue(p, pLower, "odata.omit-values"); ok {
+				val = trimPreferenceQuotes(val)
+				pref.OmitValues = &val
+				pref.OmitValuesPrefixed = true
+				continue
+			}
+			if val, ok := preferenceValue(p, pLower, "omit-values"); ok {
+				val = trimPreferenceQuotes(val)
+				pref.OmitValues = &val
 				continue
 			}
 		}
 	}
 
 	return pref
+}
+
+func preferenceValue(original, lower, name string) (string, bool) {
+	prefix := strings.ToLower(name) + "="
+	if !strings.HasPrefix(lower, prefix) {
+		return "", false
+	}
+	return original[len(prefix):], true
+}
+
+func trimPreferenceQuotes(value string) string {
+	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		return value[1 : len(value)-1]
+	}
+	return value
 }
 
 // ShouldReturnContent determines if content should be returned based on preferences and operation
@@ -128,6 +163,9 @@ func (p *Preference) GetPreferenceApplied() string {
 	if p.includeAnnotationsApplied && p.IncludeAnnotations != nil {
 		applied = append(applied, `odata.include-annotations="`+*p.IncludeAnnotations+`"`)
 	}
+	if p.omitValuesApplied && p.OmitValues != nil {
+		applied = append(applied, "omit-values="+*p.OmitValues)
+	}
 	return strings.Join(applied, ", ")
 }
 
@@ -161,6 +199,13 @@ func (p *Preference) ApplyAllowEntityReferences() {
 func (p *Preference) ApplyIncludeAnnotations() {
 	if p.IncludeAnnotations != nil {
 		p.includeAnnotationsApplied = true
+	}
+}
+
+// ApplyOmitValues marks the omit-values preference as applied.
+func (p *Preference) ApplyOmitValues(allowUnprefixed bool) {
+	if p.OmitValues != nil && (allowUnprefixed || p.OmitValuesPrefixed) {
+		p.omitValuesApplied = true
 	}
 }
 

--- a/internal/preference/preference_test.go
+++ b/internal/preference/preference_test.go
@@ -194,6 +194,7 @@ func TestParsePrefer_MaxPageSizeCaseVariations(t *testing.T) {
 		{"Lowercase", "odata.maxpagesize=100", 100},
 		{"CamelCase", "odata.maxPageSize=200", 200},
 		{"PascalCase", "odata.MaxPageSize=300", 300},
+		{"Unprefixed", "maxpagesize=400", 400},
 	}
 
 	for _, tc := range testCases {
@@ -242,6 +243,16 @@ func TestParsePrefer_TrackChanges(t *testing.T) {
 	applied := pref.GetPreferenceApplied()
 	if applied != "odata.track-changes" {
 		t.Fatalf("expected Preference-Applied to include track changes, got %s", applied)
+	}
+}
+
+func TestParsePrefer_TrackChangesUnprefixed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Prefer", "track-changes")
+
+	pref := ParsePrefer(req)
+	if !pref.TrackChangesRequested {
+		t.Fatalf("expected unprefixed track-changes to be requested")
 	}
 }
 
@@ -376,6 +387,7 @@ func TestParsePrefer_AllowEntityReferencesCaseInsensitive(t *testing.T) {
 		"ODATA.ALLOW-ENTITYREFERENCES",
 		"Odata.Allow-EntityReferences",
 		"odata.allow-entityreferences",
+		"allow-entityreferences",
 	}
 	for _, h := range headers {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -439,6 +451,71 @@ func TestParsePrefer_IncludeAnnotationsUnquoted(t *testing.T) {
 	}
 	if *pref.IncludeAnnotations != "*" {
 		t.Errorf("expected '*', got %q", *pref.IncludeAnnotations)
+	}
+}
+
+func TestParsePrefer_IncludeAnnotationsUnprefixed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Prefer", `include-annotations="*"`)
+	pref := ParsePrefer(req)
+
+	if pref.IncludeAnnotations == nil {
+		t.Fatal("IncludeAnnotations should be set for unprefixed value")
+	}
+	if *pref.IncludeAnnotations != "*" {
+		t.Errorf("expected '*', got %q", *pref.IncludeAnnotations)
+	}
+}
+
+func TestParsePrefer_OmitValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"UnprefixedNulls", "omit-values=nulls", "nulls"},
+		{"PrefixedDefaults", "odata.omit-values=defaults", "defaults"},
+		{"Quoted", `omit-values="nulls"`, "nulls"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Prefer", tt.header)
+			pref := ParsePrefer(req)
+
+			if pref.OmitValues == nil {
+				t.Fatal("OmitValues should be set")
+			}
+			if *pref.OmitValues != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, *pref.OmitValues)
+			}
+
+			pref.ApplyOmitValues(true)
+			if applied := pref.GetPreferenceApplied(); applied != "omit-values="+tt.want {
+				t.Fatalf("expected omit-values preference to be applied, got %q", applied)
+			}
+		})
+	}
+}
+
+func TestApplyOmitValues_UnprefixedNotAppliedWhenDisallowed(t *testing.T) {
+	value := "nulls"
+	pref := &Preference{OmitValues: &value}
+	pref.ApplyOmitValues(false)
+
+	if applied := pref.GetPreferenceApplied(); applied != "" {
+		t.Fatalf("expected unprefixed omit-values not to apply when disallowed, got %q", applied)
+	}
+}
+
+func TestApplyOmitValues_PrefixedAppliedWhenUnprefixedDisallowed(t *testing.T) {
+	value := "nulls"
+	pref := &Preference{OmitValues: &value, OmitValuesPrefixed: true}
+	pref.ApplyOmitValues(false)
+
+	if applied := pref.GetPreferenceApplied(); applied != "omit-values=nulls" {
+		t.Fatalf("expected prefixed omit-values to apply, got %q", applied)
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -61,6 +61,9 @@ func (v Version) Supports(feature string) bool {
 	case "matchespattern":
 		// matchesPattern() filter function added in OData 4.01 (§11.5.3.3)
 		return v.Major > 4 || (v.Major == 4 && v.Minor >= 1)
+	case "unprefixed-preferences":
+		// OData 4.01 requires supported OData preference names without the odata. prefix.
+		return v.Major > 4 || (v.Major == 4 && v.Minor >= 1)
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary

Adds parsing and response application support for OData preference variants that were previously missing or only partially recognized:

- accepts unprefixed OData 4.01 preference names such as `maxpagesize`, `track-changes`, `allow-entityreferences`, and `include-annotations`
- recognizes `omit-values` / `odata.omit-values`
- gates unprefixed `omit-values` application through negotiated OData 4.01 support so OData 4.0 responses do not report it as applied
- adds preference parser tests for the new variants

## Validation

Not run locally: `go`, `gofmt`, and `golangci-lint` are not available in the shell environment.