### PR TITLE
Fix response negotiation for unprefixed/case-insensitive format in OData 4.01

### DIFF
--- a/internal/response/atom.go
+++ b/internal/response/atom.go
@@ -22,7 +22,7 @@ const (
 // IsAtomFormat returns true if the request asks for Atom/XML format via
 // $format=atom, $format=application/atom+xml, or Accept: application/atom+xml.
 func IsAtomFormat(r *http.Request) bool {
-	format := getFormatParameter(r.URL.RawQuery)
+	format := getFormatParameter(r)
 	if format != "" {
 		parts := strings.Split(format, ";")
 		baseFormat := strings.TrimSpace(parts[0])

--- a/internal/response/atom_test.go
+++ b/internal/response/atom_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/nlstn/go-odata/internal/version"
 )
 
 // TestIsAtomFormat tests the IsAtomFormat function
@@ -64,6 +66,24 @@ func TestIsAtomFormat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsAtomFormat_UnprefixedFormat_401Only(t *testing.T) {
+	t.Run("odata 4.01 accepts unprefixed format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test?format=atom", nil)
+		req = req.WithContext(version.WithVersion(req.Context(), version.Version{Major: 4, Minor: 1}))
+		if !IsAtomFormat(req) {
+			t.Fatalf("expected unprefixed format=atom to be active for OData 4.01")
+		}
+	})
+
+	t.Run("odata 4.0 ignores unprefixed format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test?format=atom", nil)
+		req = req.WithContext(version.WithVersion(req.Context(), version.Version{Major: 4, Minor: 0}))
+		if IsAtomFormat(req) {
+			t.Fatalf("expected unprefixed format to be inactive for OData 4.0")
+		}
+	})
 }
 
 // TestWriteAtomCollection tests the WriteAtomCollection function

--- a/internal/response/content_negotiation_test.go
+++ b/internal/response/content_negotiation_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/nlstn/go-odata/internal/version"
 )
 
 // TestIsAcceptableFormat tests the IsAcceptableFormat function for data endpoints
@@ -146,6 +148,24 @@ func TestIsAcceptableFormat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsAcceptableFormat_UnprefixedFormat_401Only(t *testing.T) {
+	t.Run("odata 4.01 accepts unprefixed format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test?format=atom", nil)
+		req = req.WithContext(version.WithVersion(req.Context(), version.Version{Major: 4, Minor: 1}))
+		if !IsAcceptableFormat(req) {
+			t.Fatalf("expected unprefixed format to be accepted for OData 4.01")
+		}
+	})
+
+	t.Run("odata 4.0 ignores unprefixed format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test?format=xml", nil)
+		req = req.WithContext(version.WithVersion(req.Context(), version.Version{Major: 4, Minor: 0}))
+		if !IsAcceptableFormat(req) {
+			t.Fatalf("expected unprefixed format to be ignored for OData 4.0")
+		}
+	})
 }
 
 // TestDataEndpointsRejectXML tests that data endpoints properly handle XML requests

--- a/internal/response/format_helpers.go
+++ b/internal/response/format_helpers.go
@@ -3,13 +3,13 @@ package response
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"reflect"
 	"sort"
 	"strings"
 
 	"github.com/nlstn/go-odata/internal/metadata"
 	oquery "github.com/nlstn/go-odata/internal/query"
+	"github.com/nlstn/go-odata/internal/version"
 )
 
 // Valid OData metadata levels per OData v4 specification
@@ -89,7 +89,7 @@ func validateMetadataValue(value string) error {
 // Returns an error if an invalid metadata value is specified.
 // Valid values are: "minimal", "full", "none"
 func ValidateODataMetadata(r *http.Request) error {
-	format := getFormatParameter(r.URL.RawQuery)
+	format := getFormatParameter(r)
 	if format != "" {
 		if err := validateMetadataInFormat(format); err != nil {
 			return err
@@ -109,7 +109,7 @@ func ValidateODataMetadata(r *http.Request) error {
 // GetODataMetadataLevel extracts the odata.metadata parameter value from the request
 // Returns "minimal" (default), "full", or "none" based on Accept header or $format parameter
 func GetODataMetadataLevel(r *http.Request) string {
-	format := getFormatParameter(r.URL.RawQuery)
+	format := getFormatParameter(r)
 	if format != "" {
 		return extractMetadataFromFormat(format)
 	}
@@ -125,7 +125,7 @@ func GetODataMetadataLevel(r *http.Request) string {
 // GetIEEE754Compatible extracts IEEE754Compatible format parameter value from
 // $format or Accept. Returns false when unspecified.
 func GetIEEE754Compatible(r *http.Request) bool {
-	format := getFormatParameter(r.URL.RawQuery)
+	format := getFormatParameter(r)
 	if format != "" {
 		if value, ok := extractIEEE754FromMediaType(format); ok {
 			return value
@@ -165,18 +165,22 @@ func BuildJSONContentType(r *http.Request) string {
 	return fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel)
 }
 
-func getFormatParameter(rawQuery string) string {
-	params := strings.Split(rawQuery, "&")
-	for _, param := range params {
-		if strings.HasPrefix(param, "$format=") || strings.HasPrefix(param, "%24format=") {
-			parts := strings.SplitN(param, "=", 2)
-			if len(parts) == 2 {
-				decoded, err := url.QueryUnescape(parts[1])
-				if err != nil {
-					return parts[1]
-				}
-				return decoded
-			}
+func getFormatParameter(r *http.Request) string {
+	queryParams := oquery.ParseRawQuery(r.URL.RawQuery)
+
+	v := version.GetVersion(r.Context())
+	caseInsensitive := v.Major > 4 || (v.Major == 4 && v.Minor >= 1)
+	if caseInsensitive {
+		queryParams = oquery.NormalizeQueryParams(queryParams)
+	}
+
+	if format := queryParams.Get("$format"); format != "" {
+		return format
+	}
+	if caseInsensitive {
+		// Preserve support for unprefixed 4.01-style system query options.
+		if format := queryParams.Get("format"); format != "" {
+			return format
 		}
 	}
 	return ""
@@ -305,7 +309,7 @@ func extractIEEE754FromParts(parts []string) (bool, bool) {
 // IsAcceptableFormat checks if the requested format via Accept header or $format is supported
 // Returns true if the format is acceptable (JSON, Atom/XML, or wildcard), false otherwise
 func IsAcceptableFormat(r *http.Request) bool {
-	format := getFormatParameter(r.URL.RawQuery)
+	format := getFormatParameter(r)
 	if format != "" {
 		parts := strings.Split(format, ";")
 		baseFormat := strings.TrimSpace(parts[0])

--- a/internal/response/metadata_level_test.go
+++ b/internal/response/metadata_level_test.go
@@ -404,7 +404,8 @@ func TestGetFormatParameter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getFormatParameter(tt.rawQuery)
+			req := httptest.NewRequest(http.MethodGet, "/test?"+tt.rawQuery, nil)
+			got := getFormatParameter(req)
 			if got != tt.expected {
 				t.Errorf("getFormatParameter(%q) = %q, want %q",
 					tt.rawQuery, got, tt.expected)


### PR DESCRIPTION
## Summary
Make response format negotiation honor OData 4.01 case-insensitive/unprefixed system query options for `$format`.

### Changes
- Rework response-side format extraction to parse query params through OData query parsing.
- In OData 4.01, normalize system option keys and accept unprefixed/case-insensitive `format` forms.
- Keep OData 4.0 strict behavior.
- Add regression tests covering `format=...` behavior for 4.01 vs 4.0.

## Validation
- `go test ./internal/response`