### PR TITLE
Fix 'has' operator failing on enum value literals (Namespace.TypeName'Member')

### DIFF
--- a/internal/query/ast_parser_arithmetic.go
+++ b/internal/query/ast_parser_arithmetic.go
@@ -175,6 +175,12 @@ func (p *ASTParser) parseLiteral(token *Token) ASTNode {
 		expr.Value = token.Value
 		expr.Type = "guid"
 		return expr
+	case TokenEnumValue:
+		p.advance()
+		expr := AcquireLiteralExpr()
+		expr.Value = token.Value // full literal, e.g. "Namespace.TypeName'MemberName'"
+		expr.Type = "enum"
+		return expr
 	default:
 		return nil
 	}

--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -3,6 +3,7 @@ package query
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/nlstn/go-odata/internal/metadata"
 )
@@ -309,6 +310,15 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 		return nil, err
 	}
 
+	// Resolve enum value literals (e.g. Namespace.TypeName'MemberName') to their numeric value
+	if enumLit, ok := n.Right.(*LiteralExpr); ok && enumLit.Type == "enum" {
+		resolved, err := resolveEnumMemberName(enumLit.Value.(string), property, entityMetadata)
+		if err != nil {
+			return nil, err
+		}
+		value = resolved
+	}
+
 	// Validate numeric value against numeric property
 	// Check for Int64 overflow
 	// Per OData v4 spec, numeric literals that overflow the target integer type should be rejected
@@ -323,6 +333,34 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 	expr.Operator = FilterOperator(n.Operator)
 	expr.Value = value
 	return expr, nil
+}
+
+// resolveEnumMemberName resolves an OData enum value literal such as
+// "Namespace.TypeName'MemberName'" to the int64 value of the named member
+// by looking it up in the property's registered enum members.
+func resolveEnumMemberName(enumLiteral string, property string, entityMetadata *metadata.EntityMetadata) (int64, error) {
+	start := strings.Index(enumLiteral, "'")
+	if start < 0 || !strings.HasSuffix(enumLiteral, "'") {
+		return 0, fmt.Errorf("invalid enum value literal: %s", enumLiteral)
+	}
+	memberName := enumLiteral[start+1 : len(enumLiteral)-1]
+
+	if entityMetadata == nil {
+		return 0, fmt.Errorf("cannot resolve enum member %q: no entity metadata available", memberName)
+	}
+
+	prop := entityMetadata.FindProperty(property)
+	if prop == nil {
+		return 0, fmt.Errorf("property %q not found in entity metadata", property)
+	}
+
+	for _, member := range prop.EnumMembers {
+		if strings.EqualFold(member.Name, memberName) {
+			return member.Value, nil
+		}
+	}
+
+	return 0, fmt.Errorf("enum member %q not found for property %q", memberName, property)
 }
 
 // validateValueAgainstPropertyType validates that a filter value is appropriate for the target property type.

--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -312,7 +312,11 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 
 	// Resolve enum value literals (e.g. Namespace.TypeName'MemberName') to their numeric value
 	if enumLit, ok := n.Right.(*LiteralExpr); ok && enumLit.Type == "enum" {
-		resolved, err := resolveEnumMemberName(enumLit.Value.(string), property, entityMetadata)
+		strVal, ok := enumLit.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("internal error: enum literal has non-string value %T", enumLit.Value)
+		}
+		resolved, err := resolveEnumMemberName(strVal, property, entityMetadata)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/query/has_function_test.go
+++ b/internal/query/has_function_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/nlstn/go-odata/internal/metadata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestHasFunction(t *testing.T) {
@@ -99,6 +101,148 @@ func TestHasFunctionSQLGeneration(t *testing.T) {
 
 	if args[0] != int64(1) || args[1] != int64(1) {
 		t.Errorf("Expected args [1, 1], got %v", args)
+	}
+}
+
+// TestHasEnumValueLiteral verifies that the OData enum value literal syntax
+// (Namespace.TypeName'MemberName') works correctly with the has operator.
+func TestHasEnumValueLiteral(t *testing.T) {
+	entityMeta := &metadata.EntityMetadata{
+		EntityName: "Product",
+		Properties: []metadata.PropertyMetadata{
+			{
+				Name:      "Status",
+				FieldName: "Status",
+				JsonName:  "Status",
+				IsEnum:    true,
+				IsFlags:   true,
+				EnumMembers: []metadata.EnumMember{
+					{Name: "None", Value: 0},
+					{Name: "InStock", Value: 1},
+					{Name: "OnSale", Value: 2},
+					{Name: "Discontinued", Value: 4},
+					{Name: "Featured", Value: 8},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		filter        string
+		wantValue     int64
+		wantErr       bool
+	}{
+		{
+			name:      "qualified enum literal with has infix",
+			filter:    "Status has MyService.ProductStatus'Featured'",
+			wantValue: 8,
+		},
+		{
+			name:      "qualified enum literal — case-insensitive member name",
+			filter:    "Status has MyService.ProductStatus'featured'",
+			wantValue: 8,
+		},
+		{
+			name:      "qualified enum literal — InStock",
+			filter:    "Status has MyService.ProductStatus'InStock'",
+			wantValue: 1,
+		},
+		{
+			name:    "unknown member name returns error",
+			filter:  "Status has MyService.ProductStatus'Unknown'",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := parseFilter(tt.filter, entityMeta, nil, 0)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got none (filter=%v)", filter)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if filter.Operator != OpHas {
+				t.Errorf("expected OpHas, got %s", filter.Operator)
+			}
+			if filter.Value != tt.wantValue {
+				t.Errorf("expected value %d, got %v", tt.wantValue, filter.Value)
+			}
+		})
+	}
+}
+
+// TestHasEnumValueLiteralSQL verifies end-to-end that enum value literals produce
+// the correct bitwise SQL and match the right rows in SQLite.
+func TestHasEnumValueLiteralSQL(t *testing.T) {
+	type Product struct {
+		ID     int    `gorm:"primaryKey"`
+		Name   string `gorm:"column:name"`
+		Status int    `gorm:"column:status"`
+	}
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&Product{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Status values: InStock=1, OnSale=2, Discontinued=4, Featured=8
+	products := []Product{
+		{ID: 1, Name: "Normal", Status: 1},        // InStock
+		{ID: 2, Name: "Sale", Status: 3},           // InStock|OnSale
+		{ID: 3, Name: "Featured", Status: 9},       // InStock|Featured
+		{ID: 4, Name: "FeaturedSale", Status: 11},  // InStock|OnSale|Featured
+		{ID: 5, Name: "Discontinued", Status: 4},   // Discontinued
+	}
+	if err := db.Create(&products).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	meta := &metadata.EntityMetadata{
+		EntityName: "Product",
+		Properties: []metadata.PropertyMetadata{
+			{Name: "ID", FieldName: "ID", JsonName: "ID", ColumnName: "id"},
+			{Name: "Name", FieldName: "Name", JsonName: "Name", ColumnName: "name"},
+			{
+				Name:       "Status",
+				FieldName:  "Status",
+				JsonName:   "Status",
+				ColumnName: "status",
+				IsEnum:     true,
+				IsFlags:    true,
+				EnumMembers: []metadata.EnumMember{
+					{Name: "InStock", Value: 1},
+					{Name: "OnSale", Value: 2},
+					{Name: "Discontinued", Value: 4},
+					{Name: "Featured", Value: 8},
+				},
+			},
+		},
+	}
+
+	filterExpr, err := parseFilter("Status has Svc.ProductStatus'Featured'", meta, nil, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&Product{}).Scopes(func(d *gorm.DB) *gorm.DB {
+		return ApplyFilterOnly(d, filterExpr, meta, nil)
+	}).Count(&count).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	// Products 3 and 4 have the Featured bit set
+	if count != 2 {
+		t.Errorf("expected 2 products with Featured flag, got %d", count)
 	}
 }
 

--- a/internal/query/tokenizer.go
+++ b/internal/query/tokenizer.go
@@ -29,6 +29,7 @@ const (
 	TokenTime
 	TokenDateTime
 	TokenGUID
+	TokenEnumValue // OData enum value literal: Namespace.TypeName'MemberName'
 )
 
 // Token represents a single token in the filter expression
@@ -678,6 +679,16 @@ func (t *Tokenizer) tokenizeIdentifierOrKeyword(pos int) *Token {
 	}
 
 	value := t.readIdentifier()
+
+	// OData enum value literal: Namespace.TypeName'MemberName' (OData v4 §4.3)
+	// Qualified enum type names always contain a dot (e.g. "MyService.Status"),
+	// so we only merge identifier+'quoted' when the identifier has a dot.
+	// This avoids colliding with OData typed-literal prefixes like duration'P1D'
+	// or binary'...' which are plain keywords without dots.
+	if t.ch == '\'' && strings.ContainsRune(value, '.') {
+		memberName := t.readString()
+		return t.getToken(TokenEnumValue, value+"'"+memberName+"'", pos)
+	}
 
 	// Check for arithmetic functions: add, sub, mul, div, mod can be either
 	// functions (when followed by '(') or infix operators


### PR DESCRIPTION
## Summary

- `$filter=Status has ComplianceService.ProductStatus'Featured'` returned HTTP 400 with "unexpected token after expression" because the tokenizer split `ComplianceService.ProductStatus'Featured'` into an identifier and a string literal with no operator between them
- Added `TokenEnumValue` — when the tokenizer reads an identifier containing a dot and the next character is `'`, it consumes the quoted member name and emits a single token. The dot requirement avoids colliding with OData typed-literal prefixes (`duration'P1D'`, `binary'...'`) which are plain keywords without dots
- The AST parser materializes `TokenEnumValue` as a `LiteralExpr{Type: "enum"}` holding the full literal string
- During AST-to-`FilterExpression` conversion, "enum" literals are resolved to their `int64` numeric value by looking up the member name (case-insensitively) in the target property's `EnumMembers` — the same member list used for `$metadata` generation
- The existing SQL generation for `OpHas` (`(col & ?) = ?`) requires no changes

Fixes #723

## Test plan

- [ ] `TestHasEnumValueLiteral` — parse-level tests: qualified enum literal resolves to correct `int64` value, unknown members return an error, case-insensitive lookup works
- [ ] `TestHasEnumValueLiteralSQL` — integration test against in-memory SQLite: seeds 5 products with various flag combinations, asserts only the 2 with the `Featured` bit set are returned
- [ ] `TestTokenizer/Duration_prefixed_literal` and `TestTokenizer/Binary_prefixed_literal` — existing tests confirming `duration'P1D'` / `binary'...'` are still tokenized as before (not merged into `TokenEnumValue`)
- [ ] `TestASTParser_LiteralTyping/Duration_prefixed_literal` and `/Binary_prefixed_literal` — same guards at the AST level
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)