### PR TITLE
fix: absolute @odata.index positions with $skip

### DIFF
--- a/internal/handlers/collection_response.go
+++ b/internal/handlers/collection_response.go
@@ -82,8 +82,13 @@ func (h *EntityHandler) collectionResponseWriter(w http.ResponseWriter, r *http.
 			contextProps = queryOptions.Select
 		}
 
+		skip := 0
+		if queryOptions.Skip != nil {
+			skip = *queryOptions.Skip
+		}
+
 		metadataProvider := h.getMetadataAdapter()
-		if err := response.WriteODataCollectionWithNavigationAndSelect(w, r, h.metadata.EntitySetName, results, totalCount, nextLink, deltaLink, metadataProvider, queryOptions.Expand, selectedNavProps, h.metadata, contextProps); err != nil {
+		if err := response.WriteODataCollectionWithNavigationAndSelect(w, r, h.metadata.EntitySetName, results, totalCount, nextLink, deltaLink, metadataProvider, queryOptions.Expand, selectedNavProps, h.metadata, contextProps, skip); err != nil {
 			h.logger.Error("Error writing OData response", "error", err)
 		}
 

--- a/internal/handlers/pagination_test.go
+++ b/internal/handlers/pagination_test.go
@@ -292,6 +292,63 @@ func TestEntityHandlerCollectionWithTopAndSkip(t *testing.T) {
 	}
 }
 
+func TestEntityHandlerCollectionWithIndexAndSkip(t *testing.T) {
+	handler, db := setupProductHandler(t)
+
+	products := make([]Product, 10)
+	for i := 0; i < 10; i++ {
+		products[i] = Product{
+			ID:          i + 1,
+			Name:        "Product " + string(rune('A'+(i%26))),
+			Description: "Description",
+			Price:       float64(i+1) * 10.0,
+			Category:    "Electronics",
+		}
+		db.Create(&products[i])
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/Products", nil)
+	q := req.URL.Query()
+	q.Add("$top", "2")
+	q.Add("$skip", "2")
+	q.Add("$index", "")
+	req.URL.RawQuery = q.Encode()
+	w := httptest.NewRecorder()
+
+	handler.HandleCollection(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Status = %v, want %v", w.Code, http.StatusOK)
+	}
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	value, ok := response["value"].([]interface{})
+	if !ok || len(value) != 2 {
+		t.Fatalf("Expected 2 results, got %v", response["value"])
+	}
+
+	// @odata.index must reflect the absolute position in the total collection
+	// (i.e. offset by $skip), not the position within the returned page.
+	expectedIndexes := []int{2, 3}
+	for i, item := range value {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("item %d is not a map", i)
+		}
+		index, ok := itemMap["@odata.index"].(float64)
+		if !ok {
+			t.Fatalf("item %d missing @odata.index, got %v", i, itemMap["@odata.index"])
+		}
+		if int(index) != expectedIndexes[i] {
+			t.Errorf("item %d @odata.index = %d, want %d", i, int(index), expectedIndexes[i])
+		}
+	}
+}
+
 func TestEntityHandlerCollectionWithCount(t *testing.T) {
 	handler, db := setupProductHandler(t)
 

--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -30,20 +30,23 @@ func WriteODataCollectionWithDelta(w http.ResponseWriter, r *http.Request, entit
 
 // WriteODataCollectionWithNavigation writes an OData collection response with navigation links.
 func WriteODataCollectionWithNavigation(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink *string, metadata EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, fullMetadata *metadata.EntityMetadata) error {
-	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, nil, metadata, expandOptions, selectedNavProps, fullMetadata, nil)
+	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, nil, metadata, expandOptions, selectedNavProps, fullMetadata, nil, 0)
 }
 
 // WriteODataCollectionWithNavigationAndDelta writes an OData collection response with navigation links and a delta link.
 func WriteODataCollectionWithNavigationAndDelta(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, metadata EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, fullMetadata *metadata.EntityMetadata) error {
-	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, deltaLink, metadata, expandOptions, selectedNavProps, fullMetadata, nil)
+	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, deltaLink, metadata, expandOptions, selectedNavProps, fullMetadata, nil, 0)
 }
 
 // WriteODataCollectionWithNavigationAndSelect writes an OData collection response with navigation links
 // and a pre-computed list of selected/output properties used to build the @odata.context URL.
 // selectedProps should contain the $select properties (or $apply output properties) so that the
 // context URL is shaped as #EntitySet(prop1,prop2) per the OData spec.
-func WriteODataCollectionWithNavigationAndSelect(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, md EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, fullMetadata *metadata.EntityMetadata, selectedProps []string) error {
-	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, deltaLink, md, expandOptions, selectedNavProps, fullMetadata, selectedProps)
+// skip is the $skip offset applied to the underlying query, used so that @odata.index annotations
+// (when $index is requested) reflect the item's absolute position in the full collection rather
+// than its position within the current page.
+func WriteODataCollectionWithNavigationAndSelect(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, md EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, fullMetadata *metadata.EntityMetadata, selectedProps []string, skip int) error {
+	return writeODataCollectionWithNavigationResponse(w, r, entitySetName, data, count, nextLink, deltaLink, md, expandOptions, selectedNavProps, fullMetadata, selectedProps, skip)
 }
 
 func writeODataCollectionResponse(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, selectedProps []string) error {
@@ -102,7 +105,7 @@ func writeODataCollectionResponse(w http.ResponseWriter, r *http.Request, entity
 	return encoder.Encode(response)
 }
 
-func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, metadata EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, fullMetadata *metadata.EntityMetadata, selectedProps []string) error {
+func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.Request, entitySetName string, data interface{}, count *int64, nextLink, deltaLink *string, metadata EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, fullMetadata *metadata.EntityMetadata, selectedProps []string, skip int) error {
 	if !IsAcceptableFormat(r) {
 		return WriteError(w, r, http.StatusNotAcceptable, "Not Acceptable",
 			"The requested format is not supported. Only application/json and application/atom+xml are supported for data responses.")
@@ -134,7 +137,7 @@ func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.R
 
 	// Add @odata.index annotations if $index query parameter is present
 	if shouldAddIndexAnnotations(r) {
-		transformedData = addIndexAnnotations(transformedData)
+		transformedData = addIndexAnnotations(transformedData, skip)
 	}
 
 	// Build the envelope as an OrderedMap to avoid reflection-based map encoding.
@@ -244,15 +247,17 @@ func shouldAddIndexAnnotations(r *http.Request) bool {
 	return normalizedExists
 }
 
-// addIndexAnnotations adds @odata.index annotations to collection items
-// The index represents the zero-based ordinal position of each item in the collection
-func addIndexAnnotations(data []interface{}) []interface{} {
+// addIndexAnnotations adds @odata.index annotations to collection items.
+// The index represents the zero-based ordinal position of each item in the total collection,
+// so skip (the $skip offset of the current page) is added to the item's position within the page.
+func addIndexAnnotations(data []interface{}, skip int) []interface{} {
 	for i, item := range data {
+		index := skip + i
 		switch value := item.(type) {
 		case map[string]interface{}:
-			value["@odata.index"] = i
+			value["@odata.index"] = index
 		case *OrderedMap:
-			value.Set("@odata.index", i)
+			value.Set("@odata.index", index)
 		}
 	}
 	return data

--- a/internal/response/collection_test.go
+++ b/internal/response/collection_test.go
@@ -15,7 +15,7 @@ func TestAddIndexAnnotationsAddsIndexesToMaps(t *testing.T) {
 		map[string]interface{}{"ID": 2},
 	}
 
-	annotated := addIndexAnnotations(data)
+	annotated := addIndexAnnotations(data, 0)
 
 	for i, item := range annotated {
 		itemMap, ok := item.(map[string]interface{})
@@ -33,13 +33,33 @@ func TestAddIndexAnnotationsAddsIndexesToMaps(t *testing.T) {
 	}
 }
 
+func TestAddIndexAnnotationsUsesSkipAsAbsoluteOffset(t *testing.T) {
+	data := []interface{}{
+		map[string]interface{}{"ID": 1},
+		map[string]interface{}{"ID": 2},
+	}
+
+	annotated := addIndexAnnotations(data, 2)
+
+	for i, item := range annotated {
+		itemMap := item.(map[string]interface{})
+		index, ok := itemMap["@odata.index"].(int)
+		if !ok {
+			t.Fatalf("item %d missing integer @odata.index, got %T", i, itemMap["@odata.index"])
+		}
+		if want := 2 + i; index != want {
+			t.Fatalf("item %d index = %d, want %d", i, index, want)
+		}
+	}
+}
+
 func TestAddIndexAnnotationsAddsIndexesToOrderedMaps(t *testing.T) {
 	first := NewOrderedMap()
 	first.Set("ID", 1)
 	second := NewOrderedMap()
 	second.Set("ID", 2)
 
-	annotated := addIndexAnnotations([]interface{}{first, second})
+	annotated := addIndexAnnotations([]interface{}{first, second}, 0)
 
 	for i, item := range annotated {
 		ordered, ok := item.(*OrderedMap)


### PR DESCRIPTION
## Summary
- `@odata.index` annotations always started at 0 because `addIndexAnnotations` only ever saw the already-paginated page slice, with no knowledge of `$skip`.
- Threads the `$skip` offset from `queryOptions` through `WriteODataCollectionWithNavigationAndSelect` → `writeODataCollectionWithNavigationResponse` → `addIndexAnnotations`, so each item's `@odata.index` is now `skip + positionInPage`, matching OData v4.01 §11.2.5.13.

Fixes #763

## Test plan
- [x] `go test ./internal/response/... ./internal/handlers/...`
- [x] `go test ./...`
- [x] Added `TestAddIndexAnnotationsUsesSkipAsAbsoluteOffset` (unit) and `TestEntityHandlerCollectionWithIndexAndSkip` (HTTP-level) covering `GET /Products?$top=2&$skip=2&$index` → first item `@odata.index: 2`, second `3`.