### PR TITLE
fix: parse Edm.Single f/F suffix as float32 to fix equality comparisons (#737)

### DIFF
--- a/internal/query/ast_parser_arithmetic.go
+++ b/internal/query/ast_parser_arithmetic.go
@@ -209,8 +209,21 @@ func (p *ASTParser) parseNumberLiteral(value string) ASTNode {
 	}
 
 	// Edm.Single literals may use an optional f/F suffix (e.g., 3.14f, 1.5e2f).
+	// Parse as float32 to preserve single-precision representation so that the
+	// resulting float64 matches exactly what is stored for float32 struct fields
+	// (i.e. float64(float32(x))). This is critical for equality comparisons in
+	// SQL: without this, "Weight eq 3.14f" would generate "weight = 3.14" which
+	// never equals the stored value 3.140000104904175 (float32 truncation).
 	if strings.HasSuffix(value, "f") || strings.HasSuffix(value, "F") {
 		value = value[:len(value)-1]
+		// strconv.ParseFloat with bitSize=32 returns the float64 value that is
+		// exactly float64(float32(x)), matching how float32 fields are stored.
+		if f32Val, err := strconv.ParseFloat(value, 32); err == nil {
+			expr := AcquireLiteralExpr()
+			expr.Value = f32Val
+			expr.Type = "number"
+			return expr
+		}
 	}
 
 	// Try to parse as integer first, then as float

--- a/internal/query/ast_parser_test.go
+++ b/internal/query/ast_parser_test.go
@@ -428,3 +428,70 @@ func TestASTParser_ComplexExpressions(t *testing.T) {
 		})
 	}
 }
+
+// TestParseNumberLiteral_SinglePrecisionSuffix verifies that Edm.Single literals
+// with an f/F suffix are parsed as float64(float32(x)) rather than a full
+// float64 parse. This matters for equality comparisons against float32 struct
+// fields: SQLite stores float32(3.14) as 3.140000104904175, so the filter value
+// must carry that same representation. Regression test for issue #737.
+func TestParseNumberLiteral_SinglePrecisionSuffix(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string // filter whose RHS is the Edm.Single literal under test
+		wantVal float64
+	}{
+		{
+			name:    "lowercase f suffix",
+			input:   "Price eq 3.14f",
+			wantVal: float64(float32(3.14)),
+		},
+		{
+			name:    "uppercase F suffix",
+			input:   "Price eq 3.14F",
+			wantVal: float64(float32(3.14)),
+		},
+		{
+			name:    "integer value with f suffix",
+			input:   "Price eq 1f",
+			wantVal: float64(float32(1)),
+		},
+		{
+			name:    "scientific notation with f suffix",
+			input:   "Price eq 1.5e2f",
+			wantVal: float64(float32(1.5e2)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenizer := NewTokenizer(tt.input)
+			tokens, err := tokenizer.TokenizeAll()
+			if err != nil {
+				t.Fatalf("tokenization failed: %v", err)
+			}
+
+			parser := NewASTParser(tokens)
+			ast, err := parser.Parse()
+			if err != nil {
+				t.Fatalf("parsing failed: %v", err)
+			}
+			defer ReleaseASTNode(ast)
+
+			compExpr, ok := ast.(*ComparisonExpr)
+			if !ok {
+				t.Fatal("expected ComparisonExpr at AST root")
+			}
+			litExpr, ok := compExpr.Right.(*LiteralExpr)
+			if !ok {
+				t.Fatal("expected LiteralExpr on right side of comparison")
+			}
+			gotVal, ok := litExpr.Value.(float64)
+			if !ok {
+				t.Fatalf("expected float64 literal value, got %T", litExpr.Value)
+			}
+			if gotVal != tt.wantVal {
+				t.Errorf("single-precision literal %q: got %v, want %v (float64(float32(x)))", tt.input, gotVal, tt.wantVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- In `parseNumberLiteral`, Edm.Single literals with an `f`/`F` suffix (e.g. `3.14f`) are now parsed with `strconv.ParseFloat(value, 32)` (bitSize=32) instead of 64, producing `float64(float32(x))` — the same bit pattern that SQLite stores for `float32` struct fields.
- Without this fix, `$filter=Weight eq 3.14f` generated `WHERE weight = 3.14`, which never equals the stored value `3.140000104904175` (float32 truncation), returning 0 results.
- Added `TestParseNumberLiteral_SinglePrecisionSuffix` in `internal/query/ast_parser_test.go` covering lowercase `f`, uppercase `F`, integer, and scientific-notation variants.

Closes #737

## Test plan
- [ ] `go test ./...` passes (all packages green)
- [ ] New test `TestParseNumberLiteral_SinglePrecisionSuffix` covers lowercase f, uppercase F, integer with f, and scientific notation with f
- [ ] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)