### PR TITLE
Fix MSSQL compliance workflow cache restore conflict

### DIFF
--- a/.github/workflows/mssql-compliance.yml
+++ b/.github/workflows/mssql-compliance.yml
@@ -49,16 +49,6 @@ jobs:
       with:
         go-version: '1.25'
 
-    - name: Cache Go modules
-      uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.25-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-1.25-
-
     - name: Create test database
       run: |
         docker exec "${{ job.services.mssql.id }}" /opt/mssql-tools18/bin/sqlcmd \


### PR DESCRIPTION
## Summary
- remove explicit `actions/cache@v5` step from MSSQL compliance workflow
- rely on `actions/setup-go@v6` built-in Go module/build cache
- prevent duplicate cache extraction that failed with `tar: ... Cannot open: File exists`

## Why
`actions/setup-go` already restored `~/go/pkg/mod` and `~/.cache/go-build`. The additional `actions/cache` step attempted to restore the same paths again, causing the job to fail before compliance tests ran.