### PR TITLE
fix: omit null-valued properties for Prefer: omit-values=nulls

### DIFF
--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -223,6 +223,10 @@ func (h *EntityHandler) writeEntityResponseWithETag(w http.ResponseWriter, r *ht
 
 	odataResponse := h.buildOrderedEntityResponseWithMetadata(result, contextURL, metadataLevel, r, etagValue, expandOptions)
 
+	if pref.OmitsNulls() {
+		response.OmitNullValues(odataResponse)
+	}
+
 	if etagValue != "" {
 		w.Header().Set(HeaderETag, etagValue)
 	}

--- a/internal/preference/preference.go
+++ b/internal/preference/preference.go
@@ -209,6 +209,21 @@ func (p *Preference) ApplyOmitValues(allowUnprefixed bool) {
 	}
 }
 
+// OmitsNulls reports whether the omit-values=nulls preference was applied, meaning
+// properties with a null value should be removed from the response body
+// (OData v4.01 §11.2.8.6).
+func (p *Preference) OmitsNulls() bool {
+	if !p.omitValuesApplied || p.OmitValues == nil {
+		return false
+	}
+	for _, token := range strings.Split(*p.OmitValues, ",") {
+		if strings.EqualFold(strings.TrimSpace(token), "nulls") {
+			return true
+		}
+	}
+	return false
+}
+
 // MatchesAnnotationFilter reports whether the given qualified annotation term name
 // should be included according to the odata.include-annotations filter value.
 //

--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/preference"
 	"github.com/nlstn/go-odata/internal/query"
 	"github.com/nlstn/go-odata/internal/version"
 )
@@ -130,6 +131,16 @@ func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.R
 	transformedData := addNavigationLinks(data, metadata, expandOptions, selectedNavProps, r, entitySetName, metadataLevel, fullMetadata)
 	if transformedData == nil {
 		transformedData = []interface{}{}
+	}
+
+	// Honor Prefer: omit-values=nulls by removing null-valued properties from each item.
+	if pref := preference.ParsePrefer(r); pref.OmitValues != nil {
+		pref.ApplyOmitValues(version.GetVersion(r.Context()).Supports("unprefixed-preferences"))
+		if pref.OmitsNulls() {
+			for _, item := range transformedData {
+				OmitNullValues(item)
+			}
+		}
 	}
 
 	// Add @odata.index annotations if $index query parameter is present

--- a/internal/response/omit_values.go
+++ b/internal/response/omit_values.go
@@ -1,0 +1,70 @@
+package response
+
+import "reflect"
+
+// OmitNullValues removes properties with a null value from item, honoring the
+// Prefer: omit-values=nulls preference (OData v4.01 §11.2.8.6). item must be an
+// *OrderedMap or map[string]interface{}; any other type is a no-op. Nested
+// OrderedMap/map values (e.g. expanded navigation properties) and slices of them
+// are processed recursively, since the preference applies to every property in
+// the response, not just the top level.
+func OmitNullValues(item interface{}) {
+	switch v := item.(type) {
+	case *OrderedMap:
+		omitNullValuesFromOrderedMap(v)
+	case map[string]interface{}:
+		omitNullValuesFromMap(v)
+	}
+}
+
+func omitNullValuesFromOrderedMap(om *OrderedMap) {
+	if om == nil {
+		return
+	}
+	keys := append([]string(nil), om.keys...)
+	for _, key := range keys {
+		val := om.values[key]
+		if isNullValue(val) {
+			om.Delete(key)
+			continue
+		}
+		omitNullValuesFromNested(val)
+	}
+}
+
+func omitNullValuesFromMap(m map[string]interface{}) {
+	for key, val := range m {
+		if isNullValue(val) {
+			delete(m, key)
+			continue
+		}
+		omitNullValuesFromNested(val)
+	}
+}
+
+func omitNullValuesFromNested(val interface{}) {
+	switch v := val.(type) {
+	case *OrderedMap:
+		omitNullValuesFromOrderedMap(v)
+	case map[string]interface{}:
+		omitNullValuesFromMap(v)
+	case []interface{}:
+		for _, item := range v {
+			omitNullValuesFromNested(item)
+		}
+	}
+}
+
+// isNullValue reports whether v represents a JSON null: either a nil interface,
+// or a typed nil (nil pointer/map/slice) that would otherwise marshal to "null".
+func isNullValue(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Interface, reflect.Chan, reflect.Func:
+		return rv.IsNil()
+	}
+	return false
+}

--- a/internal/response/omit_values_test.go
+++ b/internal/response/omit_values_test.go
@@ -1,0 +1,67 @@
+package response
+
+import "testing"
+
+func TestOmitNullValuesRemovesNullKeysFromMap(t *testing.T) {
+	m := map[string]interface{}{
+		"ID":          1,
+		"Name":        "Widget",
+		"Description": nil,
+	}
+
+	OmitNullValues(m)
+
+	if _, ok := m["Description"]; ok {
+		t.Errorf("expected Description to be removed, got %v", m)
+	}
+	if m["Name"] != "Widget" {
+		t.Errorf("expected Name to be preserved, got %v", m["Name"])
+	}
+}
+
+func TestOmitNullValuesRemovesTypedNilPointer(t *testing.T) {
+	var nilStr *string
+	m := map[string]interface{}{
+		"Description": nilStr,
+	}
+
+	OmitNullValues(m)
+
+	if _, ok := m["Description"]; ok {
+		t.Errorf("expected typed-nil Description to be removed, got %v", m)
+	}
+}
+
+func TestOmitNullValuesRemovesNullKeysFromOrderedMap(t *testing.T) {
+	om := NewOrderedMap()
+	om.Set("ID", 1)
+	om.Set("Description", nil)
+
+	OmitNullValues(om)
+
+	if _, exists := om.values["Description"]; exists {
+		t.Errorf("expected Description to be removed, got %v", om.values)
+	}
+	if om.values["ID"] != 1 {
+		t.Errorf("expected ID to be preserved, got %v", om.values["ID"])
+	}
+}
+
+func TestOmitNullValuesRecursesIntoNestedOrderedMaps(t *testing.T) {
+	nested := NewOrderedMap()
+	nested.Set("City", "Berlin")
+	nested.Set("Zip", nil)
+
+	om := NewOrderedMap()
+	om.Set("Name", "Widget")
+	om.Set("Address", nested)
+
+	OmitNullValues(om)
+
+	if _, exists := nested.values["Zip"]; exists {
+		t.Errorf("expected nested Zip to be removed, got %v", nested.values)
+	}
+	if nested.values["City"] != "Berlin" {
+		t.Errorf("expected nested City to be preserved, got %v", nested.values["City"])
+	}
+}

--- a/test/prefer_test.go
+++ b/test/prefer_test.go
@@ -786,3 +786,126 @@ func TestPrefer_IncludeAnnotations_PreferenceApplied_AlwaysSetWhenRequested(t *t
 		t.Errorf("Preference-Applied should be set whenever include-annotations is requested, got %q", applied)
 	}
 }
+
+// OmitValuesProduct has a nullable field for testing Prefer: omit-values=nulls.
+type OmitValuesProduct struct {
+	ID          uint    `json:"ID" gorm:"primaryKey;autoIncrement" odata:"key"`
+	Name        string  `json:"Name"`
+	Description *string `json:"Description"`
+}
+
+func setupOmitValuesService(t *testing.T) (*odata.Service, *gorm.DB) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	if err := db.AutoMigrate(&OmitValuesProduct{}); err != nil {
+		t.Fatalf("Failed to migrate: %v", err)
+	}
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	if err := service.RegisterEntity(&OmitValuesProduct{}); err != nil {
+		t.Fatalf("Failed to register entity: %v", err)
+	}
+	return service, db
+}
+
+// TestPrefer_OmitValuesNulls_EntityRead verifies that Prefer: omit-values=nulls removes
+// null-valued properties from a single entity response, per OData v4.01 §11.2.8.6.
+func TestPrefer_OmitValuesNulls_EntityRead(t *testing.T) {
+	service, db := setupOmitValuesService(t)
+	db.Create(&OmitValuesProduct{Name: "Widget", Description: nil})
+
+	req := httptest.NewRequest(http.MethodGet, "/OmitValuesProducts(1)", nil)
+	req.Header.Set("Prefer", "omit-values=nulls")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if applied := w.Header().Get("Preference-Applied"); applied != "omit-values=nulls" {
+		t.Errorf("Preference-Applied = %q, want \"omit-values=nulls\"", applied)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if _, ok := resp["Description"]; ok {
+		t.Errorf("Description should be omitted entirely, got response: %v", resp)
+	}
+	if resp["Name"] != "Widget" {
+		t.Errorf("expected Name=Widget to still be present, got %v", resp["Name"])
+	}
+}
+
+// TestPrefer_OmitValuesNulls_CollectionRead verifies null-property omission on collection reads.
+func TestPrefer_OmitValuesNulls_CollectionRead(t *testing.T) {
+	service, db := setupOmitValuesService(t)
+	desc := "Has a description"
+	db.Create(&OmitValuesProduct{Name: "WithDesc", Description: &desc})
+	db.Create(&OmitValuesProduct{Name: "WithoutDesc", Description: nil})
+
+	req := httptest.NewRequest(http.MethodGet, "/OmitValuesProducts?$top=3", nil)
+	req.Header.Set("Prefer", "omit-values=nulls")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if applied := w.Header().Get("Preference-Applied"); applied != "omit-values=nulls" {
+		t.Errorf("Preference-Applied = %q, want \"omit-values=nulls\"", applied)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	values, ok := resp["value"].([]interface{})
+	if !ok || len(values) != 2 {
+		t.Fatalf("expected 2 items, got %v", resp["value"])
+	}
+
+	withDesc := values[0].(map[string]interface{})
+	if withDesc["Description"] != "Has a description" {
+		t.Errorf("expected Description to be present for first item, got %v", withDesc)
+	}
+
+	withoutDesc := values[1].(map[string]interface{})
+	if _, ok := withoutDesc["Description"]; ok {
+		t.Errorf("Description should be omitted for second item, got %v", withoutDesc)
+	}
+}
+
+// TestPrefer_OmitValuesNulls_NotAppliedWithoutPreference verifies that null properties
+// are still present when the omit-values preference is not requested.
+func TestPrefer_OmitValuesNulls_NotAppliedWithoutPreference(t *testing.T) {
+	service, db := setupOmitValuesService(t)
+	db.Create(&OmitValuesProduct{Name: "Widget", Description: nil})
+
+	req := httptest.NewRequest(http.MethodGet, "/OmitValuesProducts(1)", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	descValue, ok := resp["Description"]
+	if !ok {
+		t.Fatal("Description key should be present (as null) when preference is not requested")
+	}
+	if descValue != nil {
+		t.Errorf("expected Description to be null, got %v", descValue)
+	}
+}


### PR DESCRIPTION
## Summary
- `Preference-Applied: omit-values=nulls` was already being sent, but nothing actually stripped null-valued properties from the response body — clients still saw e.g. `"Description": null`.
- Adds `response.OmitNullValues`, which recursively removes null (including typed-nil pointer/map/slice) properties from `*OrderedMap`/`map[string]interface{}` response items, and wires it into:
  - the single-entity response path (`writeEntityResponseWithETag` — covers GET, POST create, PATCH/PUT, singleton reads)
  - the collection response path (`writeODataCollectionWithNavigationResponse`)
- Adds `Preference.OmitsNulls()` to centralize the "was omit-values=nulls actually applied" check (respects the existing version-gating for the unprefixed `omit-values=` form vs. `odata.omit-values=`).

Fixes #764

## Test plan
- [x] `go test ./...`
- [x] Added unit tests for `OmitNullValues` (plain map, `*OrderedMap`, nested `*OrderedMap`, and the typed-nil-pointer edge case that a naive `== nil` check would miss).
- [x] Added integration tests in `test/prefer_test.go`: entity GET, collection GET, and a control test confirming null properties remain present when the preference is *not* requested.