### PR TITLE
fix: $count/@odata.count ignore $apply transformations

### DIFF
--- a/internal/handlers/collection_count.go
+++ b/internal/handlers/collection_count.go
@@ -30,6 +30,13 @@ func (h *EntityHandler) countEntities(ctx context.Context, queryOptions *query.Q
 		return count, nil
 	}
 
+	// $apply transforms the collection (groupby/aggregate/filter/etc.) before any other
+	// system query option is evaluated, so the count must reflect the transformed result
+	// set rather than the original collection's row count.
+	if len(queryOptions.Apply) > 0 {
+		return h.countTransformedEntities(ctx, queryOptions, baseDB)
+	}
+
 	filter := queryOptions.Filter
 	search := queryOptions.Search
 
@@ -79,6 +86,33 @@ func (h *EntityHandler) countEntities(ctx context.Context, queryOptions *query.Q
 	count := int64(reflect.ValueOf(filtered).Len())
 
 	return count, nil
+}
+
+// countTransformedEntities returns the number of rows produced by a $apply pipeline
+// (honoring groupby/aggregate/filter transformations and any top-level $filter applied
+// against the transformed result), ignoring $top/$skip since a count reflects the total
+// matching set rather than a single page.
+func (h *EntityHandler) countTransformedEntities(ctx context.Context, queryOptions *query.QueryOptions, baseDB *gorm.DB) (int64, error) {
+	countOptions := &query.QueryOptions{
+		Apply:  queryOptions.Apply,
+		Filter: queryOptions.Filter,
+	}
+	countDB := query.ApplyQueryOptionsWithFTS(baseDB.WithContext(ctx), countOptions, h.metadata, nil, "", h.logger)
+
+	var results []map[string]interface{}
+	if err := countDB.Find(&results).Error; err != nil {
+		return 0, err
+	}
+
+	if rollupGroupBy, ok := query.GetRollupGroupByFromDB(countDB); ok {
+		rolled, err := applyMapGroupByRollup(results, rollupGroupBy)
+		if err != nil {
+			return 0, err
+		}
+		return int64(len(rolled)), nil
+	}
+
+	return int64(len(results)), nil
 }
 
 func searchAppliedAtDB(db *gorm.DB) bool {

--- a/test/apply_having_clause_test.go
+++ b/test/apply_having_clause_test.go
@@ -321,6 +321,99 @@ func TestApply_TopLevelFilter_AfterGroupByAggregate(t *testing.T) {
 	}
 }
 
+// TestApply_Count_ReflectsFilterTransformation reproduces #771's underlying defect:
+// $count / @odata.count must reflect $apply's transformed result set (here, a
+// filter() transformation), not the original collection's total row count. A client
+// relying on $apply=filter() semantics would otherwise silently receive an incorrect
+// count even though the `value` array itself is correctly filtered.
+func TestApply_Count_ReflectsFilterTransformation(t *testing.T) {
+	db := setupHavingTestDB(t)
+
+	products := []HavingProduct{
+		{ID: 1, Name: "Product 1", Price: 40.0, Category: "Cat1"},
+		{ID: 2, Name: "Product 2", Price: 200.0, Category: "Cat2"},
+		{ID: 3, Name: "Product 3", Price: 60.0, Category: "Cat3"},
+		{ID: 4, Name: "Product 4", Price: 90.0, Category: "Cat3"},
+	}
+	for _, product := range products {
+		if err := db.Create(&product).Error; err != nil {
+			t.Fatalf("Failed to create product: %v", err)
+		}
+	}
+
+	service := setupHavingTestService(t, db)
+
+	// Only Product 2, 3, 4 have Price > 50 (3 of 4).
+	req := httptest.NewRequest("GET", "/HavingProducts?$apply=filter(Price%20gt%2050)&$count=true", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	value, ok := response["value"].([]interface{})
+	if !ok {
+		t.Fatal("value is not an array")
+	}
+	if len(value) != 3 {
+		t.Fatalf("Expected 3 filtered products in value, got %d", len(value))
+	}
+
+	count, ok := response["@odata.count"].(float64)
+	if !ok || count != 3 {
+		t.Fatalf("Expected @odata.count to be 3 (matching the filtered result set), got %v", response["@odata.count"])
+	}
+
+	// The bare /$count endpoint must agree.
+	bareReq := httptest.NewRequest("GET", "/HavingProducts/$count?$apply=filter(Price%20gt%2050)", nil)
+	bareW := httptest.NewRecorder()
+	service.ServeHTTP(bareW, bareReq)
+
+	if bareW.Code != http.StatusOK {
+		t.Fatalf("Expected status 200 for bare $count, got %d. Body: %s", bareW.Code, bareW.Body.String())
+	}
+	if got := bareW.Body.String(); got != "3" {
+		t.Errorf("Expected bare /$count to return 3, got %q", got)
+	}
+}
+
+// TestApply_Count_ReflectsGroupByTransformation verifies $count reflects the number of
+// groups produced by $apply=groupby(...), not the number of underlying rows.
+func TestApply_Count_ReflectsGroupByTransformation(t *testing.T) {
+	db := setupHavingTestDB(t)
+
+	products := []HavingProduct{
+		{ID: 1, Name: "Product 1", Price: 100.0, Category: "Cat1"},
+		{ID: 2, Name: "Product 2", Price: 200.0, Category: "Cat1"},
+		{ID: 3, Name: "Product 3", Price: 50.0, Category: "Cat2"},
+		{ID: 4, Name: "Product 4", Price: 300.0, Category: "Cat3"},
+	}
+	for _, product := range products {
+		if err := db.Create(&product).Error; err != nil {
+			t.Fatalf("Failed to create product: %v", err)
+		}
+	}
+
+	service := setupHavingTestService(t, db)
+
+	req := httptest.NewRequest("GET", "/HavingProducts/$count?$apply=groupby((Category))", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+	if got := w.Body.String(); got != "3" {
+		t.Errorf("Expected /$count to return 3 (groups: Cat1, Cat2, Cat3), got %q", got)
+	}
+}
+
 func setupHavingTestDB(t *testing.T) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {


### PR DESCRIPTION
## Summary

Addresses #771.

**Investigation note first:** the issue as filed claims `$apply=filter(Price gt 50)` on its own returns only 1 of 5 matching entities, while `$filter=Price gt 50` correctly returns 5. I could not reproduce that specific symptom against the current codebase — verified with both a synthetic test and by running the actual `cmd/complianceserver` locally and querying it directly; the `value` array from `$apply=filter(...)` matches `$filter` exactly in every variation I tried (with/without `$top`, `$orderby`, OData 4.0 vs 4.01).

What I did find and confirm, in the same area, is a related, real defect: **`$count`/`@odata.count` completely ignore `$apply`.**

```
GET /Products?$apply=filter(Price gt 50)&$count=true
```
returned `@odata.count: 7` (the *unfiltered* total) while `value` correctly held 5 rows. Same for the bare `/Products/$count?$apply=filter(...)` endpoint, and for `$apply=groupby(...)` (returns the total row count instead of the number of groups).

## Root cause

`countEntities` (`internal/handlers/collection_count.go`) only ever looked at `queryOptions.Filter`; it had no awareness of `queryOptions.Apply` at all, so a count request with `$apply` present just counted the whole table (modulo the top-level `$filter`, itself only fixed by #774).

## Fix

Added `countTransformedEntities`, which runs the same `$apply` pipeline used for fetching (via `query.ApplyQueryOptionsWithFTS`, which after #774 already applies groupby/aggregate/filter and any top-level `$filter` against the transformed result), skips `$top`/`$skip` (a count reflects the total matching set, not one page), and counts the resulting rows — including the existing in-memory rollup handling for `rollup()` groupby.

## Test plan

- [x] Added `TestApply_Count_ReflectsFilterTransformation` (inline `@odata.count` and bare `/$count`, both after `$apply=filter(...)`) and `TestApply_Count_ReflectsGroupByTransformation` (`/$count` after `$apply=groupby(...)`) in `test/apply_having_clause_test.go`.
- [x] `go test ./...` passes.
- [x] `go build ./...` and `go vet ./...` pass.
- [x] Manually verified against `cmd/complianceserver` before and after the fix.