### PR TITLE
Fix nested divby/matchesPattern version gating for OData 4.0

### DIFF
--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -144,6 +144,30 @@ func usesDivByOperator(filter *query.FilterExpression) bool {
 	return usesDivByOperator(filter.Left) || usesDivByOperator(filter.Right)
 }
 
+func expandHasDivByOperator(expands []query.ExpandOption) bool {
+	for _, expand := range expands {
+		if usesDivByOperator(expand.Filter) {
+			return true
+		}
+		if expandHasDivByOperator(expand.Expand) {
+			return true
+		}
+	}
+	return false
+}
+
+func applyHasDivByOperator(apply []query.ApplyTransformation) bool {
+	for _, transform := range apply {
+		if usesDivByOperator(transform.Filter) {
+			return true
+		}
+		if transform.GroupBy != nil && applyHasDivByOperator(transform.GroupBy.Transform) {
+			return true
+		}
+	}
+	return false
+}
+
 func usesMatchesPattern(filter *query.FilterExpression) bool {
 	if filter == nil {
 		return false
@@ -155,6 +179,30 @@ func usesMatchesPattern(filter *query.FilterExpression) bool {
 		return true
 	}
 	return usesMatchesPattern(filter.Left) || usesMatchesPattern(filter.Right)
+}
+
+func expandHasMatchesPattern(expands []query.ExpandOption) bool {
+	for _, expand := range expands {
+		if usesMatchesPattern(expand.Filter) {
+			return true
+		}
+		if expandHasMatchesPattern(expand.Expand) {
+			return true
+		}
+	}
+	return false
+}
+
+func applyHasMatchesPattern(apply []query.ApplyTransformation) bool {
+	for _, transform := range apply {
+		if usesMatchesPattern(transform.Filter) {
+			return true
+		}
+		if transform.GroupBy != nil && applyHasMatchesPattern(transform.GroupBy.Transform) {
+			return true
+		}
+	}
+	return false
 }
 
 func expandHasCompute(expands []query.ExpandOption) bool {
@@ -214,12 +262,12 @@ func validateQueryOptionsForNegotiatedVersion(queryOptions *query.QueryOptions, 
 		return fmt.Errorf("invalid $filter: 'in' operator is not supported in OData %s", negotiated.String())
 	}
 
-	if usesDivByOperator(queryOptions.Filter) {
+	if usesDivByOperator(queryOptions.Filter) || expandHasDivByOperator(queryOptions.Expand) || applyHasDivByOperator(queryOptions.Apply) {
 		return fmt.Errorf("invalid $filter: 'divby' operator is not supported in OData %s", negotiated.String())
 	}
 
 	if !negotiated.Supports("matchespattern") {
-		if usesMatchesPattern(queryOptions.Filter) {
+		if usesMatchesPattern(queryOptions.Filter) || expandHasMatchesPattern(queryOptions.Expand) || applyHasMatchesPattern(queryOptions.Apply) {
 			return fmt.Errorf("invalid $filter: matchesPattern() is not supported in OData %s", negotiated.String())
 		}
 	}

--- a/internal/handlers/version_negotiation_test.go
+++ b/internal/handlers/version_negotiation_test.go
@@ -48,6 +48,42 @@ func TestValidateQueryOptionsForNegotiatedVersion_Rejects401FeaturesIn40(t *test
 	}
 }
 
+func TestValidateQueryOptionsForNegotiatedVersion_RejectsNestedDivByIn40(t *testing.T) {
+	opts := &query.QueryOptions{
+		Expand: []query.ExpandOption{
+			{
+				NavigationProperty: "Orders",
+				Filter: &query.FilterExpression{
+					Operator: query.OpDivBy,
+				},
+			},
+		},
+	}
+
+	err := validateQueryOptionsForNegotiatedVersion(opts, version.Version{Major: 4, Minor: 0})
+	if err == nil {
+		t.Fatalf("expected nested divby to be rejected for OData 4.0")
+	}
+}
+
+func TestValidateQueryOptionsForNegotiatedVersion_RejectsNestedMatchesPatternIn40(t *testing.T) {
+	opts := &query.QueryOptions{
+		Apply: []query.ApplyTransformation{
+			{
+				Type: query.ApplyTypeFilter,
+				Filter: &query.FilterExpression{
+					Operator: query.OpMatchesPattern,
+				},
+			},
+		},
+	}
+
+	err := validateQueryOptionsForNegotiatedVersion(opts, version.Version{Major: 4, Minor: 0})
+	if err == nil {
+		t.Fatalf("expected nested matchesPattern to be rejected for OData 4.0")
+	}
+}
+
 func TestValidateQueryOptionsForNegotiatedVersion_Allows401FeaturesIn401(t *testing.T) {
 	opts := &query.QueryOptions{
 		Filter:        &query.FilterExpression{Operator: query.OpIn},


### PR DESCRIPTION
## Summary
Close a version-gating gap where OData 4.01-only operators could be used in nested query structures while negotiating OData 4.0.

### Changes
- Extend 4.0 feature validation to recurse through nested `$expand` and `$apply` filters for:
  - `divby`
  - `matchesPattern()`
- Add regression tests that assert nested usage is rejected in OData 4.0.

## Validation
- `go test ./internal/handlers`