### PR TITLE
Potential fix for code scanning alert no. 32: Reflected cross-site scripting

### DIFF
--- a/internal/response/format_helpers.go
+++ b/internal/response/format_helpers.go
@@ -3,6 +3,7 @@ package response
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -409,12 +410,14 @@ func buildBaseURL(r *http.Request) string {
 		scheme = "https"
 	}
 
-	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+	if proto := strings.ToLower(strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))); proto == "http" || proto == "https" {
 		scheme = proto
 	}
 
-	host := r.Host
+	host := strings.TrimSpace(r.Host)
 	if host == "" {
+		host = "localhost:8080"
+	} else if parsed, err := url.Parse("http://" + host); err != nil || parsed.Host == "" || parsed.Host != host {
 		host = "localhost:8080"
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/NLstn/go-odata/security/code-scanning/32](https://github.com/NLstn/go-odata/security/code-scanning/32)

The best fix is to sanitize/validate request-derived URL components at construction time in `internal/response/format_helpers.go`, specifically in `buildBaseURL`. Do not trust raw `X-Forwarded-Proto` or `Host`; instead:

- allow only `http`/`https` for scheme (case-insensitive),
- normalize and validate host via `net/url` parsing (using a synthetic URL),
- fallback to safe defaults when invalid (`http` and `localhost:8080`).

This preserves existing behavior (still building absolute links) while preventing attacker-controlled header/path tricks from being reflected verbatim into response payloads. Because all reported variants flow through `buildBaseURL` / URL link builders, this single source fix addresses them together without changing handler/runtime logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
