### PR TITLE
fix: system query options are case-sensitive per OData URL Conventions §2.1

### DIFF
--- a/internal/query/apply_test.go
+++ b/internal/query/apply_test.go
@@ -746,11 +746,9 @@ func TestParseApply_GroupByNestedSequence(t *testing.T) {
 func TestParseQueryOptions_ApplyCaseAndDollarPrefixVersionBehavior(t *testing.T) {
 	meta := getApplyTestMetadata(t)
 
-	t.Run("4.01 accepts mixed-case and no-dollar apply", func(t *testing.T) {
+	t.Run("4.01 accepts lowercase dollar and no-dollar apply", func(t *testing.T) {
 		for _, rawQuery := range []string{
 			"$apply=filter(Price gt 10)",
-			"$APPLY=filter(Price gt 10)",
-			"Apply=filter(Price gt 10)",
 			"apply=filter(Price gt 10)",
 		} {
 			params, _ := url.ParseQuery(rawQuery)
@@ -761,6 +759,22 @@ func TestParseQueryOptions_ApplyCaseAndDollarPrefixVersionBehavior(t *testing.T)
 			if len(opts.Apply) != 1 || opts.Apply[0].Type != ApplyTypeFilter {
 				t.Fatalf("expected parsed apply filter for %q, got %+v", rawQuery, opts.Apply)
 			}
+		}
+	})
+
+	t.Run("4.01 rejects mixed-case dollar apply and ignores mixed-case no-dollar apply", func(t *testing.T) {
+		mixedCaseDollarParams, _ := url.ParseQuery("$APPLY=filter(Price gt 10)")
+		if _, err := ParseQueryOptionsWithConfigAndCaseSensitivity(mixedCaseDollarParams, meta, nil, true); err == nil {
+			t.Fatal("expected 4.01 parser to reject mixed-case $APPLY (option names remain case-sensitive)")
+		}
+
+		mixedCaseNoDollarParams, _ := url.ParseQuery("Apply=filter(Price gt 10)")
+		opts, err := ParseQueryOptionsWithConfigAndCaseSensitivity(mixedCaseNoDollarParams, meta, nil, true)
+		if err != nil {
+			t.Fatalf("expected 4.01 parser to treat mixed-case no-dollar apply as custom parameter, got error: %v", err)
+		}
+		if len(opts.Apply) != 0 {
+			t.Fatalf("expected no apply transformations for mixed-case no-dollar apply, got %+v", opts.Apply)
 		}
 	})
 

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -302,45 +302,36 @@ var validQueryOptions = map[string]bool{
 	"$skiptoken":     true,
 }
 
-// normalizeQueryOptionKey normalizes a query option key to lowercase with $ prefix
-// per OData v4.01 spec: system query option names are case-insensitive and may be provided without the $ prefix
-// Returns the normalized key if it's a valid OData system query option, otherwise returns the original key
+// normalizeQueryOptionKey adds a missing '$' prefix to a bare system query option name.
+// Per OData v4.01 URL Conventions §2.1, system query option names may be provided
+// without the leading '$', but remain case-sensitive lowercase names — "FILTER" or
+// "$FILTER" are not equivalent to "$filter" and must not be folded to it.
+// Returns the normalized key if it's a recognized bare option name, otherwise the
+// original key unchanged (so unrecognized or wrongly-cased options surface as
+// "unknown query option" errors instead of being silently accepted).
 func normalizeQueryOptionKey(key string) string {
-	// Try with $ prefix
-	withDollar := "$" + strings.ToLower(key)
+	if strings.HasPrefix(key, "$") {
+		return key
+	}
+
+	withDollar := "$" + key
 	if validQueryOptions[withDollar] {
 		return withDollar
 	}
 
-	// Already has $ prefix, lowercase it and check validity
-	if strings.HasPrefix(key, "$") {
-		lowercase := strings.ToLower(key)
-		if validQueryOptions[lowercase] {
-			return lowercase
-		}
-		// Unknown $ option - preserve original casing for error messages
-		return key
-	}
-
-	// Check if without modification (lowercase) it's a valid option
-	lowercase := strings.ToLower(key)
-	if validQueryOptions[lowercase] {
-		return lowercase
-	}
-
-	// Not a known OData system query option, return original
+	// Not a recognized bare OData system query option name, return original
 	return key
 }
 
-// normalizeQueryParams normalizes all query parameters to have lowercase $ prefix
-// This allows case-insensitive query options and options without $ prefix
-// Non-OData parameters are left unchanged
+// normalizeQueryParams adds a missing '$' prefix to bare system query option names.
+// This allows options without the $ prefix per OData 4.01, without relaxing case sensitivity.
+// Non-OData parameters are left unchanged.
 func normalizeQueryParams(queryParams url.Values) url.Values {
 	return NormalizeQueryParams(queryParams)
 }
 
-// NormalizeQueryParams normalizes all query parameters to have lowercase $ prefix.
-// This allows case-insensitive query options and options without $ prefix per OData 4.01.
+// NormalizeQueryParams adds a missing '$' prefix to bare system query option names.
+// This allows options without the $ prefix per OData 4.01, without relaxing case sensitivity.
 // Non-OData parameters are left unchanged.
 func NormalizeQueryParams(queryParams url.Values) url.Values {
 	normalized := make(url.Values)

--- a/internal/query/parser_test.go
+++ b/internal/query/parser_test.go
@@ -535,14 +535,14 @@ func TestNormalizeQueryParams(t *testing.T) {
 			wantKeys: []string{"$filter"},
 		},
 		{
-			name:     "dollar-prefixed uppercase key is lowercased",
+			name:     "dollar-prefixed uppercase key is left unchanged (not folded to $filter)",
 			input:    url.Values{"$FILTER": {"Price gt 10"}},
-			wantKeys: []string{"$filter"},
+			wantKeys: []string{"$FILTER"},
 		},
 		{
-			name:     "dollar-prefixed mixed-case key is lowercased",
+			name:     "dollar-prefixed mixed-case key is left unchanged (not folded)",
 			input:    url.Values{"$Filter": {"Price gt 10"}, "$TOP": {"5"}},
-			wantKeys: []string{"$filter", "$top"},
+			wantKeys: []string{"$Filter", "$TOP"},
 		},
 		{
 			name:     "non-dollar known option gets dollar prefix",
@@ -550,9 +550,9 @@ func TestNormalizeQueryParams(t *testing.T) {
 			wantKeys: []string{"$filter"},
 		},
 		{
-			name:     "non-dollar known option (uppercase) gets dollar prefix",
+			name:     "non-dollar known option (uppercase) is left unchanged (not folded)",
 			input:    url.Values{"FILTER": {"Price gt 10"}},
-			wantKeys: []string{"$filter"},
+			wantKeys: []string{"FILTER"},
 		},
 		{
 			name:     "multiple non-dollar known options get dollar prefix",
@@ -696,15 +696,10 @@ func TestParseQueryOptionsWithConfigAndCaseSensitivity_NoDollarPrefix(t *testing
 			},
 		},
 		{
-			name:            "v4.01: mixed-case dollar prefix",
+			name:            "v4.01: mixed-case dollar prefix is rejected (option names remain case-sensitive)",
 			queryString:     "$TOP=10",
 			caseInsensitive: true,
-			expectError:     false,
-			validate: func(t *testing.T, opts *QueryOptions) {
-				if opts.Top == nil || *opts.Top != 10 {
-					t.Errorf("Expected top=10, got %v", opts.Top)
-				}
-			},
+			expectError:     true,
 		},
 		{
 			name:            "v4.01: count without dollar prefix",

--- a/test/optional_dollar_prefix_test.go
+++ b/test/optional_dollar_prefix_test.go
@@ -216,9 +216,10 @@ t.Error("Expected '@odata.count' in response when count=true")
 }
 }
 
-// TestOptionalDollarPrefix_V401_MixedCaseDollarPrefix tests that mixed-case $-prefixed options
-// work in OData v4.01.
-func TestOptionalDollarPrefix_V401_MixedCaseDollarPrefix(t *testing.T) {
+// TestOptionalDollarPrefix_V401_MixedCaseDollarPrefixRejected tests that mixed-case
+// $-prefixed options are rejected in OData v4.01, since system query option names
+// remain case-sensitive even though the '$' prefix is optional (OData URL Conventions §2.1).
+func TestOptionalDollarPrefix_V401_MixedCaseDollarPrefixRejected(t *testing.T) {
 service, db := setupTestService(t)
 db.Create(&TestProduct{ID: 1, Name: "Laptop", Price: 999.99})
 db.Create(&TestProduct{ID: 2, Name: "Mouse", Price: 29.99})
@@ -229,21 +230,8 @@ w := httptest.NewRecorder()
 
 service.ServeHTTP(w, req)
 
-if w.Code != http.StatusOK {
-t.Fatalf("Expected 200 OK, got %d: %s", w.Code, w.Body.String())
-}
-
-var result map[string]interface{}
-if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
-t.Fatalf("Failed to parse response: %v", err)
-}
-
-value, ok := result["value"].([]interface{})
-if !ok {
-t.Fatal("Expected 'value' array in response")
-}
-if len(value) != 1 {
-t.Errorf("Expected 1 product ($TOP=1), got %d", len(value))
+if w.Code != http.StatusBadRequest {
+t.Errorf("Expected 400 Bad Request for mixed-case $TOP in v4.01, got %d: %s", w.Code, w.Body.String())
 }
 }
 
@@ -392,6 +380,25 @@ service.ServeHTTP(w, req)
 
 if w.Code != http.StatusBadRequest {
 t.Errorf("Expected 400 Bad Request for mixed-case $TOP in v4.0, got %d: %s", w.Code, w.Body.String())
+}
+}
+
+// TestOptionalDollarPrefix_DefaultVersion_UppercaseFilterRejected reproduces the reported
+// gap in OData URL Conventions §2.1 compliance: $FILTER must not be treated as $filter,
+// even under the default negotiated version (4.01), since system query option names are
+// case-sensitive lowercase regardless of whether the '$' prefix is required.
+func TestOptionalDollarPrefix_DefaultVersion_UppercaseFilterRejected(t *testing.T) {
+service, db := setupTestService(t)
+db.Create(&TestProduct{ID: 1, Name: "Laptop", Price: 999.99})
+db.Create(&TestProduct{ID: 2, Name: "Mouse", Price: 29.99})
+
+req := httptest.NewRequest(http.MethodGet, "/TestProducts?$FILTER="+url.QueryEscape("Price gt 100"), nil)
+w := httptest.NewRecorder()
+
+service.ServeHTTP(w, req)
+
+if w.Code != http.StatusBadRequest {
+t.Errorf("Expected 400 Bad Request for uppercase $FILTER, got %d: %s", w.Code, w.Body.String())
 }
 }
 


### PR DESCRIPTION
## Summary

Fixes #767.

`$FILTER`, `$TOP`, `$SELECT`, etc. were silently folded to their lowercase canonical form and accepted as valid, instead of being rejected with `400 Bad Request`. Per OData URL Conventions §2.1 (both 4.0 and 4.01), system query option names are case-sensitive; 4.01 only relaxes the requirement that the `$` prefix be present (`filter=...` is valid), it does not relax the casing of the name itself.

## Root cause

`normalizeQueryOptionKey` in `internal/query/parser.go` lowercased the incoming key before checking it against the set of valid option names, so `$FILTER` → `$filter` and `FILTER` → `$filter`. This ran whenever `caseInsensitive` was true, which is the default (OData-MaxVersion defaults to 4.01), and unconditionally on the actions/functions query-option path.

## Fix

`normalizeQueryOptionKey` now only adds a missing `$` prefix to a name that is *already* an exact lowercase match for a known option (preserving the legitimate 4.01 "optional `$`" behavior). It no longer folds case, so `$FILTER`/`FILTER`/`Apply` etc. pass through unchanged and are correctly rejected by the existing "unknown query option" validation.

Updated existing unit tests that encoded the old (incorrect) case-folding behavior, and added a regression test reproducing the exact report (`$FILTER=Price gt 100` → 400).

## Test plan

- [x] `go test ./internal/query/... ./test/...` passes.
- [x] Added `TestOptionalDollarPrefix_DefaultVersion_UppercaseFilterRejected` reproducing the issue.
- [x] `go build ./...` passes.