### PR TITLE
Reject empty in-list expressions (OData 4.01)

### DIFF
--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -263,6 +263,11 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 			return nil, errInOperatorRequiresCollection
 		}
 
+		// Reject empty in-list: OData 4.01 ABNF requires at least one item
+		if len(collExpr.Values) == 0 {
+			return nil, errEmptyInList
+		}
+
 		// Extract values from collection
 		values := make([]interface{}, len(collExpr.Values))
 		for i, valueNode := range collExpr.Values {

--- a/internal/query/errors.go
+++ b/internal/query/errors.go
@@ -102,6 +102,7 @@ var (
 	// Collection errors
 	errCollectionValuesMustBeLiterals = errors.New("collection values must be literals")
 	errInOperatorRequiresCollection   = errors.New("'in' operator requires a collection on the right side")
+	errEmptyInList                    = errors.New("'in' operator requires a non-empty list")
 
 	// FTS errors
 	errFTSNotAvailable = errors.New("FTS is not available")

--- a/internal/query/in_operator_test.go
+++ b/internal/query/in_operator_test.go
@@ -28,9 +28,9 @@ func TestInOperator_Basic(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "in operator with empty collection - should parse",
+			name:      "in operator with empty collection - should be rejected",
 			filter:    "Category in ()",
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name:      "in operator with float values",
@@ -190,11 +190,9 @@ func TestInOperator_SQLGeneration(t *testing.T) {
 			expectErr:    false,
 		},
 		{
-			name:         "in operator with empty collection",
-			filter:       "Category in ()",
-			expectedSQL:  "1 = 0",
-			expectedArgs: 0,
-			expectErr:    false,
+			name:      "in operator with empty collection - should be rejected",
+			filter:    "Category in ()",
+			expectErr: true,
 		},
 	}
 
@@ -319,7 +317,7 @@ func TestInOperator_ValueValidation(t *testing.T) {
 			}
 
 			// Verify at least one value
-			if len(values) == 0 && tt.filter != "Category in ()" {
+			if len(values) == 0 {
 				t.Error("Expected at least one value in collection")
 			}
 		})

--- a/test/security_limits_test.go
+++ b/test/security_limits_test.go
@@ -72,15 +72,15 @@ func TestMaxInClauseSize(t *testing.T) {
 		}
 	})
 
-	// Test case 3: Empty IN clause should still work
+	// Test case 3: Empty IN clause must be rejected (OData 4.01 ABNF requires non-empty list)
 	t.Run("EmptyIN", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/TestSecurityEntities?$filter=ID%20in%20()", nil)
 		w := httptest.NewRecorder()
 		service.ServeHTTP(w, req)
 
-		// Empty IN clause is valid (returns no results)
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+		// Empty IN clause is invalid per OData 4.01 spec
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d. Body: %s", w.Code, w.Body.String())
 		}
 	})
 }


### PR DESCRIPTION
Fixes #715

## Summary

`$filter=Name in ()` now returns `400 Bad Request` instead of `200 OK` with an empty result.

## Changes

- **`internal/query/errors.go`**: Added `errEmptyInList` error constant.
- **`internal/query/ast_parser_validation.go`**: After parsing the collection for an `in` expression, reject empty lists immediately with the new error.
- **`internal/query/in_operator_test.go`**: Updated the empty-collection test cases to expect an error (was `expectErr: false`).
- **`test/security_limits_test.go`**: Updated the `EmptyIN` sub-test to assert `400` instead of `200`.

## Why

The OData 4.01 ABNF requires at least one item in an in-list expression. Accepting `in ()` silently and returning an empty result set is non-compliant — the request should be rejected at parse/validation time.