### PR TITLE
fix: treat json:"-" as field exclusion, not literal property name

### DIFF
--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -828,6 +828,10 @@ func (h *EntityHandler) buildOrderedEntityResponseWithMetadata(result interface{
 				}
 			}
 		} else {
+			// Stream properties appear via media annotations, not as inline values
+			if propMeta != nil && propMeta.IsStream {
+				continue
+			}
 			// Regular property - add property-level annotations first (for full metadata)
 			if metadataLevel == "full" && propMeta != nil && propMeta.Annotations != nil && propMeta.Annotations.Len() > 0 {
 				for _, annotation := range propMeta.Annotations.Get() {

--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -161,6 +161,11 @@ func AnalyzeEntity(entity interface{}) (*EntityMetadata, error) {
 			continue
 		}
 
+		// Skip implementation fields excluded from JSON that have no OData-specific tag
+		if field.Tag.Get("json") == "-" && field.Tag.Get("odata") == "" {
+			continue
+		}
+
 		property, err := analyzeField(field, metadata)
 		if err != nil {
 			return nil, fmt.Errorf("error analyzing field %s: %w", field.Name, err)
@@ -247,6 +252,11 @@ func AnalyzeSingleton(entity interface{}, singletonName string) (*EntityMetadata
 			continue
 		}
 
+		// Skip implementation fields excluded from JSON that have no OData-specific tag
+		if field.Tag.Get("json") == "-" && field.Tag.Get("odata") == "" {
+			continue
+		}
+
 		property, err := analyzeField(field, metadata)
 		if err != nil {
 			return nil, fmt.Errorf("error analyzing field %s: %w", field.Name, err)
@@ -306,6 +316,11 @@ func AnalyzeVirtualEntity(entity interface{}) (*EntityMetadata, error) {
 
 		// Skip fields explicitly excluded from OData
 		if field.Tag.Get("odata") == "-" {
+			continue
+		}
+
+		// Skip implementation fields excluded from JSON that have no OData-specific tag
+		if field.Tag.Get("json") == "-" && field.Tag.Get("odata") == "" {
 			continue
 		}
 
@@ -849,7 +864,7 @@ func processFloatFacet(part, prefix string, target *float64) {
 // getJsonName extracts the JSON field name from struct tags
 func getJsonName(field reflect.StructField) string {
 	jsonTag := field.Tag.Get("json")
-	if jsonTag == "" {
+	if jsonTag == "" || jsonTag == "-" {
 		return field.Name
 	}
 
@@ -1065,19 +1080,33 @@ func detectStreamProperties(metadata *EntityMetadata) {
 		if strings.Contains(odataTag, "stream") {
 			prop.IsStream = true
 
-			// Look for associated content type and content fields
-			// Convention: for a stream property "Photo", look for "PhotoContentType" and "PhotoContent"
+			// Look for associated content type and content fields.
+			// Convention: for a stream property "Photo", look for "PhotoContentType" and "PhotoContent".
+			// These backing fields may carry json:"-" (excluded from OData properties) so we search
+			// the struct fields directly rather than only looking in metadata.Properties.
+			contentTypeName := prop.FieldName + "ContentType"
+			contentName := prop.FieldName + "Content"
+
+			// First, try OData-registered properties (backward compat)
 			for j := range metadata.Properties {
 				otherProp := &metadata.Properties[j]
-
-				// Check for content type field
-				if otherProp.FieldName == prop.FieldName+"ContentType" {
+				if otherProp.FieldName == contentTypeName {
 					prop.StreamContentTypeField = otherProp.FieldName
 				}
-
-				// Check for content field
-				if otherProp.FieldName == prop.FieldName+"Content" {
+				if otherProp.FieldName == contentName {
 					prop.StreamContentField = otherProp.FieldName
+				}
+			}
+
+			// If not found in properties, scan struct fields directly (handles json:"-" fields)
+			if prop.StreamContentTypeField == "" {
+				if _, ok := metadata.EntityType.FieldByName(contentTypeName); ok {
+					prop.StreamContentTypeField = contentTypeName
+				}
+			}
+			if prop.StreamContentField == "" {
+				if _, ok := metadata.EntityType.FieldByName(contentName); ok {
+					prop.StreamContentField = contentName
 				}
 			}
 

--- a/internal/response/expand_annotations.go
+++ b/internal/response/expand_annotations.go
@@ -126,6 +126,9 @@ func applyNestedExpandAnnotationsToStruct(entityVal reflect.Value, expandOptions
 		if !info.IsExported {
 			continue
 		}
+		if info.JsonName == "" {
+			continue
+		}
 
 		field := entityType.Field(i)
 		fieldVal := entityVal.Field(i)

--- a/internal/response/field_cache.go
+++ b/internal/response/field_cache.go
@@ -52,6 +52,11 @@ func extractJsonFieldName(field reflect.StructField) string {
 		return field.Name
 	}
 
+	// json:"-" (without trailing comma) means "exclude this field from JSON"
+	if jsonTag == "-" {
+		return ""
+	}
+
 	// Fast path: check for comma (most common case)
 	if idx := strings.IndexByte(jsonTag, ','); idx != -1 {
 		if idx > 0 {

--- a/internal/response/field_cache_test.go
+++ b/internal/response/field_cache_test.go
@@ -50,7 +50,7 @@ func TestExtractJsonFieldName(t *testing.T) {
 				Name: "FieldName",
 				Tag:  `json:"-"`,
 			},
-			expected: "-",
+			expected: "", // json:"-" means exclude from JSON; return empty string as exclusion signal
 		},
 		{
 			name: "JSON tag with comma only",

--- a/internal/response/navigation_links.go
+++ b/internal/response/navigation_links.go
@@ -237,6 +237,9 @@ func processStructEntityOrdered(entity reflect.Value, metadata EntityMetadataPro
 		if !info.IsExported {
 			continue
 		}
+		if info.JsonName == "" {
+			continue
+		}
 
 		propMeta := propMetaMap[info.Name]
 


### PR DESCRIPTION
## Summary

Fixes #751

- `json:"-"` struct fields (e.g. `PhotoContentType`, `PhotoContent`) were appearing in OData responses as the literal property key `"-"` instead of being excluded. Go's `encoding/json` treats `json:"-"` (without a trailing comma) as an exclusion signal — our tag parsers now do the same.
- Fields with `json:"-"` and no `odata` tag are skipped during metadata analysis (they are implementation-only backing fields, not OData properties). Fields with both `json:"-"` and an `odata` tag (e.g. `Photo` with `odata:"stream"`) are still processed.
- `detectStreamProperties` now scans struct fields directly so it can still locate backing fields (`PhotoContent`, `PhotoContentType`) even when they are excluded from OData metadata.

Per the OData ABNF spec, property identifiers must start with a letter or underscore; `"-"` is not a valid OData property name.

## Changes

| File | Change |
|---|---|
| `internal/metadata/analyzer.go` | `getJsonName` returns `field.Name` for `json:"-"`; field loops skip `json:"-"` fields without `odata` tag; `detectStreamProperties` scans struct type directly for backing fields |
| `internal/response/field_cache.go` | `extractJsonFieldName` returns `""` for `json:"-"` |
| `internal/response/navigation_links.go` | Skip fields with empty `JsonName` |
| `internal/response/expand_annotations.go` | Skip fields with empty `JsonName` |
| `internal/handlers/helpers.go` | Skip stream properties in the regular property serialization path |
| `internal/response/field_cache_test.go` | Update test expectation: `json:"-"` → `""` |

## Test plan

- [x] `go build ./...` — no errors
- [x] `go vet ./...` — no errors
- [x] `go test ./internal/response/... ./internal/handlers/... ./internal/metadata/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)