### PR TITLE
[codex] parse OData escaped string key literals

### DIFF
--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -371,18 +371,36 @@ func parseCompositeKey(keyPart string, components *response.ODataURLComponents) 
 		keyName := strings.TrimSpace(parts[0])
 		keyValue := strings.TrimSpace(parts[1])
 
-		// Remove quotes from value if they match
-		if len(keyValue) >= 2 {
-			if (keyValue[0] == '\'' && keyValue[len(keyValue)-1] == '\'') ||
-				(keyValue[0] == '"' && keyValue[len(keyValue)-1] == '"') {
-				keyValue = keyValue[1 : len(keyValue)-1]
-			}
+		if unquoted, ok, err := unquoteODataStringLiteral(keyValue); err != nil {
+			return err
+		} else if ok {
+			keyValue = unquoted
 		}
 
 		components.EntityKeyMap[keyName] = keyValue
 	}
 
 	return nil
+}
+
+func unquoteODataStringLiteral(value string) (string, bool, error) {
+	if len(value) < 2 {
+		return value, false, nil
+	}
+
+	quote := value[0]
+	if quote != '\'' && quote != '"' {
+		return value, false, nil
+	}
+	if value[len(value)-1] != quote {
+		return "", false, fmt.Errorf("unterminated string literal")
+	}
+
+	unquoted := value[1 : len(value)-1]
+	if quote == '\'' {
+		unquoted = strings.ReplaceAll(unquoted, "''", "'")
+	}
+	return unquoted, true, nil
 }
 
 // handleFetchError writes appropriate error responses based on the fetch error type

--- a/internal/handlers/helpers_test.go
+++ b/internal/handlers/helpers_test.go
@@ -193,6 +193,21 @@ func TestParseCompositeKey(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:    "Escaped single quote in string value",
+			keyPart: "ID=123,Name='Bob''s'",
+			wantKeyMap: map[string]string{
+				"ID":   "123",
+				"Name": "Bob's",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Unterminated string value",
+			keyPart:    "ID=123,Name='Bob",
+			wantKeyMap: nil,
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -295,14 +295,11 @@ func ParseODataURLComponents(path string) (*ODataURLComponents, error) {
 
 func parseKeyPart(keyPart string, components *ODataURLComponents) error {
 	if !strings.Contains(keyPart, "=") {
-		// For single keys, strip surrounding quotes (same as composite keys)
 		cleanKey := keyPart
-		if len(cleanKey) >= 2 {
-			// Check if the key is surrounded by matching quotes
-			if (cleanKey[0] == '\'' && cleanKey[len(cleanKey)-1] == '\'') ||
-				(cleanKey[0] == '"' && cleanKey[len(cleanKey)-1] == '"') {
-				cleanKey = cleanKey[1 : len(cleanKey)-1]
-			}
+		if unquoted, ok, err := unquoteODataStringLiteral(cleanKey); err != nil {
+			return err
+		} else if ok {
+			cleanKey = unquoted
 		}
 		components.EntityKey = cleanKey
 		return nil
@@ -322,12 +319,10 @@ func parseKeyPart(keyPart string, components *ODataURLComponents) error {
 		keyName := strings.TrimSpace(parts[0])
 		keyValue := strings.TrimSpace(parts[1])
 
-		// Strip surrounding quotes if they match
-		if len(keyValue) >= 2 {
-			if (keyValue[0] == '\'' && keyValue[len(keyValue)-1] == '\'') ||
-				(keyValue[0] == '"' && keyValue[len(keyValue)-1] == '"') {
-				keyValue = keyValue[1 : len(keyValue)-1]
-			}
+		if unquoted, ok, err := unquoteODataStringLiteral(keyValue); err != nil {
+			return err
+		} else if ok {
+			keyValue = unquoted
 		}
 
 		components.EntityKeyMap[keyName] = keyValue
@@ -341,6 +336,26 @@ func parseKeyPart(keyPart string, components *ODataURLComponents) error {
 	}
 
 	return nil
+}
+
+func unquoteODataStringLiteral(value string) (string, bool, error) {
+	if len(value) < 2 {
+		return value, false, nil
+	}
+
+	quote := value[0]
+	if quote != '\'' && quote != '"' {
+		return value, false, nil
+	}
+	if value[len(value)-1] != quote {
+		return "", false, fmt.Errorf("unterminated string literal")
+	}
+
+	unquoted := value[1 : len(value)-1]
+	if quote == '\'' {
+		unquoted = strings.ReplaceAll(unquoted, "''", "'")
+	}
+	return unquoted, true, nil
 }
 
 func splitKeyPairs(input string) ([]string, error) {

--- a/internal/response/url_parsing_test.go
+++ b/internal/response/url_parsing_test.go
@@ -70,11 +70,11 @@ func TestParseODataURLComponentsCompositeKey(t *testing.T) {
 			expectKey:       "John Doe", // Quotes should be stripped
 		},
 		{
-			name:            "Single string key with mismatched quotes should not strip",
-			path:            "Keys('value\")",
+			name:            "Single string key with escaped single quote",
+			path:            "Keys('Bob''s')",
 			expectEntitySet: "Keys",
 			expectKeyMap:    map[string]string{},
-			expectKey:       "'value\"", // Quotes should NOT be stripped (mismatched)
+			expectKey:       "Bob's",
 		},
 		{
 			name:            "Single string key with embedded quotes",
@@ -114,6 +114,12 @@ func TestParseODataURLComponentsCompositeKey(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestParseODataURLComponentsMismatchedStringKeyQuotes(t *testing.T) {
+	if _, err := ParseODataURLComponents("Keys('value\")"); err == nil {
+		t.Fatal("expected error for unterminated string key literal")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes OData string key literal handling for entity URLs and composite key parsing.

- unescapes doubled single quotes in quoted string key literals, e.g. `'Bob''s'` -> `Bob's`
- returns an error for unterminated quoted key literals instead of treating them as raw key text
- covers both response URL parsing and handler composite-key parsing paths

## Validation

Not run locally: `go`, `gofmt`, and `golangci-lint` are not available in the shell environment.