### PR TITLE
fix: apply top-level $filter to the transformed result set after $apply

### DIFF
--- a/internal/query/applier.go
+++ b/internal/query/applier.go
@@ -62,7 +62,21 @@ func ApplyQueryOptionsWithFTS(db *gorm.DB, options *QueryOptions, entityMetadata
 
 	// Apply transformations (if present, they take precedence over other query options)
 	if len(options.Apply) > 0 {
-		db = applyTransformations(db, options.Apply, entityMetadata)
+		var hasGrouping bool
+		db, hasGrouping = applyTransformations(db, options.Apply, entityMetadata)
+
+		// Per the OData Data Aggregation extension, system query options besides $apply
+		// (here $filter, $orderby, $skip, $top) apply to the transformed result set, not
+		// the original collection. $filter must be able to reference properties introduced
+		// by the transformation (e.g. an aggregate alias), so when the pipeline ends in a
+		// grouped/aggregated state it is applied as HAVING; otherwise as a plain WHERE.
+		if options.Filter != nil {
+			if hasGrouping {
+				db = applyHavingFilter(db, options.Filter, entityMetadata)
+			} else {
+				db = applyFilter(db, options.Filter, entityMetadata)
+			}
+		}
 
 		// After applying transformations, still apply orderby, top, and skip
 		// These are standalone query options that work with $apply

--- a/internal/query/apply_new_transformations_test.go
+++ b/internal/query/apply_new_transformations_test.go
@@ -131,7 +131,7 @@ func TestApplyGroupByAll_SQL(t *testing.T) {
 		t.Fatalf("parseApply failed: %v", err)
 	}
 
-	resultDB := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
+	resultDB, _ := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
 
 	var results []map[string]interface{}
 	if err := resultDB.Find(&results).Error; err != nil {
@@ -188,7 +188,7 @@ func TestApplyGroupByAll_NoTransform_CountAll(t *testing.T) {
 		t.Fatalf("parseApply failed: %v", err)
 	}
 
-	resultDB := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
+	resultDB, _ := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
 
 	var results []map[string]interface{}
 	if err := resultDB.Find(&results).Error; err != nil {
@@ -416,7 +416,7 @@ func TestApplyNest_Passthrough(t *testing.T) {
 		t.Fatalf("parseApply failed: %v", err)
 	}
 
-	resultDB := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
+	resultDB, _ := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
 	var results []ApplyTestEntity
 	if err := resultDB.Find(&results).Error; err != nil {
 		t.Fatalf("query failed: %v", err)
@@ -458,7 +458,7 @@ func TestApplyFrom_Passthrough(t *testing.T) {
 		t.Fatalf("parseApply failed: %v", err)
 	}
 
-	resultDB := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
+	resultDB, _ := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
 	var results []ApplyTestEntity
 	if err := resultDB.Find(&results).Error; err != nil {
 		t.Fatalf("query failed: %v", err)

--- a/internal/query/apply_rollup_test.go
+++ b/internal/query/apply_rollup_test.go
@@ -192,7 +192,7 @@ func TestApplyGroupByRollup_SQL(t *testing.T) {
 			t.Fatalf("parseApply(%q) failed: %v", applyStr, err)
 		}
 
-		resultDB := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
+		resultDB, _ := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
 
 		// Fetch raw rows (no GROUP BY because rollup uses in-memory path)
 		var rawResults []map[string]interface{}
@@ -327,7 +327,7 @@ func TestApplyGroupByRollup_SkipsStreamMarkerColumns(t *testing.T) {
 		t.Fatalf("parseApply failed: %v", err)
 	}
 
-	resultDB := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
+	resultDB, _ := applyTransformations(db.Session(&gorm.Session{}), transformations, meta)
 
 	var rawResults []map[string]interface{}
 	if err := resultDB.Find(&rawResults).Error; err != nil {

--- a/internal/query/apply_transform.go
+++ b/internal/query/apply_transform.go
@@ -36,8 +36,11 @@ func GetRollupGroupByFromDB(db *gorm.DB) (*GroupByTransformation, bool) {
 	return nil, false
 }
 
-// applyTransformations applies apply transformations to the GORM query
-func applyTransformations(db *gorm.DB, transformations []ApplyTransformation, entityMetadata *metadata.EntityMetadata) *gorm.DB {
+// applyTransformations applies apply transformations to the GORM query. It returns
+// whether the transformation pipeline ends in a grouped/aggregated state, so callers
+// know whether a subsequent top-level $filter must be applied as a HAVING clause
+// (referencing transformed properties like aggregate aliases) or a plain WHERE clause.
+func applyTransformations(db *gorm.DB, transformations []ApplyTransformation, entityMetadata *metadata.EntityMetadata) (*gorm.DB, bool) {
 	if db.Statement != nil && db.Statement.Dest == nil {
 		modelInstance := reflect.New(entityMetadata.EntityType).Interface()
 		db = db.Model(modelInstance)
@@ -133,7 +136,7 @@ func applyTransformations(db *gorm.DB, transformations []ApplyTransformation, en
 			// SQL-builder layer. Leave the current set unchanged.
 		}
 	}
-	return db
+	return db, hasGrouping
 }
 
 func applySearchTransformation(db *gorm.DB, search *string, entityMetadata *metadata.EntityMetadata) *gorm.DB {

--- a/test/apply_having_clause_test.go
+++ b/test/apply_having_clause_test.go
@@ -265,6 +265,62 @@ func TestApply_MultipleAggregations(t *testing.T) {
 	}
 }
 
+// TestApply_TopLevelFilter_AfterGroupByAggregate reproduces #774: a top-level $filter
+// combined with $apply=groupby(...)/aggregate(...) must filter the transformed
+// (aggregated) result set, referencing properties introduced by the transformation
+// (e.g. an aggregate alias), per the OData Data Aggregation extension §6.4 ordering of
+// system query options after $apply. This differs from filter() *inside* $apply, which
+// already worked correctly.
+func TestApply_TopLevelFilter_AfterGroupByAggregate(t *testing.T) {
+	db := setupHavingTestDB(t)
+
+	products := []HavingProduct{
+		{ID: 1, Name: "Product 1", Price: 40.0, Category: "Cat1"},  // Cat1 total: 40 (<=100)
+		{ID: 2, Name: "Product 2", Price: 200.0, Category: "Cat2"}, // Cat2 total: 200 (>100)
+		{ID: 3, Name: "Product 3", Price: 60.0, Category: "Cat3"},  // Cat3 total: 150 (>100)
+		{ID: 4, Name: "Product 4", Price: 90.0, Category: "Cat3"},
+	}
+	for _, product := range products {
+		if err := db.Create(&product).Error; err != nil {
+			t.Fatalf("Failed to create product: %v", err)
+		}
+	}
+
+	service := setupHavingTestService(t, db)
+
+	req := httptest.NewRequest("GET",
+		"/HavingProducts?$apply=groupby((Category),aggregate(Price%20with%20sum%20as%20Total))&$filter=Total%20gt%20100", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	value, ok := response["value"].([]interface{})
+	if !ok {
+		t.Fatal("value is not an array")
+	}
+
+	// Only Cat2 (200) and Cat3 (150) have Total > 100; Cat1 (40) must be filtered out.
+	if len(value) != 2 {
+		t.Fatalf("Expected 2 groups with Total > 100, got %d: %+v", len(value), value)
+	}
+
+	for _, item := range value {
+		group := item.(map[string]interface{})
+		total, ok := group["Total"].(float64)
+		if !ok || total <= 100 {
+			t.Errorf("Expected every returned group to have Total > 100, got %v", group)
+		}
+	}
+}
+
 func setupHavingTestDB(t *testing.T) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #774.

`?$apply=groupby((CategoryID),aggregate(Price with sum as Total))&$filter=Total gt 100` ignored `$filter` entirely and returned every group. Per OData Data Aggregation extension §6.4, system query options other than `$apply` (here `$filter`) apply to the *transformed* result set, and must be able to reference properties the transformation introduced (e.g. the `Total` aggregate alias).

## Root cause

`ApplyQueryOptionsWithFTS`'s `$apply` branch (`internal/query/applier.go`) applied `$apply`, then `$orderby`/`$skip`/`$top`, and returned — `options.Filter` was never even looked at once `$apply` was present. This is distinct from `filter(...)` used *inside* `$apply` (e.g. `groupby(...)/filter(...)`), which already worked via `applyHavingFilter`.

## Fix

- `applyTransformations` now returns whether the pipeline ends in a grouped/aggregated state (it already tracked this internally as `hasGrouping` for the inside-`$apply` `filter()` case).
- `ApplyQueryOptionsWithFTS` uses that to apply the top-level `$filter`: as a `HAVING` clause when grouping occurred (reusing the alias-expression resolution already in place for aggregate/computed aliases, so `Total` resolves correctly across SQLite/Postgres/MySQL/SQL Server), or as a plain `WHERE` clause otherwise.

## Test plan

- [x] Added `TestApply_TopLevelFilter_AfterGroupByAggregate` in `test/apply_having_clause_test.go`, matching the issue's exact repro shape.
- [x] `go test ./...` passes, including all existing `$apply`/HAVING/rollup/join tests.
- [x] `go build ./...` and `go vet ./...` pass.