### PR TITLE
fix: generate dialect-specific SQL for cast(field, 'Edm.Date') and cast(field, 'Edm.TimeOfDay')

### DIFF
--- a/internal/query/apply_filter.go
+++ b/internal/query/apply_filter.go
@@ -1481,6 +1481,30 @@ func buildFunctionSQL(dialect string, op FilterOperator, columnName string, valu
 		return fmt.Sprintf("ROUND(%s)", columnName), nil
 	case OpCast:
 		if typeName, ok := value.(string); ok {
+			switch typeName {
+			case "Edm.Date":
+				switch dialect {
+				case "postgres", "postgresql":
+					return fmt.Sprintf("CAST(%s AS DATE)", columnName), nil
+				case "mysql", "mariadb":
+					return fmt.Sprintf("DATE(%s)", columnName), nil
+				case "sqlserver", "mssql":
+					return fmt.Sprintf("CAST(TRY_CONVERT(date, %s) AS DATE)", columnName), nil
+				default: // sqlite
+					return fmt.Sprintf("date(%s)", columnName), nil
+				}
+			case "Edm.TimeOfDay":
+				switch dialect {
+				case "postgres", "postgresql":
+					return fmt.Sprintf("CAST(%s AS TIME)", columnName), nil
+				case "mysql", "mariadb":
+					return fmt.Sprintf("TIME(%s)", columnName), nil
+				case "sqlserver", "mssql":
+					return fmt.Sprintf("CAST(TRY_CONVERT(time, %s) AS TIME)", columnName), nil
+				default: // sqlite
+					return fmt.Sprintf("time(%s)", columnName), nil
+				}
+			}
 			sqlType := edmTypeToSQLType(dialect, typeName)
 			return fmt.Sprintf("CAST(%s AS %s)", columnName, sqlType), nil
 		}

--- a/internal/query/cast_functions_e2e_test.go
+++ b/internal/query/cast_functions_e2e_test.go
@@ -169,13 +169,13 @@ func TestCastFunctions_Integration(t *testing.T) {
 		{
 			name:        "cast Date",
 			odataFilter: "cast(Name, 'Edm.Date') eq '2023-01-01'",
-			expectSQL:   "CAST(name AS TEXT) = ?",
+			expectSQL:   "date(name) = ?",
 			expectArgs:  1,
 		},
 		{
 			name:        "cast TimeOfDay",
 			odataFilter: "cast(Name, 'Edm.TimeOfDay') eq '12:00:00'",
-			expectSQL:   "CAST(name AS TEXT) = ?",
+			expectSQL:   "time(name) = ?",
 			expectArgs:  1,
 		},
 	}

--- a/internal/query/cast_functions_test.go
+++ b/internal/query/cast_functions_test.go
@@ -339,6 +339,20 @@ func TestCastFunction_SQLGeneration(t *testing.T) {
 			expectedSQL:    "CAST(price AS REAL) >= ?",
 			expectedArgsNo: 1,
 		},
+		{
+			name:           "cast to Edm.Date uses date() on sqlite",
+			filter:         "cast(Name, 'Edm.Date') eq '2024-01-15'",
+			expectErr:      false,
+			expectedSQL:    "date(name) = ?",
+			expectedArgsNo: 1,
+		},
+		{
+			name:           "cast to Edm.TimeOfDay uses time() on sqlite",
+			filter:         "cast(Name, 'Edm.TimeOfDay') eq '10:30:00'",
+			expectErr:      false,
+			expectedSQL:    "time(name) = ?",
+			expectedArgsNo: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -393,6 +407,18 @@ func TestCastFunction_SQLGenerationSQLServer(t *testing.T) {
 			name:           "cast to DECIMAL",
 			filter:         "cast(Price, 'Edm.Decimal') gt 99.99",
 			expectedSQL:    "CAST([price] AS DECIMAL(38, 18)) > ?",
+			expectedArgsNo: 1,
+		},
+		{
+			name:           "cast to Edm.Date uses TRY_CONVERT on sqlserver",
+			filter:         "cast(Name, 'Edm.Date') eq '2024-01-15'",
+			expectedSQL:    "CAST(TRY_CONVERT(date, [name]) AS DATE) = ?",
+			expectedArgsNo: 1,
+		},
+		{
+			name:           "cast to Edm.TimeOfDay uses TRY_CONVERT on sqlserver",
+			filter:         "cast(Name, 'Edm.TimeOfDay') eq '10:30:00'",
+			expectedSQL:    "CAST(TRY_CONVERT(time, [name]) AS TIME) = ?",
 			expectedArgsNo: 1,
 		},
 	}


### PR DESCRIPTION
## Summary
- Fixes #739: `$filter=cast(CreatedAt,'Edm.Date') eq 2024-01-15` returned empty results because `CAST(datetime AS TEXT)` in SQLite returns the full datetime string, not just the date portion.
- For `Edm.Date` and `Edm.TimeOfDay` cast targets, `buildFunctionSQL` now emits dialect-specific SQL (`date()`/`time()` for SQLite, `DATE()`/`TIME()` for MySQL, `CAST(... AS DATE/TIME)` for Postgres, `CAST(TRY_CONVERT(...) AS DATE/TIME)` for SQL Server) instead of a generic `CAST(x AS TEXT)`.
- All other EDM types continue to use the existing `CAST(x AS TYPE)` path.

## Test plan
- [ ] `go test ./...` passes (all packages green)
- [ ] `TestCastFunction_SQLGeneration` covers new SQLite `date()`/`time()` cases
- [ ] `TestCastFunction_SQLGenerationSQLServer` covers new SQL Server `TRY_CONVERT` cases
- [ ] `TestCastFunctions_Integration` updated: `cast Date` → `date(name) = ?`, `cast TimeOfDay` → `time(name) = ?`

🤖 Generated with [Claude Code](https://claude.com/claude-code)