### PR TITLE
fix: support $expand=Nav/$ref to return entity references (OData §5.1.3)

### DIFF
--- a/internal/query/apply_expand_test.go
+++ b/internal/query/apply_expand_test.go
@@ -388,3 +388,43 @@ func TestApplyExpand(t *testing.T) {
 		}
 	})
 }
+
+func TestParseExpandRefSuffix(t *testing.T) {
+	meta := getExpandTestMetadata(t)
+
+	t.Run("Category/$ref sets IsRef and strips suffix", func(t *testing.T) {
+		opts, err := parseExpandWithConfig("category/$ref", meta, nil, 0, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 1 {
+			t.Fatalf("expected 1 expand option, got %d", len(opts))
+		}
+		if opts[0].NavigationProperty != "category" {
+			t.Errorf("NavigationProperty = %q, want %q", opts[0].NavigationProperty, "category")
+		}
+		if !opts[0].IsRef {
+			t.Error("expected IsRef = true")
+		}
+	})
+
+	t.Run("plain category does not set IsRef", func(t *testing.T) {
+		opts, err := parseExpandWithConfig("category", meta, nil, 0, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(opts) != 1 {
+			t.Fatalf("expected 1 expand option, got %d", len(opts))
+		}
+		if opts[0].IsRef {
+			t.Error("expected IsRef = false for plain expand")
+		}
+	})
+
+	t.Run("invalid navigation property with /$ref returns error", func(t *testing.T) {
+		_, err := parseExpandWithConfig("nonexistent/$ref", meta, nil, 0, false)
+		if err == nil {
+			t.Fatal("expected error for invalid navigation property, got nil")
+		}
+	})
+}

--- a/internal/query/expand_parser.go
+++ b/internal/query/expand_parser.go
@@ -128,6 +128,13 @@ func splitWithDelimiter(input string, delimiter byte) ([]string, error) {
 func parseSingleExpandCoreWithConfig(expandStr string, entityMetadata *metadata.EntityMetadata, validateMetadata bool, config *ParserConfig, currentDepth int, caseInsensitive bool) (ExpandOption, error) {
 	expand := ExpandOption{}
 
+	// Strip the /$ref suffix per OData spec §5.1.3: "Category/$ref" means expand and return
+	// only entity references ({@odata.id}) rather than full entity representations.
+	if strings.HasSuffix(expandStr, "/$ref") {
+		expand.IsRef = true
+		expandStr = strings.TrimSuffix(expandStr, "/$ref")
+	}
+
 	// Check for nested query options: NavigationProp($select=...,...)
 	if idx := strings.Index(expandStr, "("); idx != -1 {
 		if !strings.HasSuffix(expandStr, ")") {

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -37,6 +37,7 @@ type ParserConfig struct {
 // ExpandOption represents a single $expand clause
 type ExpandOption struct {
 	NavigationProperty string
+	IsRef              bool                   // true when the path ends with /$ref (return entity references only)
 	Select             []string               // Nested $select
 	Expand             []ExpandOption         // Nested $expand
 	Filter             *FilterExpression      // Nested $filter

--- a/internal/response/expand_annotations.go
+++ b/internal/response/expand_annotations.go
@@ -1,6 +1,7 @@
 package response
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -12,6 +13,11 @@ import (
 func ApplyExpandOptionToValue(value interface{}, expandOpt *query.ExpandOption, targetMetadata *metadata.EntityMetadata) (interface{}, *int) {
 	if expandOpt == nil {
 		return value, nil
+	}
+
+	// Per OData spec §5.1.3, $expand=Nav/$ref returns only entity references.
+	if expandOpt.IsRef {
+		return toEntityReferences(value, targetMetadata), nil
 	}
 
 	updatedValue := value
@@ -54,6 +60,171 @@ func ApplyExpandOptionToValue(value interface{}, expandOpt *query.ExpandOption, 
 	}
 
 	return updatedValue, count
+}
+
+// toEntityReferences converts an entity or slice of entities to the minimal entity-reference
+// representation required by OData spec §5.1.3 when $expand uses the /$ref suffix.
+// Each reference is a map containing only @odata.id built from the entity set name and key.
+func toEntityReferences(value interface{}, md *metadata.EntityMetadata) interface{} {
+	if value == nil || md == nil {
+		return nil
+	}
+
+	val := reflect.ValueOf(value)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+	}
+
+	switch val.Kind() {
+	case reflect.Slice, reflect.Array:
+		refs := make([]interface{}, val.Len())
+		for i := 0; i < val.Len(); i++ {
+			refs[i] = entityToReference(val.Index(i), md)
+		}
+		return refs
+	default:
+		return entityToReference(val, md)
+	}
+}
+
+// entityToReference builds a single {"@odata.id": "EntitySet(key)"} map for one entity.
+func entityToReference(val reflect.Value, md *metadata.EntityMetadata) map[string]interface{} {
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+	}
+
+	keySegment := buildKeySegmentForRef(val, md)
+	if keySegment == "" || md.EntitySetName == "" {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"@odata.id": md.EntitySetName + "(" + keySegment + ")",
+	}
+}
+
+// buildKeySegmentForRef extracts the key segment string from an entity value using metadata.
+func buildKeySegmentForRef(val reflect.Value, md *metadata.EntityMetadata) string {
+	if len(md.KeyProperties) == 0 {
+		return ""
+	}
+
+	if val.Kind() == reflect.Map {
+		return buildKeySegmentForRefFromMap(val, md)
+	}
+
+	if val.Kind() != reflect.Struct {
+		return ""
+	}
+
+	if len(md.KeyProperties) == 1 {
+		kp := md.KeyProperties[0]
+		fv := findFieldByName(val, kp.FieldName, kp.Name)
+		if !fv.IsValid() {
+			return ""
+		}
+		return formatRefKeyValue(fv)
+	}
+
+	var b strings.Builder
+	for i, kp := range md.KeyProperties {
+		fv := findFieldByName(val, kp.FieldName, kp.Name)
+		if !fv.IsValid() {
+			continue
+		}
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(kp.JsonName)
+		b.WriteByte('=')
+		if fv.Kind() == reflect.String {
+			b.WriteByte('\'')
+			b.WriteString(fv.String())
+			b.WriteByte('\'')
+		} else {
+			b.WriteString(formatRefKeyValue(fv))
+		}
+	}
+	return b.String()
+}
+
+func buildKeySegmentForRefFromMap(val reflect.Value, md *metadata.EntityMetadata) string {
+	if len(md.KeyProperties) == 1 {
+		kp := md.KeyProperties[0]
+		v := val.MapIndex(reflect.ValueOf(kp.JsonName))
+		if !v.IsValid() {
+			v = val.MapIndex(reflect.ValueOf(kp.Name))
+		}
+		if !v.IsValid() {
+			return ""
+		}
+		elem := v.Elem()
+		if elem.Kind() == reflect.String {
+			return "'" + elem.String() + "'"
+		}
+		return fmt.Sprintf("%v", elem.Interface())
+	}
+
+	var b strings.Builder
+	for i, kp := range md.KeyProperties {
+		v := val.MapIndex(reflect.ValueOf(kp.JsonName))
+		if !v.IsValid() {
+			v = val.MapIndex(reflect.ValueOf(kp.Name))
+		}
+		if !v.IsValid() {
+			continue
+		}
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		elem := v.Elem()
+		b.WriteString(kp.JsonName)
+		b.WriteByte('=')
+		if elem.Kind() == reflect.String {
+			b.WriteByte('\'')
+			b.WriteString(elem.String())
+			b.WriteByte('\'')
+		} else {
+			b.WriteString(fmt.Sprintf("%v", elem.Interface()))
+		}
+	}
+	return b.String()
+}
+
+// findFieldByName locates a struct field by its Go field name or JSON name.
+func findFieldByName(val reflect.Value, fieldName, fallbackName string) reflect.Value {
+	t := val.Type()
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Name == fieldName || f.Name == fallbackName {
+			return val.Field(i)
+		}
+		if tag := f.Tag.Get("json"); tag != "" {
+			parts := strings.SplitN(tag, ",", 2)
+			if parts[0] == fieldName || parts[0] == fallbackName {
+				return val.Field(i)
+			}
+		}
+	}
+	return reflect.Value{}
+}
+
+func formatRefKeyValue(v reflect.Value) string {
+	switch v.Kind() {
+	case reflect.String:
+		return "'" + v.String() + "'"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprintf("%d", v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprintf("%d", v.Uint())
+	default:
+		return fmt.Sprintf("%v", v.Interface())
+	}
 }
 
 // ApplyExpandAnnotationsToMap applies expand annotations to a map-based entity representation.

--- a/internal/response/expand_annotations_test.go
+++ b/internal/response/expand_annotations_test.go
@@ -1,6 +1,7 @@
 package response
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -230,5 +231,98 @@ func assertExpandedChildren(t *testing.T, value interface{}) {
 	}
 	if len(toys) != 2 {
 		t.Fatalf("expected 2 toys, got %d", len(toys))
+	}
+}
+
+// ---- $expand=Nav/$ref tests ----
+
+type refCategory struct {
+	ID   int    `json:"ID" odata:"key"`
+	Name string `json:"name"`
+}
+
+func TestApplyExpandOptionToValue_IsRef_SingleEntity(t *testing.T) {
+	catMeta := mustAnalyzeEntity(t, refCategory{})
+
+	expandOpt := &query.ExpandOption{IsRef: true}
+	cat := refCategory{ID: 7, Name: "Electronics"}
+
+	result, count := ApplyExpandOptionToValue(cat, expandOpt, catMeta)
+
+	if count != nil {
+		t.Fatalf("expected nil count for IsRef, got %v", *count)
+	}
+
+	ref, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+
+	odataID, ok := ref["@odata.id"]
+	if !ok {
+		t.Fatal("expected @odata.id in result")
+	}
+
+	expected := catMeta.EntitySetName + "(7)"
+	if odataID != expected {
+		t.Fatalf("@odata.id = %q, want %q", odataID, expected)
+	}
+
+	if len(ref) != 1 {
+		t.Fatalf("expected exactly 1 key in reference map, got %d: %v", len(ref), ref)
+	}
+}
+
+func TestApplyExpandOptionToValue_IsRef_Collection(t *testing.T) {
+	catMeta := mustAnalyzeEntity(t, refCategory{})
+
+	expandOpt := &query.ExpandOption{IsRef: true}
+	cats := []refCategory{
+		{ID: 1, Name: "Electronics"},
+		{ID: 2, Name: "Books"},
+	}
+
+	result, count := ApplyExpandOptionToValue(cats, expandOpt, catMeta)
+
+	if count != nil {
+		t.Fatalf("expected nil count for IsRef, got %v", *count)
+	}
+
+	refs, ok := result.([]interface{})
+	if !ok {
+		t.Fatalf("expected []interface{} result, got %T", result)
+	}
+
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 references, got %d", len(refs))
+	}
+
+	for i, r := range refs {
+		ref, ok := r.(map[string]interface{})
+		if !ok {
+			t.Fatalf("refs[%d] is %T, want map", i, r)
+		}
+		odataID, ok := ref["@odata.id"].(string)
+		if !ok {
+			t.Fatalf("refs[%d] missing string @odata.id", i)
+		}
+		expectedID := catMeta.EntitySetName + fmt.Sprintf("(%d)", cats[i].ID)
+		if odataID != expectedID {
+			t.Fatalf("refs[%d] @odata.id = %q, want %q", i, odataID, expectedID)
+		}
+	}
+}
+
+func TestApplyExpandOptionToValue_IsRef_Nil(t *testing.T) {
+	catMeta := mustAnalyzeEntity(t, refCategory{})
+
+	expandOpt := &query.ExpandOption{IsRef: true}
+	result, count := ApplyExpandOptionToValue(nil, expandOpt, catMeta)
+
+	if count != nil {
+		t.Fatalf("expected nil count, got %v", *count)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result for nil input, got %v", result)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `IsRef bool` field to `ExpandOption` to represent the `/$ref` path suffix
- Strips the `/$ref` suffix in `parseSingleExpandCoreWithConfig` before navigation property name validation, so `Category/$ref` resolves as `Category` with `IsRef = true`
- In `ApplyExpandOptionToValue`, when `IsRef` is set, the expanded entity/collection is converted to minimal entity-reference maps (`{"@odata.id": "EntitySet(key)"}`) instead of full representations

## Spec reference

OData v4.0 URL Conventions §5.1.3:
> *"A path expression ending in `/$ref` addresses the entity references of the related entities."*

Closes #755

## Test plan

- [ ] `TestParseExpandRefSuffix` — parser sets `IsRef=true` and strips `/$ref` suffix; invalid nav property still errors
- [ ] `TestApplyExpandOptionToValue_IsRef_SingleEntity` — single entity → `{"@odata.id": "Set(key)"}`
- [ ] `TestApplyExpandOptionToValue_IsRef_Collection` — collection → slice of reference maps
- [ ] `TestApplyExpandOptionToValue_IsRef_Nil` — nil input → nil output
- [ ] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)