### PR TITLE
Fix Accept negotiation fallback to 406 for unsupported media types

### DIFF
--- a/internal/response/content_negotiation_test.go
+++ b/internal/response/content_negotiation_test.go
@@ -83,6 +83,18 @@ func TestIsAcceptableFormat(t *testing.T) {
 			description:  "Should accept browser-like headers with wildcard",
 		},
 		{
+			name:         "Accept text/html only",
+			acceptHeader: "text/html",
+			want:         false,
+			description:  "Should reject text/html when no supported media type is offered",
+		},
+		{
+			name:         "Accept JSON explicitly disallowed",
+			acceptHeader: "application/json;q=0",
+			want:         false,
+			description:  "Should reject when JSON is explicitly not acceptable",
+		},
+		{
 			name:        "Format parameter json",
 			formatParam: "json",
 			want:        true,

--- a/internal/response/format_helpers.go
+++ b/internal/response/format_helpers.go
@@ -351,7 +351,9 @@ func IsAcceptableFormat(r *http.Request) bool {
 	}
 
 	var bestJSON, bestAtom, bestXML, bestWildcard float64
+	sawAnyAcceptType := false
 	for _, mt := range mediaTypes {
+		sawAnyAcceptType = true
 		switch mt.mimeType {
 		case "application/json":
 			if mt.quality > bestJSON {
@@ -382,6 +384,10 @@ func IsAcceptableFormat(r *http.Request) bool {
 		return true
 	}
 	if bestXML > 0 {
+		return false
+	}
+
+	if sawAnyAcceptType {
 		return false
 	}
 


### PR DESCRIPTION
## Summary
Fixes the content-negotiation bug where unsupported `Accept` media types could still receive JSON responses.

### Changes
- Update `IsAcceptableFormat` to return `false` when the client provides explicit `Accept` values and none are supported.
- Add regression tests for:
  - `Accept: text/html`
  - `Accept: application/json;q=0`

## Validation
- `go test ./internal/response`