### PR TITLE
Refactor: decouple runtime storage via internal store + hook bridge

### DIFF
--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/nlstn/go-odata/internal/observability"
 	"github.com/nlstn/go-odata/internal/response"
+	"github.com/nlstn/go-odata/internal/storage"
+	"github.com/nlstn/go-odata/internal/storage/gormstore"
 	"github.com/nlstn/go-odata/internal/version"
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
@@ -30,6 +32,7 @@ import (
 // BatchHandler handles $batch requests for OData v4
 type BatchHandler struct {
 	db            *gorm.DB
+	store         storage.Store
 	handlers      map[string]*EntityHandler
 	service       http.Handler
 	logger        *slog.Logger
@@ -42,8 +45,17 @@ type BatchHandler struct {
 
 // NewBatchHandler creates a new batch handler
 func NewBatchHandler(db *gorm.DB, handlers map[string]*EntityHandler, service http.Handler, maxBatchSize int) *BatchHandler {
+	return NewBatchHandlerWithStore(gormstore.New(db), handlers, service, maxBatchSize)
+}
+
+// NewBatchHandlerWithStore creates a new batch handler with a storage backend.
+func NewBatchHandlerWithStore(store storage.Store, handlers map[string]*EntityHandler, service http.Handler, maxBatchSize int) *BatchHandler {
+	if store == nil {
+		store = gormstore.New(nil)
+	}
 	return &BatchHandler{
-		db:           db,
+		db:           store.DB(context.Background()),
+		store:        store,
 		handlers:     handlers,
 		service:      service,
 		logger:       slog.Default(),
@@ -287,10 +299,11 @@ func (h *BatchHandler) processChangeset(r io.Reader, boundary string, remainingC
 	responses := []batchResponse{}
 
 	// Start a transaction for the changeset
-	tx := h.db.Begin()
-	if tx.Error != nil {
+	txAdapter, err := h.store.Begin(parentReq.Context())
+	if err != nil {
 		return []batchResponse{h.createErrorResponse(http.StatusInternalServerError, "Failed to start transaction")}, false
 	}
+	tx := txAdapter.DB()
 
 	pendingEvents := make([]pendingChangeEvent, 0)
 
@@ -1000,8 +1013,8 @@ func (h *BatchHandler) handleJSONBatch(w http.ResponseWriter, r *http.Request) {
 
 			// Start a transaction for the group if this is the first request.
 			if gs.tx == nil {
-				tx := h.db.Begin()
-				if tx.Error != nil {
+				txAdapter, beginErr := h.store.Begin(r.Context())
+				if beginErr != nil {
 					gs.failed = true
 					failedIDs[item.ID] = true
 					errResp := jsonBatchResponseItem{
@@ -1016,7 +1029,7 @@ func (h *BatchHandler) handleJSONBatch(w http.ResponseWriter, r *http.Request) {
 					}
 					continue
 				}
-				gs.tx = tx
+				gs.tx = txAdapter.DB()
 			}
 
 			// Resolve $<id> content-ID URL references within the group.

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -14,6 +15,8 @@ import (
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/observability"
 	"github.com/nlstn/go-odata/internal/query"
+	"github.com/nlstn/go-odata/internal/storage"
+	"github.com/nlstn/go-odata/internal/storage/gormstore"
 	"github.com/nlstn/go-odata/internal/trackchanges"
 	"gorm.io/gorm"
 )
@@ -21,6 +24,7 @@ import (
 // EntityHandler handles HTTP requests for entity collections
 type EntityHandler struct {
 	db                   *gorm.DB
+	store                storage.Store
 	metadata             *metadata.EntityMetadata
 	entitiesMetadata     map[string]*metadata.EntityMetadata
 	namespace            string
@@ -63,11 +67,31 @@ func NewEntityHandler(db *gorm.DB, entityMetadata *metadata.EntityMetadata, logg
 	}
 	h := &EntityHandler{
 		db:        db,
+		store:     gormstore.New(db),
 		metadata:  entityMetadata,
 		namespace: defaultNamespace,
 		logger:    logger,
 	}
 	// Initialize property map for O(1) lookups
+	h.initPropertyMap()
+	return h
+}
+
+// NewEntityHandlerWithStore creates a new entity handler with a storage backend.
+func NewEntityHandlerWithStore(store storage.Store, entityMetadata *metadata.EntityMetadata, logger *slog.Logger) *EntityHandler {
+	if store == nil {
+		store = gormstore.New(nil)
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &EntityHandler{
+		db:        store.DB(context.Background()),
+		store:     store,
+		metadata:  entityMetadata,
+		namespace: defaultNamespace,
+		logger:    logger,
+	}
 	h.initPropertyMap()
 	return h
 }
@@ -363,7 +387,7 @@ func (h *EntityHandler) FetchEntity(entityKey string) (interface{}, error) {
 
 // IsNotFoundError checks if an error is a "not found" error
 func IsNotFoundError(err error) bool {
-	return err == gorm.ErrRecordNotFound
+	return errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, storage.ErrNotFound)
 }
 
 // entityMatchesType checks if an entity matches a given type name.

--- a/internal/handlers/hooks.go
+++ b/internal/handlers/hooks.go
@@ -111,7 +111,13 @@ func callHook(entity interface{}, methodName string, r *http.Request) error {
 
 // callBeforeReadCollection invokes the ODataBeforeReadCollection hook if defined and returns any scopes it produces.
 func callBeforeReadCollection(meta *metadata.EntityMetadata, r *http.Request, opts *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error) {
-	if meta == nil || !meta.Hooks.HasODataBeforeReadCollection {
+	if meta == nil {
+		return nil, nil
+	}
+	if invoked, err := invokeGenericBeforeReadHook(meta, "ODataBeforeReadCollectionGeneric", r, opts); invoked {
+		return nil, err
+	}
+	if !meta.Hooks.HasODataBeforeReadCollection {
 		return nil, nil
 	}
 
@@ -141,7 +147,13 @@ func callBeforeReadCollection(meta *metadata.EntityMetadata, r *http.Request, op
 
 // callAfterReadCollection invokes the ODataAfterReadCollection hook if defined and returns an override when provided.
 func callAfterReadCollection(meta *metadata.EntityMetadata, r *http.Request, opts *query.QueryOptions, results interface{}) (interface{}, bool, error) {
-	if meta == nil || !meta.Hooks.HasODataAfterReadCollection {
+	if meta == nil {
+		return nil, false, nil
+	}
+	if override, hasOverride, invoked, err := invokeGenericAfterReadHook(meta, "ODataAfterReadCollectionGeneric", r, opts, results); invoked {
+		return override, hasOverride, err
+	}
+	if !meta.Hooks.HasODataAfterReadCollection {
 		return nil, false, nil
 	}
 
@@ -175,7 +187,13 @@ func callAfterReadCollection(meta *metadata.EntityMetadata, r *http.Request, opt
 
 // callBeforeReadEntity invokes the ODataBeforeReadEntity hook if defined and returns any scopes it produces.
 func callBeforeReadEntity(meta *metadata.EntityMetadata, r *http.Request, opts *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error) {
-	if meta == nil || !meta.Hooks.HasODataBeforeReadEntity {
+	if meta == nil {
+		return nil, nil
+	}
+	if invoked, err := invokeGenericBeforeReadHook(meta, "ODataBeforeReadEntityGeneric", r, opts); invoked {
+		return nil, err
+	}
+	if !meta.Hooks.HasODataBeforeReadEntity {
 		return nil, nil
 	}
 
@@ -205,7 +223,13 @@ func callBeforeReadEntity(meta *metadata.EntityMetadata, r *http.Request, opts *
 
 // callAfterReadEntity invokes the ODataAfterReadEntity hook if defined and returns an override when provided.
 func callAfterReadEntity(meta *metadata.EntityMetadata, r *http.Request, opts *query.QueryOptions, entity interface{}) (interface{}, bool, error) {
-	if meta == nil || !meta.Hooks.HasODataAfterReadEntity {
+	if meta == nil {
+		return nil, false, nil
+	}
+	if override, hasOverride, invoked, err := invokeGenericAfterReadHook(meta, "ODataAfterReadEntityGeneric", r, opts, entity); invoked {
+		return override, hasOverride, err
+	}
+	if !meta.Hooks.HasODataAfterReadEntity {
 		return nil, false, nil
 	}
 
@@ -268,4 +292,46 @@ func callHookMethod(method reflect.Value, args ...interface{}) []reflect.Value {
 		callArgs[i] = reflect.ValueOf(arg)
 	}
 	return method.Call(callArgs)
+}
+
+func invokeGenericBeforeReadHook(meta *metadata.EntityMetadata, methodName string, r *http.Request, opts *query.QueryOptions) (bool, error) {
+	ctx := r.Context()
+	results, ok := invokeReadHook(meta, methodName, ctx, r, opts)
+	if !ok {
+		return false, nil
+	}
+	if len(results) > 0 {
+		if errVal := results[0]; errVal.IsValid() && !errVal.IsNil() {
+			if err, ok := errVal.Interface().(error); ok && err != nil {
+				return true, err
+			}
+		}
+	}
+	return true, nil
+}
+
+func invokeGenericAfterReadHook(meta *metadata.EntityMetadata, methodName string, r *http.Request, opts *query.QueryOptions, payload interface{}) (interface{}, bool, bool, error) {
+	ctx := r.Context()
+	results, ok := invokeReadHook(meta, methodName, ctx, r, opts, payload)
+	if !ok {
+		return nil, false, false, nil
+	}
+
+	overrideProvided := false
+	var override interface{}
+	if len(results) > 0 {
+		first := results[0]
+		if first.IsValid() && (first.Kind() != reflect.Interface || !first.IsNil()) {
+			override = first.Interface()
+			overrideProvided = true
+		}
+	}
+	if len(results) > 1 {
+		if errVal := results[1]; errVal.IsValid() && !errVal.IsNil() {
+			if err, ok := errVal.Interface().(error); ok && err != nil {
+				return nil, false, true, err
+			}
+		}
+	}
+	return override, overrideProvided, true, nil
 }

--- a/internal/handlers/hooks_test.go
+++ b/internal/handlers/hooks_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/query"
+	"gorm.io/gorm"
 )
 
 // HookedTestEntity is a test entity with hooks
@@ -282,6 +284,51 @@ func TestCallBeforeDelete(t *testing.T) {
 				t.Errorf("callBeforeDelete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+type genericReadHookEntity struct {
+	ID int `odata:"key"`
+}
+
+func (genericReadHookEntity) ODataBeforeReadCollectionGeneric(ctx context.Context, r *http.Request, opts *query.QueryOptions) error {
+	return errors.New("generic-before-collection")
+}
+func (genericReadHookEntity) ODataBeforeReadCollection(ctx context.Context, r *http.Request, opts *query.QueryOptions) ([]func(*gorm.DB) *gorm.DB, error) {
+	return []func(*gorm.DB) *gorm.DB{func(db *gorm.DB) *gorm.DB { return db }}, nil
+}
+func (genericReadHookEntity) ODataAfterReadEntityGeneric(ctx context.Context, r *http.Request, opts *query.QueryOptions, entity interface{}) (interface{}, error) {
+	return map[string]interface{}{"source": "generic"}, nil
+}
+func (genericReadHookEntity) ODataAfterReadEntity(ctx context.Context, r *http.Request, opts *query.QueryOptions, entity interface{}) (interface{}, error) {
+	return map[string]interface{}{"source": "legacy"}, nil
+}
+
+func TestGenericReadHookPrecedence(t *testing.T) {
+	meta, err := metadata.AnalyzeEntity(genericReadHookEntity{})
+	if err != nil {
+		t.Fatalf("analyze metadata: %v", err)
+	}
+	meta.Hooks.HasODataBeforeReadCollection = true
+	meta.Hooks.HasODataAfterReadEntity = true
+
+	req := httptest.NewRequest(http.MethodGet, "/any", nil)
+
+	_, beforeErr := callBeforeReadCollection(meta, req, &query.QueryOptions{})
+	if beforeErr == nil || beforeErr.Error() != "generic-before-collection" {
+		t.Fatalf("expected generic before hook error, got %v", beforeErr)
+	}
+
+	override, ok, afterErr := callAfterReadEntity(meta, req, &query.QueryOptions{}, map[string]interface{}{"id": 1})
+	if afterErr != nil {
+		t.Fatalf("unexpected error: %v", afterErr)
+	}
+	if !ok {
+		t.Fatal("expected override")
+	}
+	result, castOK := override.(map[string]interface{})
+	if !castOK || result["source"] != "generic" {
+		t.Fatalf("expected generic override, got %#v", override)
 	}
 }
 

--- a/internal/handlers/transaction.go
+++ b/internal/handlers/transaction.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/nlstn/go-odata/internal/storage"
 	"github.com/nlstn/go-odata/internal/trackchanges"
 	"gorm.io/gorm"
 )
@@ -55,8 +56,15 @@ func (h *EntityHandler) runInTransaction(ctx context.Context, r *http.Request, f
 		return fn(tx, requestWithTransaction(r, tx))
 	}
 
-	return h.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return fn(tx, requestWithTransaction(r, tx))
+	if h.store == nil {
+		return h.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			return fn(tx, requestWithTransaction(r, tx))
+		})
+	}
+
+	return h.store.Transaction(ctx, func(tx storage.Tx) error {
+		txDB := tx.DB()
+		return fn(txDB, requestWithTransaction(r, txDB))
 	})
 }
 

--- a/internal/storage/gormstore/store.go
+++ b/internal/storage/gormstore/store.go
@@ -1,0 +1,63 @@
+package gormstore
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nlstn/go-odata/internal/storage"
+	"gorm.io/gorm"
+)
+
+type gormTx struct {
+	tx *gorm.DB
+}
+
+func (t *gormTx) DB() *gorm.DB    { return t.tx }
+func (t *gormTx) Commit() error   { return t.tx.Commit().Error }
+func (t *gormTx) Rollback() error { return t.tx.Rollback().Error }
+
+// Store is the default storage adapter backed by GORM.
+type Store struct {
+	db *gorm.DB
+}
+
+func New(db *gorm.DB) *Store {
+	return &Store{db: db}
+}
+
+func (s *Store) DB(ctx context.Context) *gorm.DB {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.WithContext(ctx)
+}
+
+func (s *Store) Transaction(ctx context.Context, fn func(tx storage.Tx) error) error {
+	return s.DB(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(&gormTx{tx: tx})
+	})
+}
+
+func (s *Store) Begin(ctx context.Context) (storage.Tx, error) {
+	tx := s.DB(ctx).Begin()
+	if tx.Error != nil {
+		return nil, tx.Error
+	}
+	return &gormTx{tx: tx}, nil
+}
+
+func (s *Store) IsNotFound(err error) bool {
+	return errors.Is(err, storage.ErrNotFound) || errors.Is(err, gorm.ErrRecordNotFound)
+}
+
+func (s *Store) MapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return storage.ErrNotFound
+	}
+	return err
+}
+
+func (s *Store) SupportsGORM() bool { return true }

--- a/internal/storage/gormstore/store_test.go
+++ b/internal/storage/gormstore/store_test.go
@@ -1,0 +1,73 @@
+package gormstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/storage"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type txTestEntity struct {
+	ID   int `gorm:"primaryKey"`
+	Name string
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&txTestEntity{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return New(db)
+}
+
+func TestStoreTransactionCommitAndRollback(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("commit", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.Transaction(ctx, func(tx storage.Tx) error {
+			return tx.DB().Create(&txTestEntity{ID: 1, Name: "ok"}).Error
+		}); err != nil {
+			t.Fatalf("transaction: %v", err)
+		}
+		var count int64
+		if err := s.DB(ctx).Model(&txTestEntity{}).Where("id = ?", 1).Count(&count).Error; err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("expected 1 row, got %d", count)
+		}
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		s := newTestStore(t)
+		_ = s.Transaction(ctx, func(tx storage.Tx) error {
+			if err := tx.DB().Create(&txTestEntity{ID: 2, Name: "rollback"}).Error; err != nil {
+				return err
+			}
+			return errors.New("force rollback")
+		})
+		var count int64
+		if err := s.DB(ctx).Model(&txTestEntity{}).Where("id = ?", 2).Count(&count).Error; err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("expected 0 rows after rollback, got %d", count)
+		}
+	})
+}
+
+func TestStoreMapErrorNotFound(t *testing.T) {
+	s := New(nil)
+	mapped := s.MapError(gorm.ErrRecordNotFound)
+	if !errors.Is(mapped, storage.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound mapping, got %v", mapped)
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+var (
+	// ErrNotFound indicates a requested record does not exist.
+	ErrNotFound = errors.New("storage: not found")
+)
+
+// Query describes parsed OData query intent passed to a storage backend.
+// This is intentionally minimal in the first decoupling phase.
+type Query struct {
+	Options interface{}
+}
+
+// Tx represents an active storage transaction.
+type Tx interface {
+	DB() *gorm.DB
+	Commit() error
+	Rollback() error
+}
+
+// Store provides the storage contract consumed by runtime handlers.
+type Store interface {
+	DB(ctx context.Context) *gorm.DB
+	Transaction(ctx context.Context, fn func(tx Tx) error) error
+	Begin(ctx context.Context) (Tx, error)
+	IsNotFound(err error) bool
+	MapError(err error) error
+	SupportsGORM() bool
+}

--- a/odata.go
+++ b/odata.go
@@ -67,6 +67,8 @@ import (
 	"github.com/nlstn/go-odata/internal/service/operations"
 	servrouter "github.com/nlstn/go-odata/internal/service/router"
 	servruntime "github.com/nlstn/go-odata/internal/service/runtime"
+	"github.com/nlstn/go-odata/internal/storage"
+	"github.com/nlstn/go-odata/internal/storage/gormstore"
 	"github.com/nlstn/go-odata/internal/trackchanges"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -283,24 +285,37 @@ type EntityHook interface {
 //	Delete: ODataBeforeDelete -> DELETE -> ODataAfterDelete
 //	Read:   ODataBeforeReadCollection/ODataBeforeReadEntity -> SELECT + OData options -> ODataAfterReadCollection/ODataAfterReadEntity
 type ReadHook interface {
+	// Deprecated: prefer storage-agnostic hook methods (see ReadHookGeneric).
 	// ODataBeforeReadCollection is called before fetching a collection.
 	// Return GORM scopes to apply before OData options ($filter, $orderby, etc).
 	// These scopes are ideal for authorization filters and eager-loading.
 	ODataBeforeReadCollection(ctx context.Context, r *http.Request, opts *QueryOptions) ([]func(*gorm.DB) *gorm.DB, error)
 
+	// Deprecated: prefer storage-agnostic hook methods (see ReadHookGeneric).
 	// ODataAfterReadCollection is called after fetching a collection.
 	// It receives the results after all query processing and can redact or transform them.
 	// Return nil, nil to keep the original response.
 	ODataAfterReadCollection(ctx context.Context, r *http.Request, opts *QueryOptions, results interface{}) (interface{}, error)
 
+	// Deprecated: prefer storage-agnostic hook methods (see ReadHookGeneric).
 	// ODataBeforeReadEntity is called before fetching a single entity.
 	// Return GORM scopes to apply before OData options. Ideal for authorization and eager-loading.
 	ODataBeforeReadEntity(ctx context.Context, r *http.Request, opts *QueryOptions) ([]func(*gorm.DB) *gorm.DB, error)
 
+	// Deprecated: prefer storage-agnostic hook methods (see ReadHookGeneric).
 	// ODataAfterReadEntity is called after fetching a single entity.
 	// It receives the entity after all query processing and can redact or transform it.
 	// Return nil, nil to keep the original response.
 	ODataAfterReadEntity(ctx context.Context, r *http.Request, opts *QueryOptions, entity interface{}) (interface{}, error)
+}
+
+// ReadHookGeneric defines storage-agnostic optional read hooks.
+// When both generic and legacy GORM read hooks are implemented, generic hooks take precedence.
+type ReadHookGeneric interface {
+	ODataBeforeReadCollectionGeneric(ctx context.Context, r *http.Request, opts *QueryOptions) error
+	ODataAfterReadCollectionGeneric(ctx context.Context, r *http.Request, opts *QueryOptions, results interface{}) (interface{}, error)
+	ODataBeforeReadEntityGeneric(ctx context.Context, r *http.Request, opts *QueryOptions) error
+	ODataAfterReadEntityGeneric(ctx context.Context, r *http.Request, opts *QueryOptions, entity interface{}) (interface{}, error)
 }
 
 // CacheLevel controls whether and how an entity's data is cached in memory.
@@ -380,6 +395,8 @@ const (
 type Service struct {
 	// db holds the GORM database connection
 	db *gorm.DB
+	// store holds the internal storage backend abstraction
+	store storage.Store
 	// entities holds registered entity metadata keyed by entity set name
 	entities map[string]*metadata.EntityMetadata
 	// entityContainerAnnotations holds annotations applied to the entity container
@@ -503,6 +520,7 @@ func NewServiceWithConfig(db *gorm.DB, cfg ServiceConfig) (*Service, error) {
 
 	s := &Service{
 		db:                         db,
+		store:                      gormstore.New(db),
 		entities:                   entities,
 		entityContainerAnnotations: metadata.NewAnnotationCollection(),
 		handlers:                   handlersMap,
@@ -526,7 +544,7 @@ func NewServiceWithConfig(db *gorm.DB, cfg ServiceConfig) (*Service, error) {
 	s.serviceDocumentHandler.SetPolicy(s.policy)
 	s.operationsHandler = operations.NewHandler(s.actions, s.functions, s.handlers, s.entities, s.namespace, logger)
 	// Initialize batch handler with reference to service's internal handler (for changesets)
-	s.batchHandler = handlers.NewBatchHandler(db, handlersMap, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	s.batchHandler = handlers.NewBatchHandlerWithStore(s.store, handlersMap, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.serveHTTP(w, r, false)
 	}), maxBatchSize)
 	s.router = servrouter.NewRouter(
@@ -1017,7 +1035,7 @@ func (s *Service) RegisterEntity(entity interface{}, cacheConfigs ...EntityCache
 	}
 
 	// Create and store the handler
-	handler := handlers.NewEntityHandler(s.db, entityMetadata, s.logger)
+	handler := handlers.NewEntityHandlerWithStore(s.store, entityMetadata, s.logger)
 	handler.SetNamespace(s.namespace)
 	handler.SetEntitiesMetadata(s.entities)
 	handler.SetDeltaTracker(s.deltaTracker)
@@ -1143,7 +1161,7 @@ func (s *Service) RegisterSingleton(entity interface{}, singletonName string) er
 	}
 
 	// Create and store the handler (same handler type works for both entities and singletons)
-	handler := handlers.NewEntityHandler(s.db, singletonMetadata, s.logger)
+	handler := handlers.NewEntityHandlerWithStore(s.store, singletonMetadata, s.logger)
 	handler.SetNamespace(s.namespace)
 	handler.SetEntitiesMetadata(s.entities)
 	handler.SetFTSManager(s.ftsManager)
@@ -1234,7 +1252,7 @@ func (s *Service) RegisterVirtualEntity(entity interface{}) error {
 	}
 
 	// Create and store the handler (no database operations will be performed)
-	handler := handlers.NewEntityHandler(s.db, entityMetadata, s.logger)
+	handler := handlers.NewEntityHandlerWithStore(s.store, entityMetadata, s.logger)
 	handler.SetNamespace(s.namespace)
 	handler.SetEntitiesMetadata(s.entities)
 	handler.SetFTSManager(s.ftsManager)

--- a/transaction_context.go
+++ b/transaction_context.go
@@ -8,6 +8,7 @@ import (
 )
 
 // TransactionFromContext returns the active *gorm.DB transaction stored for hook execution.
+// Deprecated: this helper is GORM-specific; prefer storage-agnostic hook patterns.
 // Hooks invoked by the entity and collection write handlers can opt into the shared
 // transaction by calling this helper with the context they receive.
 func TransactionFromContext(ctx context.Context) (*gorm.DB, bool) {


### PR DESCRIPTION
## Summary
- introduce internal storage contracts (`internal/storage`) and a GORM-backed adapter (`internal/storage/gormstore`)
- wire `Service` and batch/entity handlers to use the internal store while keeping current public constructors compatible
- route transactional handler flow through the store abstraction
- add storage-agnostic read-hook bridge methods with precedence over legacy GORM read hooks
- keep legacy hook and transaction surfaces functional; add deprecation notes for GORM-specific transaction helper
- add adapter tests for commit/rollback and not-found mapping, plus hook precedence coverage

## Validation
- `go test ./...`
- `go build ./...`
- `cd compliance-suite && go run .`

## Notes
- `golangci-lint` was not available in the execution environment (`command not found`), so linting could not be run in this session.