### PR TITLE
fix: include Location header on in-progress async status monitor 202

### DIFF
--- a/internal/async/manager.go
+++ b/internal/async/manager.go
@@ -428,6 +428,7 @@ type jobSnapshot struct {
 	retryAfter *time.Duration
 	response   *StoredResponse
 	err        string
+	monitorURL string
 }
 
 // ServeMonitor handles HTTP requests for job status monitoring.
@@ -492,6 +493,11 @@ func (m *Manager) ServeMonitor(w http.ResponseWriter, r *http.Request) {
 
 	switch snapshot.status {
 	case JobPending, JobRunning:
+		location := snapshot.monitorURL
+		if location == "" {
+			location = id
+		}
+		w.Header().Set("Location", location)
 		w.Header().Set("Preference-Applied", "respond-async")
 		if snapshot.retryAfter != nil {
 			w.Header().Set("Retry-After", formatRetryAfter(*snapshot.retryAfter))
@@ -670,9 +676,10 @@ func recordToSnapshot(record *JobRecord) (jobSnapshot, error) {
 		return jobSnapshot{}, err
 	}
 	snapshot := jobSnapshot{
-		status:   record.Status,
-		response: resp,
-		err:      record.ErrorText,
+		status:     record.Status,
+		response:   resp,
+		err:        record.ErrorText,
+		monitorURL: record.MonitorURL,
 	}
 	if retry != nil {
 		snapshot.retryAfter = retry

--- a/test/async_monitor_test.go
+++ b/test/async_monitor_test.go
@@ -64,6 +64,44 @@ func TestAsyncMonitorGetMatchesSynchronousResponse(t *testing.T) {
 	}
 }
 
+func TestAsyncMonitorInProgressResponseHasLocationHeader(t *testing.T) {
+	service, db := setupPreferTestService(t)
+	enableAsyncProcessing(t, service, 2*time.Second)
+
+	existing := []PreferTestProduct{
+		{Name: "Pending One", Price: 10},
+		{Name: "Pending Two", Price: 20},
+	}
+	if err := db.Create(&existing).Error; err != nil {
+		t.Fatalf("failed to seed products: %v", err)
+	}
+
+	asyncReq := httptest.NewRequest(http.MethodGet, "/PreferTestProducts?$orderby=Name", nil)
+	asyncReq.Header.Set("Prefer", "respond-async")
+	asyncRec := httptest.NewRecorder()
+	service.ServeHTTP(asyncRec, asyncReq)
+
+	if asyncRec.Code != http.StatusAccepted {
+		t.Fatalf("expected async acknowledgement, got %d", asyncRec.Code)
+	}
+
+	location := asyncRec.Header().Get("Location")
+	if location == "" {
+		t.Fatal("missing monitor Location header")
+	}
+
+	pollRec := issueMonitorRequest(t, service, http.MethodGet, location)
+	if pollRec.Code != http.StatusAccepted {
+		t.Fatalf("expected job still in progress (202), got %d", pollRec.Code)
+	}
+
+	if got := pollRec.Header().Get("Location"); got == "" {
+		t.Fatal("in-progress 202 response from status monitor missing Location header (OData §13.1)")
+	}
+
+	waitForMonitorCompletion(t, service, location)
+}
+
 func TestAsyncMonitorDeleteRemovesCompletedJob(t *testing.T) {
 	service, _ := setupPreferTestService(t)
 	enableAsyncProcessing(t, service, time.Second)


### PR DESCRIPTION
## Summary

Fixes #769.

Per OData Protocol §13.1, a GET to the status-monitor resource for a job that is still pending/running must return `202 Accepted` with a `Location` header pointing back to the status-monitor resource. The monitor URL was already persisted on `JobRecord.MonitorURL` at job creation, but `ServeMonitor`'s in-progress branch never read it back onto the response.

## Change

- `jobSnapshot` now carries `monitorURL`, populated from `record.MonitorURL` in `recordToSnapshot`.
- The `JobPending`/`JobRunning` branch of `ServeMonitor` sets the `Location` header (falling back to the job ID, mirroring `WriteInitialResponse`'s existing fallback) before writing the 202.

## Test plan

- [x] Added `TestAsyncMonitorInProgressResponseHasLocationHeader`, which polls the monitor while the job is still in progress and asserts the `Location` header is present.
- [x] `go test ./internal/async/... ./test/...` passes.
- [x] `go build ./...` passes.