### PR TITLE
[codex] reject unsupported deep update collections

### DIFF
--- a/internal/handlers/deep_update.go
+++ b/internal/handlers/deep_update.go
@@ -36,9 +36,10 @@ func (h *EntityHandler) processDeepUpdateNavigationProperties(ctx context.Contex
 		// Always remove navigation property keys from updateData to prevent GORM column errors
 		keysToRemove = append(keysToRemove, key)
 
-		// Collection-valued navigation properties are not supported for deep update
+		// Collection-valued navigation properties require collection graph merge semantics.
+		// Silently dropping them would make a non-applied deep update look successful.
 		if navProp.NavigationIsArray {
-			continue
+			return nil, fmt.Errorf("deep update for collection-valued navigation property '%s' is not supported", key)
 		}
 
 		// Only proceed if the value is a map (inline entity data)


### PR DESCRIPTION
## Summary

Changes deep update handling for collection-valued navigation properties from silent omission to an explicit request error.

Previously inline collection navigation payloads were removed from the update map and ignored, which could make unsupported OData graph updates look successful. This now fails fast with a clear error so clients do not get a false-positive update result.

## Validation

Not run locally: `go`, `gofmt`, and `golangci-lint` are not available in the shell environment.