### PR TITLE
fix: reject POST with foreign key referencing a nonexistent entity

### DIFF
--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -114,6 +114,11 @@ func (h *EntityHandler) handlePostEntity(w http.ResponseWriter, r *http.Request)
 			return newTransactionHandledError(err)
 		}
 
+		if err := h.validateReferentialConstraints(ctx, tx, requestData); err != nil {
+			WriteError(w, r, http.StatusBadRequest, "Invalid reference", err.Error())
+			return newTransactionHandledError(err)
+		}
+
 		if err := h.callBeforeCreate(entity, hookReq); err != nil {
 			h.writeHookError(w, r, err, http.StatusForbidden, "Authorization failed")
 			return newTransactionHandledError(err)

--- a/internal/handlers/validation.go
+++ b/internal/handlers/validation.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/response"
 	"go.opentelemetry.io/otel/trace"
+	"gorm.io/gorm"
 )
 
 // validateDataTypes validates that all values in updateData match the expected types
@@ -122,6 +124,59 @@ func (h *EntityHandler) validateRequiredFieldsNotNull(updateData map[string]inte
 
 	if len(nullRequiredFields) > 0 {
 		return fmt.Errorf("required properties cannot be set to null: %s", strings.Join(nullRequiredFields, ", "))
+	}
+
+	return nil
+}
+
+// validateReferentialConstraints checks that scalar foreign-key values supplied in
+// requestData reference an existing row in the target entity set, for every
+// single-valued navigation property with GORM-derived referential constraints.
+// Properties the client did not supply, or explicitly set to null, are skipped -
+// nullability/requiredness of the FK itself is enforced elsewhere.
+func (h *EntityHandler) validateReferentialConstraints(ctx context.Context, tx *gorm.DB, requestData map[string]interface{}) error {
+	for i := range h.metadata.Properties {
+		navProp := &h.metadata.Properties[i]
+		if !navProp.IsNavigationProp || navProp.NavigationIsArray || len(navProp.ReferentialConstraints) == 0 {
+			continue
+		}
+
+		targetMetadata, err := h.metadata.ResolveNavigationTarget(navProp.Name)
+		if err != nil {
+			// Target entity set isn't registered (e.g. navigation to an unmounted
+			// entity) - nothing we can validate against.
+			continue
+		}
+
+		for dependentProp, principalProp := range navProp.ReferentialConstraints {
+			dependentMeta := h.metadata.FindProperty(dependentProp)
+			if dependentMeta == nil {
+				continue
+			}
+
+			value, provided := requestData[dependentMeta.JsonName]
+			if !provided {
+				value, provided = requestData[dependentMeta.Name]
+			}
+			if !provided || value == nil {
+				continue
+			}
+
+			principalMeta := targetMetadata.FindProperty(principalProp)
+			if principalMeta == nil {
+				continue
+			}
+
+			var count int64
+			if err := tx.WithContext(ctx).Table(targetMetadata.TableName).
+				Where(fmt.Sprintf("%s = ?", principalMeta.ColumnName), value).
+				Limit(1).Count(&count).Error; err != nil {
+				return fmt.Errorf("failed to validate reference '%s': %w", navProp.Name, err)
+			}
+			if count == 0 {
+				return fmt.Errorf("referenced entity for navigation property '%s' not found (%s = %v)", navProp.Name, dependentMeta.JsonName, value)
+			}
+		}
 	}
 
 	return nil

--- a/test/navigation_composite_key_test.go
+++ b/test/navigation_composite_key_test.go
@@ -1,6 +1,7 @@
 package odata_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -237,6 +238,42 @@ func TestNavigationCompositeKey_AllDescriptions(t *testing.T) {
 	// Product 1 should have 3 descriptions (EN, FR, DE)
 	if len(values) != 3 {
 		t.Errorf("Expected 3 descriptions, got %d", len(values))
+	}
+}
+
+// TestNavigationCompositeKey_CreateWithNonexistentForeignKeyRejected tests that POSTing an
+// entity whose foreign key references a nonexistent parent is rejected instead of silently
+// creating a row with a dangling reference (OData Protocol §11.4.2: services SHOULD enforce
+// referential constraints defined in the data model).
+func TestNavigationCompositeKey_CreateWithNonexistentForeignKeyRejected(t *testing.T) {
+	service := setupCompositeKeyTest(t)
+
+	body := []byte(`{"ProductID": 999, "LanguageKey": "EN", "Description": "Orphaned description"}`)
+	req := httptest.NewRequest(http.MethodPost, "/ProductDescriptionCompositeKeys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for nonexistent ProductID, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestNavigationCompositeKey_CreateWithExistingForeignKeyAllowed tests that POSTing an entity
+// whose foreign key references an existing parent still succeeds.
+func TestNavigationCompositeKey_CreateWithExistingForeignKeyAllowed(t *testing.T) {
+	service := setupCompositeKeyTest(t)
+
+	body := []byte(`{"ProductID": 1, "LanguageKey": "ES", "Description": "Un ordenador portatil"}`)
+	req := httptest.NewRequest(http.MethodPost, "/ProductDescriptionCompositeKeys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status 201 for existing ProductID, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #772.

`POST /ProductDescriptions` (or any entity with a scalar FK navigation property) with a foreign key value that doesn't reference an existing row previously returned `201 Created`, leaving a dangling reference. Per OData Protocol §11.4.2, services SHOULD enforce referential constraints defined in the data model. Existence was only checked on the `@odata.bind` path (`bind.go`), not for plain scalar FK values sent directly in the request body.

## Change

- `internal/handlers/validation.go`: new `validateReferentialConstraints`, which generically walks the entity's single-valued navigation properties with GORM-derived `ReferentialConstraints`, and for each FK value the client actually supplied (skipping properties not provided or explicitly `null`), checks that a row with that principal key exists in the target entity set/table.
- `internal/handlers/collection_write.go`: wired into `handlePostEntity` alongside the existing required-property/null-value checks, returning `400 Bad Request` on violation.

This is generic — it applies to any entity with a `foreignKey`/`references` GORM navigation property, not just `ProductDescription`.

## Test plan

- [x] Added `TestNavigationCompositeKey_CreateWithNonexistentForeignKeyRejected` and `TestNavigationCompositeKey_CreateWithExistingForeignKeyAllowed` in `test/navigation_composite_key_test.go`, reusing the existing composite-key fixture that matches the reported shape.
- [x] `go test ./...` passes (no regressions in existing FK/navigation/bind tests).
- [x] `go build ./...` and `go vet ./...` pass.