### PR TITLE
Fix #729: add Allow header to all 405 Method Not Allowed responses

### DIFF
--- a/internal/async/manager.go
+++ b/internal/async/manager.go
@@ -485,6 +485,7 @@ func (m *Manager) ServeMonitor(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet, http.MethodHead, "":
 		// continue
 	default:
+		w.Header().Set("Allow", "GET, HEAD, DELETE")
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}

--- a/internal/handlers/action_function.go
+++ b/internal/handlers/action_function.go
@@ -39,7 +39,7 @@ func (h *ActionFunctionHandler) HandleActionOrFunction(w http.ResponseWriter, r 
 		// Functions are invoked with GET
 		h.handleFunction(w, r, name, key, isBound)
 	default:
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, "Method not allowed",
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, POST, OPTIONS", "Method not allowed",
 			fmt.Sprintf("Method %s is not allowed for actions or functions", r.Method)); err != nil {
 			slog.Default().Error("Error writing error response", "error", err)
 		}

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -157,7 +157,7 @@ func (h *BatchHandler) HandleBatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method != http.MethodPost {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, "Method not allowed",
+		if err := response.WriteMethodNotAllowed(w, r, "POST, OPTIONS", "Method not allowed",
 			"Only POST method is supported for $batch requests"); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -618,7 +618,7 @@ func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.D
 			}
 			return
 		case "$batch":
-			if err := response.WriteError(w, r, http.StatusMethodNotAllowed, "Method not allowed",
+			if err := response.WriteMethodNotAllowed(w, r, "POST, OPTIONS", "Method not allowed",
 				"Nested $batch requests are not supported within transactional batch requests"); err != nil {
 				h.logger.Error("Error writing error response", "error", err)
 			}

--- a/internal/handlers/collection.go
+++ b/internal/handlers/collection.go
@@ -26,7 +26,7 @@ func (h *EntityHandler) HandleCollection(w http.ResponseWriter, r *http.Request)
 		methodToCheck = http.MethodGet
 	}
 	if h.isMethodDisabled(methodToCheck) {
-		WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		WriteMethodNotAllowed(w, r, h.allowedMethods([]string{"GET", "HEAD", "POST"}), ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not allowed for this entity", r.Method))
 		return
 	}
@@ -45,7 +45,7 @@ func (h *EntityHandler) HandleCollection(w http.ResponseWriter, r *http.Request)
 		}
 		h.handleOptionsCollection(w)
 	default:
-		WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		WriteMethodNotAllowed(w, r, "GET, HEAD, POST, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for entity collections", r.Method))
 	}
 }
@@ -70,7 +70,7 @@ func (h *EntityHandler) HandleCount(w http.ResponseWriter, r *http.Request) {
 	// Check if GET method is disabled (applies to both GET and HEAD)
 	if r.Method == http.MethodGet || r.Method == http.MethodHead {
 		if h.isMethodDisabled(http.MethodGet) {
-			WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+			WriteMethodNotAllowed(w, r, h.allowedMethods([]string{"GET", "HEAD"}), ErrMsgMethodNotAllowed,
 				fmt.Sprintf("Method %s is not allowed for this entity", r.Method))
 			return
 		}
@@ -88,7 +88,7 @@ func (h *EntityHandler) HandleCount(w http.ResponseWriter, r *http.Request) {
 		}
 		h.handleOptionsCount(w)
 	default:
-		WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for $count", r.Method))
 	}
 }

--- a/internal/handlers/complex_properties.go
+++ b/internal/handlers/complex_properties.go
@@ -38,7 +38,7 @@ func (h *EntityHandler) HandleComplexTypeProperty(w http.ResponseWriter, r *http
 		}
 		h.handleOptionsComplexTypeProperty(w)
 	default:
-		h.writeMethodNotAllowedError(w, r, r.Method, "complex property access")
+		h.writeMethodNotAllowedError(w, r, r.Method, "complex property access", "GET, HEAD, OPTIONS")
 	}
 }
 

--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"reflect"
 	"strings"
 	"sync"
@@ -290,6 +291,24 @@ func (h *EntityHandler) isMethodDisabled(method string) bool {
 		return false
 	}
 	return h.metadata.DisabledMethods[method]
+}
+
+// allowedMethods returns a comma-separated Allow header value built from candidates,
+// omitting any methods that are currently disabled, and always appending OPTIONS.
+// HEAD is controlled by the GET disable flag.
+func (h *EntityHandler) allowedMethods(candidates []string) string {
+	allowed := make([]string, 0, len(candidates)+1)
+	for _, m := range candidates {
+		checkMethod := m
+		if m == http.MethodHead {
+			checkMethod = http.MethodGet
+		}
+		if !h.isMethodDisabled(checkMethod) {
+			allowed = append(allowed, m)
+		}
+	}
+	allowed = append(allowed, http.MethodOptions)
+	return strings.Join(allowed, ", ")
 }
 
 // EnableChangeTracking turns on change tracking for this entity handler.

--- a/internal/handlers/entity_media.go
+++ b/internal/handlers/entity_media.go
@@ -47,7 +47,7 @@ func (h *EntityHandler) HandleMediaEntityValue(w http.ResponseWriter, r *http.Re
 		}
 		h.handleOptionsMediaEntityValue(w)
 	default:
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, PUT, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for media entity $value", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}

--- a/internal/handlers/entity_read.go
+++ b/internal/handlers/entity_read.go
@@ -31,7 +31,7 @@ func (h *EntityHandler) HandleEntity(w http.ResponseWriter, r *http.Request, ent
 		methodToCheck = http.MethodGet
 	}
 	if h.isMethodDisabled(methodToCheck) {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, h.allowedMethods([]string{"GET", "HEAD", "DELETE", "PATCH", "PUT"}), ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not allowed for this entity", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -56,7 +56,7 @@ func (h *EntityHandler) HandleEntity(w http.ResponseWriter, r *http.Request, ent
 		}
 		h.handleOptionsEntity(w)
 	default:
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, DELETE, PATCH, PUT, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for individual entities", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -84,7 +84,7 @@ func (h *EntityHandler) handleGetEntity(w http.ResponseWriter, r *http.Request, 
 
 	// Check if this is a virtual entity without overwrite handler
 	if h.metadata.IsVirtual {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, DELETE, PATCH, PUT, OPTIONS", ErrMsgMethodNotAllowed,
 			"Virtual entities require an overwrite handler for GetEntity operation"); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -209,7 +209,7 @@ func (h *EntityHandler) HandleEntityRef(w http.ResponseWriter, r *http.Request, 
 
 	ctx := r.Context()
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for entity references", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -298,7 +298,7 @@ func (h *EntityHandler) HandleCollectionRef(w http.ResponseWriter, r *http.Reque
 
 	ctx := r.Context()
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for collection references", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}

--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -43,7 +43,7 @@ func (h *EntityHandler) handleDeleteEntity(w http.ResponseWriter, r *http.Reques
 
 	// Check if this is a virtual entity without overwrite handler
 	if h.metadata.IsVirtual {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, DELETE, PATCH, PUT, OPTIONS", ErrMsgMethodNotAllowed,
 			"Virtual entities require an overwrite handler for Delete operation"); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -136,7 +136,7 @@ func (h *EntityHandler) handlePatchEntity(w http.ResponseWriter, r *http.Request
 
 	// Check if this is a virtual entity without overwrite handler
 	if h.metadata.IsVirtual {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, DELETE, PATCH, PUT, OPTIONS", ErrMsgMethodNotAllowed,
 			"Virtual entities require an overwrite handler for Update operation"); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -354,7 +354,7 @@ func (h *EntityHandler) handlePutEntity(w http.ResponseWriter, r *http.Request, 
 
 	// Check if this is a virtual entity without overwrite handler
 	if h.metadata.IsVirtual {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, DELETE, PATCH, PUT, OPTIONS", ErrMsgMethodNotAllowed,
 			"Virtual entities require an overwrite handler for Update operation"); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}

--- a/internal/handlers/error_writer.go
+++ b/internal/handlers/error_writer.go
@@ -13,3 +13,10 @@ func WriteError(w http.ResponseWriter, r *http.Request, status int, code, detail
 		slog.Default().Error("Error writing error response", "error", err)
 	}
 }
+
+// WriteMethodNotAllowed writes a 405 response with the Allow header and logs if the write fails.
+func WriteMethodNotAllowed(w http.ResponseWriter, r *http.Request, allow, code, detail string) {
+	if err := response.WriteMethodNotAllowed(w, r, allow, code, detail); err != nil {
+		slog.Default().Error("Error writing error response", "error", err)
+	}
+}

--- a/internal/handlers/metadata_handler.go
+++ b/internal/handlers/metadata_handler.go
@@ -314,7 +314,7 @@ func (h *MetadataHandler) HandleMetadata(w http.ResponseWriter, r *http.Request)
 		}
 		h.handleOptionsMetadata(w)
 	default:
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, "Method not allowed",
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", "Method not allowed",
 			fmt.Sprintf("Method %s is not supported for metadata document", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}

--- a/internal/handlers/navigation_properties.go
+++ b/internal/handlers/navigation_properties.go
@@ -34,7 +34,7 @@ func (h *EntityHandler) HandleNavigationProperty(w http.ResponseWriter, r *http.
 		if isRef {
 			h.handlePutNavigationPropertyRef(w, r, entityKey, navigationProperty)
 		} else {
-			WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+			WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 				fmt.Sprintf("Method %s is not supported for navigation properties without $ref", r.Method))
 		}
 	case http.MethodPost:
@@ -44,7 +44,7 @@ func (h *EntityHandler) HandleNavigationProperty(w http.ResponseWriter, r *http.
 		if isRef {
 			h.handlePostNavigationPropertyRef(w, r, entityKey, navigationProperty)
 		} else {
-			WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+			WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 				fmt.Sprintf("Method %s is not supported for navigation properties without $ref", r.Method))
 		}
 	case http.MethodDelete:
@@ -54,7 +54,7 @@ func (h *EntityHandler) HandleNavigationProperty(w http.ResponseWriter, r *http.
 		if isRef {
 			h.handleDeleteNavigationPropertyRef(w, r, entityKey, navigationProperty)
 		} else {
-			WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+			WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 				fmt.Sprintf("Method %s is not supported for navigation properties without $ref", r.Method))
 		}
 	case http.MethodOptions:
@@ -67,8 +67,13 @@ func (h *EntityHandler) HandleNavigationProperty(w http.ResponseWriter, r *http.
 			h.handleOptionsNavigationProperty(w)
 		}
 	default:
-		WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
-			fmt.Sprintf("Method %s is not supported for navigation properties", r.Method))
+		if isRef {
+			WriteMethodNotAllowed(w, r, "GET, HEAD, PUT, POST, DELETE, OPTIONS", ErrMsgMethodNotAllowed,
+				fmt.Sprintf("Method %s is not supported for navigation properties", r.Method))
+		} else {
+			WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
+				fmt.Sprintf("Method %s is not supported for navigation properties", r.Method))
+		}
 	}
 }
 
@@ -86,7 +91,7 @@ func (h *EntityHandler) HandleNavigationPropertyCount(w http.ResponseWriter, r *
 		}
 		h.handleOptionsNavigationPropertyCount(w)
 	default:
-		WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for navigation property $count", r.Method))
 	}
 }

--- a/internal/handlers/property_helpers.go
+++ b/internal/handlers/property_helpers.go
@@ -106,9 +106,10 @@ func (h *EntityHandler) NavigationTargetSet(propertyName string) (string, bool) 
 	return "", false
 }
 
-// writeMethodNotAllowedError writes a method not allowed error for a specific context
-func (h *EntityHandler) writeMethodNotAllowedError(w http.ResponseWriter, r *http.Request, method, context string) {
-	if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+// writeMethodNotAllowedError writes a method not allowed error for a specific context.
+// allow is the value to set in the Allow response header (e.g. "GET, HEAD, OPTIONS").
+func (h *EntityHandler) writeMethodNotAllowedError(w http.ResponseWriter, r *http.Request, method, context, allow string) {
+	if err := response.WriteMethodNotAllowed(w, r, allow, ErrMsgMethodNotAllowed,
 		fmt.Sprintf("Method %s is not supported for %s", method, context)); err != nil {
 		h.logger.Error("Error writing error response", "error", err)
 	}

--- a/internal/handlers/property_helpers_test.go
+++ b/internal/handlers/property_helpers_test.go
@@ -264,7 +264,7 @@ func TestEntityHandler_writeMethodNotAllowedError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/test", nil)
 
-	handler.writeMethodNotAllowedError(w, r, "POST", "structural properties")
+	handler.writeMethodNotAllowedError(w, r, "POST", "structural properties", "GET, HEAD, OPTIONS")
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("Status = %v, want %v", w.Code, http.StatusMethodNotAllowed)

--- a/internal/handlers/restrictions.go
+++ b/internal/handlers/restrictions.go
@@ -45,7 +45,7 @@ func boolFromAnnotationValue(value interface{}) (bool, bool) {
 
 func (h *EntityHandler) enforceInsertRestrictions(w http.ResponseWriter, r *http.Request) bool {
 	if isOperationProhibited(h.metadata.EntitySetAnnotations, metadata.CapInsertRestrictions, "Insertable") {
-		h.writeMethodNotAllowedError(w, r, "POST", fmt.Sprintf("entity set '%s'", h.metadata.EntitySetName))
+		h.writeMethodNotAllowedError(w, r, "POST", fmt.Sprintf("entity set '%s'", h.metadata.EntitySetName), "GET, HEAD, OPTIONS")
 		return false
 	}
 
@@ -54,7 +54,7 @@ func (h *EntityHandler) enforceInsertRestrictions(w http.ResponseWriter, r *http
 
 func (h *EntityHandler) enforceUpdateRestrictions(w http.ResponseWriter, r *http.Request, method string) bool {
 	if isOperationProhibited(h.metadata.EntitySetAnnotations, metadata.CapUpdateRestrictions, "Updatable") {
-		h.writeMethodNotAllowedError(w, r, method, fmt.Sprintf("entity set '%s'", h.metadata.EntitySetName))
+		h.writeMethodNotAllowedError(w, r, method, fmt.Sprintf("entity set '%s'", h.metadata.EntitySetName), "GET, HEAD, DELETE, OPTIONS")
 		return false
 	}
 
@@ -63,7 +63,7 @@ func (h *EntityHandler) enforceUpdateRestrictions(w http.ResponseWriter, r *http
 
 func (h *EntityHandler) enforceDeleteRestrictions(w http.ResponseWriter, r *http.Request) bool {
 	if isOperationProhibited(h.metadata.EntitySetAnnotations, metadata.CapDeleteRestrictions, "Deletable") {
-		h.writeMethodNotAllowedError(w, r, "DELETE", fmt.Sprintf("entity set '%s'", h.metadata.EntitySetName))
+		h.writeMethodNotAllowedError(w, r, "DELETE", fmt.Sprintf("entity set '%s'", h.metadata.EntitySetName), "GET, HEAD, PUT, PATCH, OPTIONS")
 		return false
 	}
 

--- a/internal/handlers/service_document.go
+++ b/internal/handlers/service_document.go
@@ -55,7 +55,7 @@ func (h *ServiceDocumentHandler) HandleServiceDocument(w http.ResponseWriter, r 
 		}
 		h.handleOptionsServiceDocument(w)
 	default:
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, "Method not allowed",
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", "Method not allowed",
 			fmt.Sprintf("Method %s is not supported for service document", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}

--- a/internal/handlers/singleton.go
+++ b/internal/handlers/singleton.go
@@ -23,7 +23,7 @@ func (h *EntityHandler) HandleSingleton(w http.ResponseWriter, r *http.Request) 
 		methodToCheck = http.MethodGet
 	}
 	if h.isMethodDisabled(methodToCheck) {
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, h.allowedMethods([]string{"GET", "HEAD", "PUT", "PATCH"}), ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not allowed for this entity", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}
@@ -52,7 +52,7 @@ func (h *EntityHandler) HandleSingleton(w http.ResponseWriter, r *http.Request) 
 		}
 		h.handleOptionsSingleton(w)
 	default:
-		if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+		if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, PATCH, PUT, OPTIONS", ErrMsgMethodNotAllowed,
 			fmt.Sprintf("Method %s is not supported for singleton", r.Method)); err != nil {
 			h.logger.Error("Error writing error response", "error", err)
 		}

--- a/internal/handlers/stream_properties.go
+++ b/internal/handlers/stream_properties.go
@@ -29,7 +29,7 @@ func (h *EntityHandler) HandleStreamProperty(w http.ResponseWriter, r *http.Requ
 		if isValue {
 			h.handlePutStreamProperty(w, r, entityKey, propertyName)
 		} else {
-			if err := response.WriteError(w, r, http.StatusMethodNotAllowed, ErrMsgMethodNotAllowed,
+			if err := response.WriteMethodNotAllowed(w, r, "GET, HEAD, OPTIONS", ErrMsgMethodNotAllowed,
 				"PUT is only supported on stream properties with /$value"); err != nil {
 				h.logger.Error("Error writing error response", "error", err)
 			}
@@ -40,7 +40,11 @@ func (h *EntityHandler) HandleStreamProperty(w http.ResponseWriter, r *http.Requ
 		}
 		h.handleOptionsStreamProperty(w, isValue)
 	default:
-		h.writeMethodNotAllowedError(w, r, r.Method, "stream property access")
+		allow := "GET, HEAD, OPTIONS"
+		if isValue {
+			allow = "GET, HEAD, PUT, OPTIONS"
+		}
+		h.writeMethodNotAllowedError(w, r, r.Method, "stream property access", allow)
 	}
 }
 

--- a/internal/handlers/structural_properties.go
+++ b/internal/handlers/structural_properties.go
@@ -31,7 +31,7 @@ func (h *EntityHandler) HandleStructuralProperty(w http.ResponseWriter, r *http.
 		}
 		h.handleOptionsStructuralProperty(w)
 	default:
-		h.writeMethodNotAllowedError(w, r, r.Method, "property access")
+		h.writeMethodNotAllowedError(w, r, r.Method, "property access", "GET, HEAD, OPTIONS")
 	}
 }
 

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -70,6 +70,12 @@ type ODataError struct {
 	InnerError *ODataInnerError   `json:"innererror,omitempty"`
 }
 
+// WriteMethodNotAllowed writes a 405 Method Not Allowed response with the Allow header.
+func WriteMethodNotAllowed(w http.ResponseWriter, r *http.Request, allow string, message string, details string) error {
+	w.Header().Set("Allow", allow)
+	return WriteError(w, r, http.StatusMethodNotAllowed, message, details)
+}
+
 // WriteError writes an OData v4 compliant error response.
 func WriteError(w http.ResponseWriter, r *http.Request, code int, message string, details string) error {
 	odataErr := &ODataError{

--- a/internal/service/operations/handler.go
+++ b/internal/service/operations/handler.go
@@ -195,7 +195,7 @@ func (h *Handler) HandleActionOrFunction(w http.ResponseWriter, r *http.Request,
 			h.logError("Error encoding response", err)
 		}
 	default:
-		if writeErr := response.WriteError(w, r, http.StatusMethodNotAllowed, "Method not allowed",
+		if writeErr := response.WriteMethodNotAllowed(w, r, "GET, HEAD, POST, OPTIONS", "Method not allowed",
 			fmt.Sprintf("Method %s is not allowed for actions or functions", r.Method)); writeErr != nil {
 			h.logError("Error writing error response", writeErr)
 		}

--- a/internal/service/router/router.go
+++ b/internal/service/router/router.go
@@ -192,14 +192,14 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			pathWithoutParams = path[:idx]
 		}
 		if r.isActionOrFunction(pathWithoutParams) {
-			if writeErr := response.WriteError(w, req, http.StatusMethodNotAllowed, "Method not allowed",
+			if writeErr := response.WriteMethodNotAllowed(w, req, "GET, HEAD, POST, OPTIONS", "Method not allowed",
 				fmt.Sprintf("Method %s is not allowed for actions or functions", req.Method)); writeErr != nil {
 				r.logger.Error("Error writing error response", "error", writeErr)
 			}
 			return
 		}
 		if r.isActionOrFunction(path) {
-			if writeErr := response.WriteError(w, req, http.StatusMethodNotAllowed, "Method not allowed",
+			if writeErr := response.WriteMethodNotAllowed(w, req, "GET, HEAD, POST, OPTIONS", "Method not allowed",
 				fmt.Sprintf("Method %s is not allowed for actions or functions", req.Method)); writeErr != nil {
 				r.logger.Error("Error writing error response", "error", writeErr)
 			}


### PR DESCRIPTION
## Summary

- Adds `response.WriteMethodNotAllowed(w, r, allow, message, details)` helper that sets the `Allow` header before writing the 405 error body
- Adds `handlers.WriteMethodNotAllowed` wrapper (parallel to existing `WriteError`) and `EntityHandler.allowedMethods(candidates)` to compute the effective allowed-method list when individual methods are disabled via `DisabledMethods` config
- Updates all ~24 call sites across handlers, router, operations, batch, async, and response packages

Closes #729.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `curl -s -D - -o /dev/null -X PUT http://localhost:9090/$metadata` now returns `Allow: GET, HEAD, OPTIONS` in the response
- [x] Same for service document `/` and entity collections (e.g. `PUT /Products`)
- [ ] OData compliance suite `8.1.7 / test_405_includes_allow_header` should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)