### PR TITLE
fix: duration literal comparison uses numeric seconds not lexicographic string order (#736)

### DIFF
--- a/internal/query/apply_filter.go
+++ b/internal/query/apply_filter.go
@@ -728,6 +728,25 @@ func buildComparisonConditionWithDB(db *gorm.DB, dialect string, filter *FilterE
 		return "", nil
 	}
 
+	// Duration comparison: convert both sides to seconds so that ordering is numeric
+	// rather than lexicographic. "P1D" > "PT1H" is false lexicographically but
+	// true numerically (86400 > 3600), so we must compare as numbers.
+	if filter.ValueType == "duration" {
+		if durStr, ok := filter.Value.(string); ok {
+			rhsSeconds := parseDurationToSeconds(durStr)
+			var colSQL string
+			if dialect == "postgres" {
+				colSQL = fmt.Sprintf("EXTRACT(EPOCH FROM CAST(NULLIF(CAST(%s AS TEXT), '') AS INTERVAL))", columnName)
+			} else {
+				colSQL = iso8601DurationToSecondsSQL(columnName, dialect)
+			}
+			compSQL := buildComparisonSQL(filter.Operator, colSQL)
+			if compSQL != "" {
+				return compSQL, []interface{}{rhsSeconds}
+			}
+		}
+	}
+
 	// Try to build a comparison with a function on the right side (e.g., Name eq tolower('JOHN'))
 	if sql, args, ok := tryBuildRightSideFunctionComparison(dialect, columnName, filter.Operator, filter.Value, entityMetadata); ok {
 		return sql, args

--- a/internal/query/apply_filter.go
+++ b/internal/query/apply_filter.go
@@ -736,7 +736,9 @@ func buildComparisonConditionWithDB(db *gorm.DB, dialect string, filter *FilterE
 			rhsSeconds := parseDurationToSeconds(durStr)
 			var colSQL string
 			if dialect == "postgres" {
-				colSQL = fmt.Sprintf("EXTRACT(EPOCH FROM CAST(NULLIF(CAST(%s AS TEXT), '') AS INTERVAL))", columnName)
+				// Guard non-P values (empty, negative like "-P1D") before casting to INTERVAL,
+				// since PostgreSQL rejects "-P1D" with a SQL error rather than returning NULL.
+				colSQL = fmt.Sprintf("CASE WHEN %[1]s IS NULL THEN NULL WHEN %[1]s NOT LIKE 'P%%' THEN NULL ELSE EXTRACT(EPOCH FROM CAST(%[1]s AS INTERVAL)) END", columnName)
 			} else {
 				colSQL = iso8601DurationToSecondsSQL(columnName, dialect)
 			}
@@ -744,6 +746,9 @@ func buildComparisonConditionWithDB(db *gorm.DB, dialect string, filter *FilterE
 			if compSQL != "" {
 				return compSQL, []interface{}{rhsSeconds}
 			}
+			// Operator not supported for duration comparison; skip to avoid falling
+			// through to string-based comparison which gives wrong results.
+			return "", nil
 		}
 	}
 
@@ -1136,8 +1141,12 @@ func iso8601DurationToSecondsSQL(c, dialect string) string {
 	// Seconds: digits before 'S', starting after the last of 'M'/'H'/'T'.
 	secStart := "CASE WHEN " + mRel + ">0 THEN " + mAbs + "+1 WHEN " + h + ">" + t + " THEN " + h + "+1 ELSE " + t + "+1 END"
 	secLen := s + "-CASE WHEN " + mRel + ">0 THEN " + mAbs + " WHEN " + h + ">" + t + " THEN " + h + " ELSE " + t + " END-1"
+	// Use '0' (string) not 0 (int) in the ELSE branch: SQL Server resolves CASE result
+	// type by precedence — mixing nvarchar (SUBSTRING) with int (0) picks int, which
+	// then fails to convert '1.5' to int for fractional seconds. Both branches as
+	// nvarchar lets the outer castReal convert correctly.
 	seconds := castReal("CASE WHEN " + t + ">0 AND " + s + ">" + t +
-		" THEN " + substr3(c, secStart, secLen) + " ELSE 0 END")
+		" THEN " + substr3(c, secStart, secLen) + " ELSE '0' END")
 
 	return "CASE WHEN " + c + " IS NULL THEN NULL WHEN " + c + " NOT LIKE 'P%' THEN NULL ELSE (" +
 		days + "+" + hours + "+" + minutes + "+" + seconds + ") END"

--- a/internal/query/ast_parser_arithmetic.go
+++ b/internal/query/ast_parser_arithmetic.go
@@ -328,6 +328,60 @@ func isValidDurationLiteral(value string) bool {
 	return strings.HasSuffix(body, "D")
 }
 
+// parseDurationToSeconds converts an ISO-8601 duration string (as used for Edm.Duration)
+// to its equivalent total number of seconds as a float64.
+// Handles days, hours, minutes, and seconds components.
+// Examples: "PT1H" -> 3600, "P1D" -> 86400, "P1DT2H30M" -> 95400.
+// Returns 0 for empty or invalid strings.
+func parseDurationToSeconds(s string) float64 {
+	if s == "" || !strings.HasPrefix(s, "P") {
+		return 0
+	}
+
+	body := s[1:] // strip leading 'P'
+	var days, hours, minutes float64
+	var secs float64
+
+	tIdx := strings.IndexByte(body, 'T')
+	datePart := body
+	timePart := ""
+	if tIdx >= 0 {
+		datePart = body[:tIdx]
+		timePart = body[tIdx+1:]
+	}
+
+	// Parse date part: only 'D' (days) is supported in Edm.Duration
+	if dIdx := strings.IndexByte(datePart, 'D'); dIdx >= 0 {
+		if v, err := strconv.ParseFloat(datePart[:dIdx], 64); err == nil {
+			days = v
+		}
+	}
+
+	// Parse time part: H, M, S
+	if timePart != "" {
+		rem := timePart
+		if hIdx := strings.IndexByte(rem, 'H'); hIdx >= 0 {
+			if v, err := strconv.ParseFloat(rem[:hIdx], 64); err == nil {
+				hours = v
+			}
+			rem = rem[hIdx+1:]
+		}
+		if mIdx := strings.IndexByte(rem, 'M'); mIdx >= 0 {
+			if v, err := strconv.ParseFloat(rem[:mIdx], 64); err == nil {
+				minutes = v
+			}
+			rem = rem[mIdx+1:]
+		}
+		if sIdx := strings.IndexByte(rem, 'S'); sIdx >= 0 {
+			if v, err := strconv.ParseFloat(rem[:sIdx], 64); err == nil {
+				secs = v
+			}
+		}
+	}
+
+	return days*86400 + hours*3600 + minutes*60 + secs
+}
+
 // parsePropertyPath parses a property path with slashes (e.g., Orders/Items/any)
 func (p *ASTParser) parsePropertyPath(initialProp string) (ASTNode, error) {
 	path := initialProp

--- a/internal/query/ast_parser_arithmetic.go
+++ b/internal/query/ast_parser_arithmetic.go
@@ -334,7 +334,15 @@ func isValidDurationLiteral(value string) bool {
 // Examples: "PT1H" -> 3600, "P1D" -> 86400, "P1DT2H30M" -> 95400.
 // Returns 0 for empty or invalid strings.
 func parseDurationToSeconds(s string) float64 {
-	if s == "" || !strings.HasPrefix(s, "P") {
+	if s == "" {
+		return 0
+	}
+	neg := false
+	if strings.HasPrefix(s, "-") {
+		neg = true
+		s = s[1:]
+	}
+	if !strings.HasPrefix(s, "P") {
 		return 0
 	}
 
@@ -379,7 +387,11 @@ func parseDurationToSeconds(s string) float64 {
 		}
 	}
 
-	return days*86400 + hours*3600 + minutes*60 + secs
+	result := days*86400 + hours*3600 + minutes*60 + secs
+	if neg {
+		return -result
+	}
+	return result
 }
 
 // parsePropertyPath parses a property path with slashes (e.g., Orders/Items/any)

--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -211,6 +211,9 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 		// We'll use a special marker in the property name to indicate this is a function comparison
 		filterExpr.Property = fmt.Sprintf("_func_%s_%s_%s", funcExpr.Operator, funcExpr.Property, n.Operator)
 		filterExpr.Operator = FilterOperator(n.Operator)
+		if lit, ok := n.Right.(*LiteralExpr); ok {
+			filterExpr.ValueType = lit.Type
+		}
 
 		// Store the original function info in Left for SQL generation
 		filterExpr.Left = funcExpr
@@ -236,6 +239,9 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 		expr.Property = arithExpr.Property
 		expr.Operator = FilterOperator(n.Operator)
 		expr.Value = value
+		if lit, ok := n.Right.(*LiteralExpr); ok {
+			expr.ValueType = lit.Type
+		}
 		expr.Left = arithExpr
 		return expr, nil
 	}

--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -336,6 +336,11 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 	expr.Property = property
 	expr.Operator = FilterOperator(n.Operator)
 	expr.Value = value
+	// Preserve the OData type of the right-hand literal so that apply_filter can
+	// generate semantically-correct SQL (e.g. numeric seconds comparison for durations).
+	if lit, ok := n.Right.(*LiteralExpr); ok {
+		expr.ValueType = lit.Type
+	}
 	return expr, nil
 }
 

--- a/internal/query/date_functions_test.go
+++ b/internal/query/date_functions_test.go
@@ -1127,3 +1127,139 @@ func TestTotalSecondsISO8601SQLite(t *testing.T) {
 
 	}
 }
+
+// TestDurationDirectComparisonSQL verifies that a direct duration literal comparison
+// (e.g. $filter=ShippingTime gt duration'PT1H') generates seconds-based SQL
+// rather than a raw string comparison (issue #736).
+func TestDurationDirectComparisonSQL(t *testing.T) {
+	type DurationRow struct {
+		ID           int    `gorm:"primaryKey"`
+		ShippingTime string `gorm:"column:shipping_time"`
+	}
+
+	meta, err := metadata.AnalyzeEntity(DurationRow{})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	tests := []struct {
+		filter   string
+		wantSecs float64
+		wantOp   string
+	}{
+		{"ShippingTime gt duration'PT1H'", 3600, ">"},
+		{"ShippingTime ge duration'P1D'", 86400, ">="},
+		{"ShippingTime lt duration'P1DT2H30M'", 95400, "<"},
+		{"ShippingTime eq duration'PT2H'", 7200, "="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filter, func(t *testing.T) {
+			filterExpr, err := parseFilter(tt.filter, meta, nil, 0)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if filterExpr.ValueType != "duration" {
+				t.Errorf("expected ValueType=duration, got %q", filterExpr.ValueType)
+			}
+			sql, args := buildFilterCondition("sqlite", filterExpr, meta)
+			if len(args) != 1 {
+				t.Fatalf("expected 1 bind arg, got %d; sql=%s", len(args), sql)
+			}
+			secs, ok := args[0].(float64)
+			if !ok {
+				t.Fatalf("expected float64 arg, got %T %v", args[0], args[0])
+			}
+			if secs != tt.wantSecs {
+				t.Errorf("expected %v seconds, got %v", tt.wantSecs, secs)
+			}
+			// Verify the SQL contains the comparison operator (not a raw string quote)
+			if !containsString(sql, tt.wantOp+" ?") {
+				t.Errorf("expected SQL to contain %q; got: %s", tt.wantOp+" ?", sql)
+			}
+			// The SQL must NOT contain a raw string literal like 'PT1H'
+			if containsString(sql, "'PT") || containsString(sql, "'P1") || containsString(sql, "'P2") {
+				t.Errorf("SQL contains raw duration string literal (string comparison bug): %s", sql)
+			}
+		})
+	}
+}
+
+// TestDurationDirectComparisonE2E verifies that direct duration literal filter
+// (e.g. $filter=ShippingTime gt duration'PT1H') returns the correct rows from SQLite.
+// This is the regression test for issue #736.
+func TestDurationDirectComparisonE2E(t *testing.T) {
+	type DurationRow struct {
+		ID           int    `gorm:"primaryKey"`
+		ShippingTime string `gorm:"column:shipping_time"`
+	}
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&DurationRow{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	rows := []DurationRow{
+		{ID: 1, ShippingTime: "P1D"},       // 86400 s
+		{ID: 2, ShippingTime: "PT2H"},      // 7200 s
+		{ID: 3, ShippingTime: "P2D"},       // 172800 s
+		{ID: 4, ShippingTime: "P1DT2H30M"}, // 95400 s
+		{ID: 5, ShippingTime: ""},          // empty — should be excluded
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	meta, err := metadata.AnalyzeEntity(DurationRow{})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	tests := []struct {
+		filter        string
+		expectedCount int
+		desc          string
+	}{
+		// These cases fail without the fix because lexicographic comparison gives
+		// wrong results: "P1D" < "PT1H" (string), but 86400 > 3600 (numeric).
+		{"ShippingTime gt duration'PT1H'", 4, "P1D,PT2H,P2D,P1DT2H30M are all > 1 hour"},
+		{"ShippingTime ge duration'P1D'", 3, "P1D,P2D,P1DT2H30M are >= 1 day"},
+		{"ShippingTime lt duration'PT3H'", 1, "only PT2H is < 3 hours"},
+		{"ShippingTime eq duration'PT2H'", 1, "only PT2H equals 2 hours"},
+		{"ShippingTime ne duration'PT2H'", 3, "P1D, P2D, P1DT2H30M are != 2 hours (empty excluded)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filter, func(t *testing.T) {
+			filterExpr, err := parseFilter(tt.filter, meta, nil, 0)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			var count int64
+			if err := db.Model(&DurationRow{}).Scopes(func(d *gorm.DB) *gorm.DB {
+				return ApplyFilterOnly(d, filterExpr, meta, nil)
+			}).Count(&count).Error; err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			if int(count) != tt.expectedCount {
+				t.Errorf("%s: expected %d rows, got %d", tt.desc, tt.expectedCount, count)
+			}
+		})
+	}
+}
+
+// containsString is a helper used by the duration comparison SQL tests.
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/query/date_functions_test.go
+++ b/internal/query/date_functions_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -753,7 +754,7 @@ func TestDateFunctions_SQLGenerationSQLServer(t *testing.T) {
 			name:   "totalseconds SQL Server",
 			filter: "totalseconds(CreatedAt) gt 3600",
 			// Edm.Duration is an ISO-8601 string; SQL Server parses it with CHARINDEX/SUBSTRING.
-			expectedSQL:    "CASE WHEN [created_at] IS NULL THEN NULL WHEN [created_at] NOT LIKE 'P%' THEN NULL ELSE (CAST(CASE WHEN CHARINDEX('D',[created_at])>0 AND (CHARINDEX('T',[created_at])=0 OR CHARINDEX('D',[created_at])<CHARINDEX('T',[created_at])) THEN SUBSTRING([created_at],2,CHARINDEX('D',[created_at])-2) ELSE 0 END AS INT)*86400+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,CHARINDEX('H',[created_at])-CHARINDEX('T',[created_at])-1) ELSE 0 END AS INT)*3600+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN SUBSTRING([created_at],CASE WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at])+1 ELSE CHARINDEX('T',[created_at])+1 END,CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))-1-CASE WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at]) ELSE CHARINDEX('T',[created_at]) END) ELSE 0 END AS INT)*60+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('S',[created_at])>CHARINDEX('T',[created_at]) THEN SUBSTRING([created_at],CASE WHEN CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))+1 WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at])+1 ELSE CHARINDEX('T',[created_at])+1 END,CHARINDEX('S',[created_at])-CASE WHEN CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000)) WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at]) ELSE CHARINDEX('T',[created_at]) END-1) ELSE 0 END AS FLOAT)) END > ?",
+			expectedSQL:    "CASE WHEN [created_at] IS NULL THEN NULL WHEN [created_at] NOT LIKE 'P%' THEN NULL ELSE (CAST(CASE WHEN CHARINDEX('D',[created_at])>0 AND (CHARINDEX('T',[created_at])=0 OR CHARINDEX('D',[created_at])<CHARINDEX('T',[created_at])) THEN SUBSTRING([created_at],2,CHARINDEX('D',[created_at])-2) ELSE 0 END AS INT)*86400+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,CHARINDEX('H',[created_at])-CHARINDEX('T',[created_at])-1) ELSE 0 END AS INT)*3600+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN SUBSTRING([created_at],CASE WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at])+1 ELSE CHARINDEX('T',[created_at])+1 END,CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))-1-CASE WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at]) ELSE CHARINDEX('T',[created_at]) END) ELSE 0 END AS INT)*60+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('S',[created_at])>CHARINDEX('T',[created_at]) THEN SUBSTRING([created_at],CASE WHEN CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))+1 WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at])+1 ELSE CHARINDEX('T',[created_at])+1 END,CHARINDEX('S',[created_at])-CASE WHEN CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000)) WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at]) ELSE CHARINDEX('T',[created_at]) END-1) ELSE '0' END AS FLOAT)) END > ?",
 			expectedArgsNo: 1,
 		},
 	}
@@ -1174,11 +1175,11 @@ func TestDurationDirectComparisonSQL(t *testing.T) {
 				t.Errorf("expected %v seconds, got %v", tt.wantSecs, secs)
 			}
 			// Verify the SQL contains the comparison operator (not a raw string quote)
-			if !containsString(sql, tt.wantOp+" ?") {
+			if !strings.Contains(sql, tt.wantOp+" ?") {
 				t.Errorf("expected SQL to contain %q; got: %s", tt.wantOp+" ?", sql)
 			}
 			// The SQL must NOT contain a raw string literal like 'PT1H'
-			if containsString(sql, "'PT") || containsString(sql, "'P1") || containsString(sql, "'P2") {
+			if strings.Contains(sql, "'PT") || strings.Contains(sql, "'P1") || strings.Contains(sql, "'P2") {
 				t.Errorf("SQL contains raw duration string literal (string comparison bug): %s", sql)
 			}
 		})
@@ -1249,17 +1250,4 @@ func TestDurationDirectComparisonE2E(t *testing.T) {
 			}
 		})
 	}
-}
-
-// containsString is a helper used by the duration comparison SQL tests.
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		func() bool {
-			for i := 0; i <= len(s)-len(substr); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-			return false
-		}())
 }

--- a/internal/query/filter_pool.go
+++ b/internal/query/filter_pool.go
@@ -40,6 +40,7 @@ func (f *FilterExpression) reset() {
 	f.Property = ""
 	f.Operator = ""
 	f.Value = nil
+	f.ValueType = ""
 	f.Left = nil
 	f.Right = nil
 	f.Logical = ""

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -205,6 +205,7 @@ type FilterExpression struct {
 	Property        string
 	Operator        FilterOperator
 	Value           interface{}
+	ValueType       string // Type hint for the value (e.g. "duration"); empty for untyped values
 	Left            *FilterExpression
 	Right           *FilterExpression
 	Logical         LogicalOperator


### PR DESCRIPTION
## Summary

Fixes #736

- `$filter=ShippingTime gt duration'PT1H'` previously generated `shipping_time > 'PT1H'` — a raw string comparison that gives wrong results for ISO-8601 duration strings (e.g. `"P1D" < "PT1H"` lexicographically, so products with 1-day shipping were excluded even though 86400 s > 3600 s).
- The fix adds a `ValueType string` field to `FilterExpression` that carries the OData literal type through from the parser to SQL generation. When `ValueType == "duration"`, `buildComparisonConditionWithDB` converts the column to seconds via `iso8601DurationToSecondsSQL` (all dialects) / `EXTRACT(EPOCH …)` (PostgreSQL) and binds the parsed RHS seconds as a `float64` parameter.
- A new `parseDurationToSeconds` Go helper mirrors the SQL logic for the right-hand side value.

## Files changed

| File | What changed |
|---|---|
| `internal/query/parser.go` | Add `ValueType string` field to `FilterExpression` |
| `internal/query/filter_pool.go` | Reset `ValueType` in `reset()` so pooled expressions are clean |
| `internal/query/ast_parser_validation.go` | Set `expr.ValueType = lit.Type` when RHS is a typed literal |
| `internal/query/ast_parser_arithmetic.go` | Add `parseDurationToSeconds` helper |
| `internal/query/apply_filter.go` | Detect `ValueType == "duration"` and emit seconds-based SQL |
| `internal/query/date_functions_test.go` | SQL unit test + SQLite E2E regression test for all comparison operators |

## Test plan

- [ ] `go test ./internal/query/ -run TestDurationDirectComparisonSQL` — verifies generated SQL binds seconds (not the raw string) for all comparison operators
- [ ] `go test ./internal/query/ -run TestDurationDirectComparisonE2E` — verifies correct row counts against an in-memory SQLite database (the exact cases from the issue: `P1D`, `P2D`, `P1DT2H30M` all returned for `gt duration'PT1H'`)
- [ ] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)