### PR TITLE
[codex] support nested select options

### DIFF
--- a/internal/query/helpers.go
+++ b/internal/query/helpers.go
@@ -163,7 +163,7 @@ func propertyExistsWithNavCache(propertyName string, entityMetadata *metadata.En
 
 // parseSelect parses the $select query option
 func parseSelect(selectStr string) []string {
-	parts := strings.Split(selectStr, ",")
+	parts := splitAggregateExpressions(selectStr)
 	result := make([]string, 0, len(parts))
 	for _, part := range parts {
 		trimmed := strings.TrimSpace(part)

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -436,7 +436,7 @@ func ParseQueryOptionsWithConfigAndCaseSensitivity(queryParams url.Values, entit
 		return nil, err
 	}
 
-	if err := parseSelectOption(queryParams, entityMetadata, options, caseInsensitive); err != nil {
+	if err := parseSelectOption(queryParams, entityMetadata, options, config, caseInsensitive); err != nil {
 		return nil, err
 	}
 
@@ -564,9 +564,15 @@ func parseFilterOption(queryParams url.Values, entityMetadata *metadata.EntityMe
 }
 
 // parseSelectOption parses the $select query parameter
-func parseSelectOption(queryParams url.Values, entityMetadata *metadata.EntityMetadata, options *QueryOptions, caseInsensitive bool) error {
+func parseSelectOption(queryParams url.Values, entityMetadata *metadata.EntityMetadata, options *QueryOptions, config *ParserConfig, caseInsensitive bool) error {
 	if selectStr := queryParams.Get("$select"); selectStr != "" {
-		selectedProps := parseSelect(selectStr)
+		selectedProps, selectedExpands, err := parseSelectWithNestedOptions(selectStr, entityMetadata, config, caseInsensitive)
+		if err != nil {
+			return fmt.Errorf("invalid $select: %w", err)
+		}
+		if len(selectedExpands) > 0 {
+			options.Expand = mergeExpandOptions(options.Expand, selectedExpands)
+		}
 
 		// Wildcard '*' is only valid in OData v4.01 (caseInsensitive=true).
 		// Check this before the early metadata-nil return so it is always enforced.
@@ -640,6 +646,102 @@ func parseSelectOption(queryParams url.Values, entityMetadata *metadata.EntityMe
 		options.Select = selectedProps
 	}
 	return nil
+}
+
+func parseSelectWithNestedOptions(selectStr string, entityMetadata *metadata.EntityMetadata, config *ParserConfig, caseInsensitive bool) ([]string, []ExpandOption, error) {
+	parts := parseSelect(selectStr)
+	selectedProps := make([]string, 0, len(parts))
+	selectedExpands := make([]ExpandOption, 0)
+
+	for _, part := range parts {
+		if !strings.Contains(part, "(") {
+			selectedProps = append(selectedProps, part)
+			continue
+		}
+
+		openIdx := strings.IndexByte(part, '(')
+		if openIdx <= 0 || !strings.HasSuffix(part, ")") {
+			return nil, nil, fmt.Errorf("invalid nested select item %q", part)
+		}
+
+		navPropName := strings.TrimSpace(part[:openIdx])
+		if navPropName == "" {
+			return nil, nil, fmt.Errorf("invalid nested select item %q", part)
+		}
+
+		expand, err := parseSingleExpandCoreWithConfig(part, entityMetadata, entityMetadata != nil, config, 0, caseInsensitive)
+		if err != nil {
+			return nil, nil, err
+		}
+		selectedProps = append(selectedProps, navPropName)
+		selectedExpands = append(selectedExpands, expand)
+	}
+
+	return selectedProps, selectedExpands, nil
+}
+
+func mergeExpandOptions(existing []ExpandOption, additions []ExpandOption) []ExpandOption {
+	for _, addition := range additions {
+		merged := false
+		for i := range existing {
+			if existing[i].NavigationProperty != addition.NavigationProperty {
+				continue
+			}
+			if len(addition.Select) > 0 {
+				existing[i].Select = mergeStrings(existing[i].Select, addition.Select)
+			}
+			if len(addition.Expand) > 0 {
+				existing[i].Expand = mergeExpandOptions(existing[i].Expand, addition.Expand)
+			}
+			if addition.Filter != nil {
+				existing[i].Filter = addition.Filter
+			}
+			if len(addition.OrderBy) > 0 {
+				existing[i].OrderBy = addition.OrderBy
+			}
+			if addition.Top != nil {
+				existing[i].Top = addition.Top
+			}
+			if addition.Skip != nil {
+				existing[i].Skip = addition.Skip
+			}
+			if addition.Compute != nil {
+				existing[i].Compute = addition.Compute
+			}
+			if addition.Count {
+				existing[i].Count = true
+			}
+			if addition.Levels != nil {
+				existing[i].Levels = addition.Levels
+			}
+			merged = true
+			break
+		}
+		if !merged {
+			existing = append(existing, addition)
+		}
+	}
+	return existing
+}
+
+func mergeStrings(existing []string, additions []string) []string {
+	seen := make(map[string]bool, len(existing)+len(additions))
+	result := make([]string, 0, len(existing)+len(additions))
+	for _, value := range existing {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	for _, value := range additions {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
 }
 
 // extractComputeAliasesFromString extracts aliases from a $compute string

--- a/internal/query/parser_test.go
+++ b/internal/query/parser_test.go
@@ -45,6 +45,11 @@ func TestParseSelect(t *testing.T) {
 			expected:  []string{"Name", "Price", "Category"},
 		},
 		{
+			name:      "Nested select options",
+			selectStr: "Name,Category($select=Title;$top=1)",
+			expected:  []string{"Name", "Category($select=Title;$top=1)"},
+		},
+		{
 			name:      "Empty string",
 			selectStr: "",
 			expected:  []string{},
@@ -64,6 +69,35 @@ func TestParseSelect(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestParseQueryOptionsSelectNestedOptions(t *testing.T) {
+	params := url.Values{}
+	params.Set("$select", "Name,Category($select=Title;$top=1)")
+
+	opts, err := ParseQueryOptionsWithConfigAndCaseSensitivity(params, nil, nil, true)
+	if err != nil {
+		t.Fatalf("ParseQueryOptionsWithConfigAndCaseSensitivity returned error: %v", err)
+	}
+
+	if len(opts.Select) != 2 {
+		t.Fatalf("expected 2 selected properties, got %d", len(opts.Select))
+	}
+	if opts.Select[0] != "Name" || opts.Select[1] != "Category" {
+		t.Fatalf("unexpected select properties: %#v", opts.Select)
+	}
+	if len(opts.Expand) != 1 {
+		t.Fatalf("expected nested select to create one expand option, got %d", len(opts.Expand))
+	}
+	if opts.Expand[0].NavigationProperty != "Category" {
+		t.Fatalf("expected nested select expand for Category, got %q", opts.Expand[0].NavigationProperty)
+	}
+	if len(opts.Expand[0].Select) != 1 || opts.Expand[0].Select[0] != "Title" {
+		t.Fatalf("expected nested $select=Title, got %#v", opts.Expand[0].Select)
+	}
+	if opts.Expand[0].Top == nil || *opts.Expand[0].Top != 1 {
+		t.Fatalf("expected nested $top=1, got %#v", opts.Expand[0].Top)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds parser support for nested query options inside `$select` items.

The previous `$select` parser split directly on commas, so nested option lists could be split incorrectly and then validated as invalid property names. This change:

- splits `$select` values while respecting parentheses
- recognizes selected navigation properties with nested options, e.g. `Category($select=Title;$top=1)`
- maps those nested selected navigation options into existing `ExpandOption` execution structures
- merges nested selected navigation options with explicit `$expand` options when both target the same navigation property

## Validation

Not run locally: `go`, `gofmt`, and `golangci-lint` are not available in the shell environment.