### PR TITLE
Fix #732: fall back to in-memory search when $search expression contains NOT

### DIFF
--- a/internal/query/fts.go
+++ b/internal/query/fts.go
@@ -601,17 +601,27 @@ func (m *FTSManager) ApplyFTSSearch(db *gorm.DB, tableName string, searchQuery s
 		wsQuery := expr.toWebsearchQuery()
 		db = db.Where(fmt.Sprintf("%s.search_vector @@ websearch_to_tsquery('%s', ?)", ftsTableName, m.language), wsQuery)
 	case "FTS5":
-		// FTS5 MATCH natively supports AND, OR, NOT, and phrase search
+		// FTS5 binary NOT (A NOT B) supports one positive and one negative operand;
+		// unary/top-level NOT and compound NOT expressions have no FTS5 equivalent.
+		// Fall back to in-memory search so the caller can evaluate the full boolean
+		// expression correctly.
+		if expr.containsNot() {
+			return db, errFTSNotAvailable
+		}
 		ftsQuery := expr.toFTS5Query()
 		db = db.Where(fmt.Sprintf("%s MATCH ?", ftsTableName), ftsQuery)
 	default:
-		// FTS3/FTS4: supports AND (implicit), OR, and phrase; NOT is not supported
-		// and is silently dropped from the query (positive terms still match)
+		// FTS3/FTS4: the MATCH operator has no NOT support at all. Rather than
+		// silently dropping NOT clauses (producing wrong results) or passing the
+		// raw OData query string through (which causes a "malformed MATCH expression"
+		// 500 error), signal unavailability so the caller falls back to the in-memory
+		// evaluator which handles NOT correctly.
+		if expr.containsNot() {
+			return db, errFTSNotAvailable
+		}
 		ftsQuery := expr.toFTS34Query()
 		if ftsQuery == "" {
-			// toFTS34Query can return "" if the entire expression is negated;
-			// fall back to the raw query to avoid an empty MATCH clause
-			ftsQuery = searchQuery
+			return db, errFTSNotAvailable
 		}
 		db = db.Where(fmt.Sprintf("%s MATCH ?", ftsTableName), ftsQuery)
 	}

--- a/internal/query/search_expression.go
+++ b/internal/query/search_expression.go
@@ -228,6 +228,19 @@ func (p *searchParser) parsePrimary() *SearchExprNode {
 	}
 }
 
+// containsNot reports whether the expression tree has any NOT node at any depth.
+// Used to decide whether an FTS backend that cannot express NOT (FTS3/FTS4) or
+// cannot express unary/compound NOT (FTS5) should fall back to in-memory search.
+func (n *SearchExprNode) containsNot() bool {
+	if n == nil {
+		return false
+	}
+	if n.op == searchOpNot {
+		return true
+	}
+	return n.left.containsNot() || n.right.containsNot()
+}
+
 // --- FTS query serialization --------------------------------------------------
 
 // toFTS5Query converts the expression to SQLite FTS5 MATCH syntax.

--- a/internal/query/search_expression_test.go
+++ b/internal/query/search_expression_test.go
@@ -182,7 +182,8 @@ func TestToFTS34Query(t *testing.T) {
 		{"laptop", "laptop"},
 		{"laptop AND wireless", "laptop wireless"},
 		{"laptop OR phone", "(laptop OR phone)"},
-		// NOT is not supported by FTS3/4 and is dropped
+		// NOT is dropped by toFTS34Query itself; ApplyFTSSearch now returns
+		// errFTSNotAvailable before reaching this code when containsNot() is true.
 		{"laptop NOT phone", "laptop"},
 	}
 	for _, tt := range tests {
@@ -194,6 +195,74 @@ func TestToFTS34Query(t *testing.T) {
 			got := node.toFTS34Query()
 			if got != tt.expected {
 				t.Errorf("toFTS34Query(%q) = %q, want %q", tt.query, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSearchExprNode_containsNot(t *testing.T) {
+	tests := []struct {
+		query    string
+		want     bool
+	}{
+		{"laptop", false},
+		{"laptop AND wireless", false},
+		{"laptop OR phone", false},
+		{"NOT laptop", true},
+		{"laptop NOT wireless", true},  // implicit AND with NOT right child
+		{"Mouse NOT Wireless", true},   // issue #732 case 1
+		{"NOT Laptop", true},           // issue #732 case 2
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			node := ParseSearchExpression(tt.query)
+			if node == nil {
+				t.Fatalf("ParseSearchExpression returned nil for %q", tt.query)
+			}
+			if got := node.containsNot(); got != tt.want {
+				t.Errorf("containsNot(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FTS NOT fallback — issue #732
+// ---------------------------------------------------------------------------
+
+// TestFTSManager_ApplyFTSSearch_NOT_FallsBackToInMemory verifies that queries
+// containing NOT return errFTSNotAvailable so the caller can use in-memory
+// evaluation (which handles NOT correctly) instead of producing wrong results
+// or a 500 from an unsupported FTS3/4 MATCH syntax.
+func TestFTSManager_ApplyFTSSearch_NOT_FallsBackToInMemory(t *testing.T) {
+	db := newFTSTestDB(t)
+	if err := db.AutoMigrate(&FTSTestEntity{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if err := db.Create(&[]FTSTestEntity{
+		{ID: 1, Name: "Wireless Mouse", Description: "ergonomic wireless mouse", Category: "Accessories"},
+		{ID: 2, Name: "Gaming Mouse Ultra", Description: "high-performance gaming mouse", Category: "Accessories"},
+		{ID: 3, Name: "Laptop Pro", Description: "professional laptop", Category: "Electronics"},
+	}).Error; err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	mgr := NewFTSManager(db)
+	if !mgr.IsFTSAvailable() {
+		t.Skip("FTS not available")
+	}
+
+	meta, err := metadata.AnalyzeEntity(FTSTestEntity{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity: %v", err)
+	}
+
+	for _, query := range []string{"Mouse NOT Wireless", "NOT Laptop"} {
+		t.Run(query, func(t *testing.T) {
+			q := db.Table("fts_test_entities")
+			_, err := mgr.ApplyFTSSearch(q, "fts_test_entities", query, meta)
+			if err == nil {
+				t.Errorf("ApplyFTSSearch(%q): expected errFTSNotAvailable, got nil", query)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `containsNot()` helper to `SearchExprNode` that walks the expression tree to detect any NOT node
- In `ApplyFTSSearch`, returns `errFTSNotAvailable` for **all** FTS backends (FTS3, FTS4, FTS5) when the expression contains NOT — triggering the existing in-memory fallback (`matchesSearchExpr`) which already evaluates NOT correctly
- Removes the dangerous `ftsQuery = searchQuery` fallback in the FTS3/4 path that was the direct cause of the HTTP 500

## Root cause

**Bug 1 — wrong results (`Mouse NOT Wireless` returns both products):**
FTS3/4 `toFTS34Query()` drops NOT clauses silently, so `AND(Mouse, NOT(Wireless))` became a bare `Mouse` MATCH, matching "Wireless Mouse" as well.

**Bug 2 — HTTP 500 (`NOT Laptop`):**
When the top-level expression was `NOT(Laptop)`, `toFTS34Query()` returned `""`. The code then fell back to the raw query string `"NOT Laptop"` as the MATCH argument, which SQLite FTS3/4 rejected with `malformed MATCH expression: [NOT Laptop]`. FTS5 has the same issue: its NOT is a binary operator (`A NOT B`), so `NOT Laptop` (unary) is also a runtime SQL error.

## Test plan

- [x] `TestSearchExprNode_containsNot` — unit tests for all containsNot cases including the two issue scenarios
- [x] `TestFTSManager_ApplyFTSSearch_NOT_FallsBackToInMemory` — verifies `ApplyFTSSearch` returns `errFTSNotAvailable` for `"Mouse NOT Wireless"` and `"NOT Laptop"` on FTS3/4
- [x] Existing `TestApplySearch_NOT_BooleanOperator` — confirms in-memory evaluator correctly handles NOT (already passing)
- [x] Full test suite passes: `go test ./...`

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)