### PR TITLE
fix: resolve chained navigation paths like /Products({id})/Category/Products

### DIFF
--- a/http_runtime_test.go
+++ b/http_runtime_test.go
@@ -132,6 +132,10 @@ func (h *mockEntityHandler) FetchEntity(_ string) (interface{}, error) {
 	return nil, nil
 }
 
+func (h *mockEntityHandler) FetchNavEntityKey(_ string, _ string) (string, error) {
+	return "", nil
+}
+
 func newRuntimeService(recorder *pathRecorder) *Service {
 	handler := &mockEntityHandler{record: recorder.record}
 	resolver := func(name string) (servrouter.EntityHandler, bool) {

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -540,7 +540,8 @@ func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.D
 		return strings.Join(parts, ",")
 	}
 
-	handlePropertyRequest := func(w http.ResponseWriter, r *http.Request, handler *EntityHandler,
+	var handlePropertyRequest func(http.ResponseWriter, *http.Request, *EntityHandler, *response.ODataURLComponents, string)
+	handlePropertyRequest = func(w http.ResponseWriter, r *http.Request, handler *EntityHandler,
 		components *response.ODataURLComponents, key string) {
 		property := components.NavigationProperty
 		if property == "" {
@@ -554,6 +555,44 @@ func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.D
 		if components.IsCount {
 			handler.HandleNavigationPropertyCount(w, r, key, property)
 			return
+		}
+
+		// Handle chained navigation properties (e.g. Products(1)/Category/Products).
+		propertySegments := components.PropertySegments
+		if len(propertySegments) == 0 && property != "" {
+			propertySegments = []string{property}
+		}
+		if len(propertySegments) > 1 && handler.IsNavigationProperty(propertySegments[0]) {
+			targetEntitySet, hasTarget := handler.NavigationTargetSet(propertySegments[0])
+			if hasTarget {
+				targetHandler, targetExists := txHandlers[targetEntitySet]
+				if targetExists {
+					intermediateKey, err := handler.FetchNavEntityKey(key, propertySegments[0])
+					if err != nil {
+						statusCode := http.StatusInternalServerError
+						if IsNotFoundError(err) {
+							statusCode = http.StatusNotFound
+						}
+						if writeErr := response.WriteError(w, r, statusCode, "Navigation path error",
+							fmt.Sprintf("Could not resolve navigation path: %v", err)); writeErr != nil {
+							h.logger.Error("Error writing error response", "error", writeErr)
+						}
+						return
+					}
+					newComponents := &response.ODataURLComponents{
+						EntitySet:          targetEntitySet,
+						EntityKey:          intermediateKey,
+						EntityKeyMap:       make(map[string]string),
+						NavigationProperty: propertySegments[1],
+						PropertySegments:   propertySegments[1:],
+						PropertyPath:       strings.Join(propertySegments[1:], "/"),
+						IsRef:              components.IsRef,
+						IsCount:            components.IsCount,
+					}
+					handlePropertyRequest(w, r, targetHandler, newComponents, intermediateKey)
+					return
+				}
+			}
 		}
 
 		if handler.IsNavigationProperty(property) {

--- a/internal/handlers/navigation_properties.go
+++ b/internal/handlers/navigation_properties.go
@@ -718,6 +718,64 @@ func (h *EntityHandler) fetchParentEntityWithNav(entityKey, navPropertyName stri
 	return parent, db.First(parent).Error
 }
 
+// FetchNavEntityKey fetches the key string of the entity pointed to by a single-valued
+// navigation property. Used by the router to resolve chained navigation paths like
+// Products(1)/Category/Products.
+func (h *EntityHandler) FetchNavEntityKey(entityKey, navPropName string) (string, error) {
+	navProp := h.findNavigationProperty(navPropName)
+	if navProp == nil {
+		return "", fmt.Errorf("navigation property '%s' not found", navPropName)
+	}
+	if navProp.NavigationIsArray {
+		return "", fmt.Errorf("navigation property '%s' is a collection; chained navigation requires a single-valued property", navPropName)
+	}
+	targetMetadata, err := h.getTargetMetadata(navProp.NavigationTarget)
+	if err != nil {
+		return "", fmt.Errorf("failed to get target metadata: %w", err)
+	}
+	parent, err := h.fetchParentEntityWithNav(entityKey, navProp.Name)
+	if err != nil {
+		return "", err
+	}
+	navFieldValue := h.extractNavigationField(parent, navProp.Name)
+	if !navFieldValue.IsValid() {
+		return "", fmt.Errorf("could not access navigation property '%s'", navPropName)
+	}
+	navEntity := navFieldValue
+	if navEntity.Kind() == reflect.Ptr {
+		if navEntity.IsNil() {
+			return "", gorm.ErrRecordNotFound
+		}
+		navEntity = navEntity.Elem()
+	}
+	keyValues := response.ExtractEntityKeys(navEntity.Interface(), targetMetadata.KeyProperties)
+	if len(keyValues) == 0 {
+		return "", fmt.Errorf("could not extract key from navigation entity '%s'", navPropName)
+	}
+	if len(targetMetadata.KeyProperties) == 1 {
+		return fmt.Sprint(keyValues[targetMetadata.KeyProperties[0].JsonName]), nil
+	}
+	// Composite key: build "key1=val1,key2='val2'" format (numeric values unquoted, strings quoted)
+	parts := make([]string, 0, len(targetMetadata.KeyProperties))
+	for _, keyProp := range targetMetadata.KeyProperties {
+		v := keyValues[keyProp.JsonName]
+		s := fmt.Sprint(v)
+		isNumeric := true
+		for _, ch := range s {
+			if ch < '0' || ch > '9' {
+				isNumeric = false
+				break
+			}
+		}
+		if isNumeric {
+			parts = append(parts, fmt.Sprintf("%s=%s", keyProp.JsonName, s))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s='%s'", keyProp.JsonName, strings.ReplaceAll(s, "'", "''")))
+		}
+	}
+	return strings.Join(parts, ","), nil
+}
+
 // extractNavigationField extracts the navigation property field value from the parent entity
 func (h *EntityHandler) extractNavigationField(parent interface{}, navPropertyName string) reflect.Value {
 	parentValue := reflect.ValueOf(parent).Elem()

--- a/internal/service/router/router.go
+++ b/internal/service/router/router.go
@@ -36,6 +36,7 @@ type EntityHandler interface {
 	IsComplexTypeProperty(string) bool
 	NavigationTargetSet(string) (string, bool)
 	FetchEntity(string) (interface{}, error)
+	FetchNavEntityKey(entityKey, navPropName string) (string, error)
 }
 
 // HandlerResolver resolves an entity handler for the given entity set.
@@ -490,6 +491,39 @@ func (r *Router) handlePropertyRequest(w http.ResponseWriter, req *http.Request,
 
 			r.actionInvoker(w, req, lastOperationName, "", true, targetEntitySet)
 			return
+		}
+
+		// Handle chained navigation properties (e.g. Products(1)/Category/Products).
+		// OData §11.2.4.2: each navigation segment is resolved in turn against its parent entity.
+		if handler.IsNavigationProperty(firstSegment) {
+			targetEntitySet := r.getNavigationTargetEntitySet(handler, firstSegment)
+			targetHandler, targetExists := r.resolveHandler(targetEntitySet)
+			if targetExists {
+				intermediateKey, err := handler.FetchNavEntityKey(keyString, firstSegment)
+				if err != nil {
+					statusCode := http.StatusInternalServerError
+					if handlers.IsNotFoundError(err) {
+						statusCode = http.StatusNotFound
+					}
+					if writeErr := response.WriteError(w, req, statusCode, "Navigation path error",
+						fmt.Sprintf("Could not resolve navigation path: %v", err)); writeErr != nil {
+						r.logger.Error("Error writing error response", "error", writeErr)
+					}
+					return
+				}
+				newComponents := &response.ODataURLComponents{
+					EntitySet:          targetEntitySet,
+					EntityKey:          intermediateKey,
+					EntityKeyMap:       make(map[string]string),
+					NavigationProperty: propertySegments[1],
+					PropertySegments:   propertySegments[1:],
+					PropertyPath:       strings.Join(propertySegments[1:], "/"),
+					IsRef:              components.IsRef,
+					IsCount:            components.IsCount,
+				}
+				r.handlePropertyRequest(w, req, targetHandler, newComponents)
+				return
+			}
 		}
 	}
 

--- a/internal/service/router/router_test.go
+++ b/internal/service/router/router_test.go
@@ -31,13 +31,14 @@ func newTestAsyncManager(t *testing.T) *async.Manager {
 }
 
 type stubEntityHandler struct {
-	isSingleton       bool
-	navigationProps   map[string]bool
-	navigationTargets map[string]string
-	streamProps       map[string]bool
-	structuralProps   map[string]bool
-	complexProps      map[string]bool
-	calls             []string
+	isSingleton         bool
+	navigationProps     map[string]bool
+	navigationTargets   map[string]string
+	streamProps         map[string]bool
+	structuralProps     map[string]bool
+	complexProps        map[string]bool
+	calls               []string
+	fetchNavEntityKeyFn func(entityKey, navPropName string) (string, error)
 }
 
 func newStubEntityHandler() *stubEntityHandler {
@@ -122,6 +123,13 @@ func (h *stubEntityHandler) IsComplexTypeProperty(name string) bool {
 
 func (h *stubEntityHandler) FetchEntity(string) (interface{}, error) { return nil, nil }
 
+func (h *stubEntityHandler) FetchNavEntityKey(entityKey, navPropName string) (string, error) {
+	if h.fetchNavEntityKeyFn != nil {
+		return h.fetchNavEntityKeyFn(entityKey, navPropName)
+	}
+	return "", nil
+}
+
 func (h *stubEntityHandler) NavigationTargetSet(name string) (string, bool) {
 	if target, ok := h.navigationTargets[name]; ok {
 		return target, true
@@ -137,6 +145,28 @@ func boolToString(v bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+func newTestRouterMulti(handlers map[string]EntityHandler, actionDefs map[string][]*actions.ActionDefinition, functionDefs map[string][]*actions.FunctionDefinition, invoker ActionInvoker) *Router {
+	if actionDefs == nil {
+		actionDefs = make(map[string][]*actions.ActionDefinition)
+	}
+	if functionDefs == nil {
+		functionDefs = make(map[string][]*actions.FunctionDefinition)
+	}
+	return NewRouter(
+		func(name string) (EntityHandler, bool) {
+			h, ok := handlers[name]
+			return h, ok
+		},
+		func(http.ResponseWriter, *http.Request) {},
+		func(http.ResponseWriter, *http.Request) {},
+		func(http.ResponseWriter, *http.Request) {},
+		actionDefs,
+		functionDefs,
+		invoker,
+		nil,
+	)
 }
 
 func newTestRouter(handler EntityHandler, actionDefs map[string][]*actions.ActionDefinition, functionDefs map[string][]*actions.FunctionDefinition, invoker ActionInvoker) *Router {
@@ -601,5 +631,36 @@ func TestRouter_FunctionCompositionWithRenamedNavigation(t *testing.T) {
 
 	if !invoked {
 		t.Fatalf("expected function composition to use navigation target entity set")
+	}
+}
+
+// TestRouter_ChainedNavigation verifies that a two-level navigation path like
+// GET /Products(1)/Category/Products dispatches to the target entity handler
+// (Categories) using the intermediate entity's key returned by FetchNavEntityKey.
+func TestRouter_ChainedNavigation(t *testing.T) {
+	productsHandler := newStubEntityHandler()
+	productsHandler.navigationProps["Category"] = true
+	productsHandler.navigationTargets["Category"] = "Categories"
+	productsHandler.fetchNavEntityKeyFn = func(_, _ string) (string, error) {
+		return "42", nil // Category with key 42
+	}
+
+	categoriesHandler := newStubEntityHandler()
+	categoriesHandler.navigationProps["Products"] = true
+
+	r := newTestRouterMulti(map[string]EntityHandler{
+		"Products":   productsHandler,
+		"Categories": categoriesHandler,
+	}, nil, nil, func(http.ResponseWriter, *http.Request, string, string, bool, string) {})
+
+	req := httptest.NewRequest(http.MethodGet, "/Products(1)/Category/Products", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if len(productsHandler.calls) != 0 {
+		t.Fatalf("Products handler should not have been called for the final nav, got %v", productsHandler.calls)
+	}
+	if len(categoriesHandler.calls) != 1 || categoriesHandler.calls[0] != "navigation:42:Products:false" {
+		t.Fatalf("expected Categories handler navigation:42:Products:false, got %v", categoriesHandler.calls)
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes #749: `GET /Products({id})/Category/Products` returned the Category entity instead of the Products collection for that Category
- Adds `FetchNavEntityKey` to the `EntityHandler` interface to retrieve the key of an entity reached via a single-valued navigation property
- The router and batch handler now detect multi-segment navigation paths (where the last segment is not an action/function), resolve each intermediate entity's key, and delegate the remaining segments to the target entity handler recursively
- This correctly implements OData §11.2.4.2 for chained navigation paths of arbitrary depth

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] New unit test `TestRouter_ChainedNavigation` verifies that `GET /Products(1)/Category/Products` dispatches to the Categories handler's `HandleNavigationProperty` with the resolved intermediate key
- [ ] Manual test with compliance server: `GET /Products(<valid-id>)/Category/Products` should return an OData collection response with `@odata.context: "$metadata#Products"` and a `value` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)