### PR TITLE
Fix $index detection for normalized OData 4.01 query options

### DIFF
--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/query"
+	"github.com/nlstn/go-odata/internal/version"
 )
 
 // WriteODataCollection writes an OData collection response.
@@ -221,8 +222,21 @@ func WriteODataDeltaResponse(w http.ResponseWriter, r *http.Request, entitySetNa
 
 // shouldAddIndexAnnotations checks if the $index query parameter is present in the request
 func shouldAddIndexAnnotations(r *http.Request) bool {
-	_, exists := r.URL.Query()["$index"]
-	return exists
+	queryParams := query.ParseRawQuery(r.URL.RawQuery)
+	_, prefixedExists := queryParams["$index"]
+	if prefixedExists {
+		return true
+	}
+
+	v := version.GetVersion(r.Context())
+	caseInsensitive := v.Major > 4 || (v.Major == 4 && v.Minor >= 1)
+	if !caseInsensitive {
+		return false
+	}
+
+	queryParams = query.NormalizeQueryParams(queryParams)
+	_, normalizedExists := queryParams["$index"]
+	return normalizedExists
 }
 
 // addIndexAnnotations adds @odata.index annotations to collection items

--- a/internal/response/collection_test.go
+++ b/internal/response/collection_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/nlstn/go-odata/internal/version"
 )
 
 func TestAddIndexAnnotationsAddsIndexesToMaps(t *testing.T) {
@@ -132,4 +134,22 @@ func TestWriteODataDeltaResponse(t *testing.T) {
 	if !ok || len(value) != 1 {
 		t.Fatalf("expected single entry in delta response")
 	}
+}
+
+func TestShouldAddIndexAnnotations_401Normalization(t *testing.T) {
+	t.Run("odata 4.01 accepts unprefixed index", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/Products?index=true", nil)
+		req = req.WithContext(version.WithVersion(req.Context(), version.Version{Major: 4, Minor: 1}))
+		if !shouldAddIndexAnnotations(req) {
+			t.Fatalf("expected unprefixed index to be recognized in OData 4.01")
+		}
+	})
+
+	t.Run("odata 4.0 requires prefixed index", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/Products?index=true", nil)
+		req = req.WithContext(version.WithVersion(req.Context(), version.Version{Major: 4, Minor: 0}))
+		if shouldAddIndexAnnotations(req) {
+			t.Fatalf("expected unprefixed index to be ignored in OData 4.0")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
Fix `$index` response annotation activation to honor OData 4.01 system query option normalization.

### Changes
- Update `$index` detection in collection response handling to parse/normalize query params under negotiated 4.01.
- Preserve strict 4.0 behavior.
- Add regression tests for:
  - 4.01 + `?index=true` -> enabled
  - 4.0 + `?index=true` -> disabled

## Validation
- `go test ./internal/response`