### PR TITLE
fix: map unique/primary key constraint violations on create to 409

### DIFF
--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -120,7 +120,7 @@ func (h *EntityHandler) handlePostEntity(w http.ResponseWriter, r *http.Request)
 		}
 
 		if err := tx.Create(entity).Error; err != nil {
-			WriteError(w, r, http.StatusInternalServerError, ErrMsgDatabaseError, err.Error())
+			h.writeCreateDatabaseError(w, r, err)
 			return newTransactionHandledError(err)
 		}
 
@@ -219,9 +219,7 @@ func (h *EntityHandler) handlePostMediaEntity(w http.ResponseWriter, r *http.Req
 		}
 
 		if err := tx.Create(entity).Error; err != nil {
-			if writeErr := response.WriteError(w, r, http.StatusInternalServerError, ErrMsgDatabaseError, err.Error()); writeErr != nil {
-				h.logger.Error("Error writing error response", "error", writeErr)
-			}
+			h.writeCreateDatabaseError(w, r, err)
 			return newTransactionHandledError(err)
 		}
 

--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -33,6 +33,8 @@ const (
 	ErrDetailVersionNotSupported = "This service only supports OData version 4.0 and above. The maximum version specified in the OData-MaxVersion header is below 4.0."
 	ErrMsgValidationFailed       = "Validation failed"
 	ErrMsgNotImplemented         = "Not implemented"
+	ErrMsgConflict               = "Conflict"
+	ErrDetailDuplicateKey        = "An entity with the same key already exists."
 )
 
 // Error detail format constants

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/nlstn/go-odata/internal/etag"
 	"github.com/nlstn/go-odata/internal/odataerrors"
@@ -288,4 +289,46 @@ func (h *EntityHandler) writeDatabaseError(w http.ResponseWriter, r *http.Reques
 	if writeErr := response.WriteError(w, r, http.StatusInternalServerError, ErrMsgDatabaseError, err.Error()); writeErr != nil {
 		h.logger.Error("Error writing error response", "error", writeErr)
 	}
+}
+
+// isUniqueConstraintViolation reports whether err represents a unique or primary
+// key constraint violation raised by the underlying database driver. GORM only
+// translates these into the driver-agnostic gorm.ErrDuplicatedKey when the
+// consuming application opens its *gorm.DB with Config.TranslateError enabled,
+// which this library does not control, so raw driver error text is matched too.
+func isUniqueConstraintViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "unique constraint"): // SQLite, PostgreSQL
+		return true
+	case strings.Contains(msg, "duplicate entry"): // MySQL, MariaDB
+		return true
+	case strings.Contains(msg, "duplicate key"): // PostgreSQL (alternate wording)
+		return true
+	case strings.Contains(msg, "violation of unique key constraint"),
+		strings.Contains(msg, "violation of primary key constraint"): // SQL Server
+		return true
+	}
+	return false
+}
+
+// writeCreateDatabaseError writes an error response for a failed entity creation,
+// mapping unique/primary key constraint violations to 409 Conflict (OData JSON
+// Format §5.1.2 requires a Conflict response when the entity already exists)
+// instead of the generic 500 used for other database errors.
+func (h *EntityHandler) writeCreateDatabaseError(w http.ResponseWriter, r *http.Request, err error) {
+	if isUniqueConstraintViolation(err) {
+		if writeErr := response.WriteError(w, r, http.StatusConflict, ErrMsgConflict, ErrDetailDuplicateKey); writeErr != nil {
+			h.logger.Error("Error writing error response", "error", writeErr)
+		}
+		return
+	}
+	h.writeDatabaseError(w, r, err)
 }

--- a/test/create_conflict_test.go
+++ b/test/create_conflict_test.go
@@ -1,0 +1,82 @@
+package odata_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ConflictTestDescription has a composite primary key (non-numeric, so it is never
+// mistaken for a database-generated/auto-increment key) to isolate the duplicate-key
+// conflict behavior under test from key-generation concerns.
+type ConflictTestDescription struct {
+	ProductCode string `json:"ProductCode" gorm:"primaryKey" odata:"key"`
+	LanguageKey string `json:"LanguageKey" gorm:"primaryKey" odata:"key"`
+	Description string `json:"Description"`
+}
+
+func setupCreateConflictTest(t *testing.T) *odata.Service {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&ConflictTestDescription{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	db.Create(&ConflictTestDescription{ProductCode: "P1", LanguageKey: "EN", Description: "A portable computer"})
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	if err := service.RegisterEntity(&ConflictTestDescription{}); err != nil {
+		t.Fatalf("RegisterEntity() error: %v", err)
+	}
+
+	return service
+}
+
+// TestCreateWithDuplicateCompositeKeyReturnsConflict tests that POSTing an entity whose
+// composite key already exists returns 409 Conflict rather than a generic 500 Internal
+// Server Error (OData JSON Format §5.1.2: services MUST respond with 409 Conflict if the
+// entity already exists).
+func TestCreateWithDuplicateCompositeKeyReturnsConflict(t *testing.T) {
+	service := setupCreateConflictTest(t)
+
+	body := []byte(`{"ProductCode": "P1", "LanguageKey": "EN", "Description": "Duplicate"}`)
+	req := httptest.NewRequest(http.MethodPost, "/ConflictTestDescriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("Expected status 409 for duplicate composite key, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateWithNewCompositeKeySucceeds tests that POSTing an entity with a composite key
+// that doesn't already exist still succeeds normally.
+func TestCreateWithNewCompositeKeySucceeds(t *testing.T) {
+	service := setupCreateConflictTest(t)
+
+	body := []byte(`{"ProductCode": "P1", "LanguageKey": "FR", "Description": "Un ordinateur portable"}`)
+	req := httptest.NewRequest(http.MethodPost, "/ConflictTestDescriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status 201 for new composite key, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/test/post_test.go
+++ b/test/post_test.go
@@ -611,9 +611,9 @@ func TestPostEntity_DuplicateCompositeKey(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	// Should return 500 Internal Server Error (database constraint violation)
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+	// Should return 409 Conflict (OData JSON Format §5.1.2: the entity already exists)
+	if w.Code != http.StatusConflict {
+		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusConflict, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #773.

Creating an entity that violates a unique/primary key constraint (e.g. two `ProductDescriptions` with the same composite key) returned `500 Internal Server Error`. Per OData JSON Format §5.1.2, a create request for an entity that already exists MUST get `409 Conflict`.

## Change

- `internal/handlers/entity_helpers.go`: new `isUniqueConstraintViolation(err)`, which recognizes `gorm.ErrDuplicatedKey` (for callers that enable `gorm.Config.TranslateError`) and falls back to matching common raw driver error text (SQLite, PostgreSQL, MySQL/MariaDB, SQL Server), since this library receives an already-opened `*gorm.DB` from the consuming application and can't control how it was configured. New `writeCreateDatabaseError` maps a detected violation to 409, otherwise preserves the existing 500 behavior.
- `internal/handlers/collection_write.go`: both entity-create paths (`handlePostEntity`, `handlePostMediaEntity`) now go through `writeCreateDatabaseError` instead of hardcoding 500.
- `internal/handlers/constants.go`: added `ErrMsgConflict` / `ErrDetailDuplicateKey`.

## Test plan

- [x] Added `test/create_conflict_test.go` covering both the conflict (409) and the non-conflicting new-key (201) cases.
- [x] Fixed `TestPostEntity_DuplicateCompositeKey` in `test/post_test.go`, which had encoded the previous 500 as the expected/correct behavior.
- [x] `go test ./...` passes.
- [x] `go build ./...` and `go vet ./...` pass.