### PR TITLE
fix: enforce MaxLength facet on POST/PATCH string properties

### DIFF
--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -114,6 +114,11 @@ func (h *EntityHandler) handlePostEntity(w http.ResponseWriter, r *http.Request)
 			return newTransactionHandledError(err)
 		}
 
+		if err := h.validateMaxLength(requestData); err != nil {
+			WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
+			return newTransactionHandledError(err)
+		}
+
 		if err := h.validateReferentialConstraints(ctx, tx, requestData); err != nil {
 			WriteError(w, r, http.StatusBadRequest, "Invalid reference", err.Error())
 			return newTransactionHandledError(err)

--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -243,6 +243,13 @@ func (h *EntityHandler) handlePatchEntity(w http.ResponseWriter, r *http.Request
 			return newTransactionHandledError(err)
 		}
 
+		if err := h.validateMaxLength(updateData); err != nil {
+			if writeErr := response.WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error()); writeErr != nil {
+				h.logger.Error("Error writing error response", "error", writeErr)
+			}
+			return newTransactionHandledError(err)
+		}
+
 		if err := h.callBeforeUpdate(entity, hookReq); err != nil {
 			h.writeHookError(w, r, err, http.StatusForbidden, "Authorization failed")
 			return newTransactionHandledError(err)

--- a/internal/handlers/validation.go
+++ b/internal/handlers/validation.go
@@ -129,6 +129,35 @@ func (h *EntityHandler) validateRequiredFieldsNotNull(updateData map[string]inte
 	return nil
 }
 
+// validateMaxLength validates that string property values do not exceed their
+// declared MaxLength facet (OData CSDL §6.2.3). A property with no MaxLength
+// declared (metadata.MaxLength <= 0) is unconstrained.
+func (h *EntityHandler) validateMaxLength(data map[string]interface{}) error {
+	var violations []string
+
+	for propName, propValue := range data {
+		strValue, ok := propValue.(string)
+		if !ok {
+			continue
+		}
+
+		propMeta := h.metadata.FindProperty(propName)
+		if propMeta == nil || propMeta.MaxLength <= 0 {
+			continue
+		}
+
+		if len(strValue) > propMeta.MaxLength {
+			violations = append(violations, fmt.Sprintf("%s (length %d exceeds MaxLength %d)", propMeta.JsonName, len(strValue), propMeta.MaxLength))
+		}
+	}
+
+	if len(violations) > 0 {
+		return fmt.Errorf("value exceeds declared MaxLength: %s", strings.Join(violations, ", "))
+	}
+
+	return nil
+}
+
 // validateReferentialConstraints checks that scalar foreign-key values supplied in
 // requestData reference an existing row in the target entity set, for every
 // single-valued navigation property with GORM-derived referential constraints.

--- a/test/maxlength_validation_test.go
+++ b/test/maxlength_validation_test.go
@@ -1,0 +1,109 @@
+package odata_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// MaxLengthTestProduct declares a MaxLength=10 facet on Name, matching how the CSDL
+// document advertises `<Property Name="Name" Type="Edm.String" MaxLength="10" />`.
+type MaxLengthTestProduct struct {
+	ID   uint   `json:"ID" gorm:"primaryKey" odata:"key"`
+	Name string `json:"Name" gorm:"size:10" odata:"maxlength=10"`
+}
+
+func setupMaxLengthTest(t *testing.T) *odata.Service {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&MaxLengthTestProduct{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	if err := service.RegisterEntity(&MaxLengthTestProduct{}); err != nil {
+		t.Fatalf("Failed to register entity: %v", err)
+	}
+
+	return service
+}
+
+// TestMaxLength_PostRejectsOversizedString reproduces #768: a string value longer than
+// the declared MaxLength facet must be rejected with 400 Bad Request, per OData CSDL
+// §6.2.3 (MaxLength) and Protocol §11.4.2 (400 for a request body invalid per the model).
+func TestMaxLength_PostRejectsOversizedString(t *testing.T) {
+	service := setupMaxLengthTest(t)
+
+	body := []byte(`{"Name": "ThisNameIsWayTooLong"}`)
+	req := httptest.NewRequest(http.MethodPost, "/MaxLengthTestProducts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for oversized Name, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMaxLength_PostAllowsStringWithinLimit tests that a string at or under the
+// MaxLength limit is still accepted.
+func TestMaxLength_PostAllowsStringWithinLimit(t *testing.T) {
+	service := setupMaxLengthTest(t)
+
+	body := []byte(`{"Name": "ExactlyTen"}`) // 10 characters
+	req := httptest.NewRequest(http.MethodPost, "/MaxLengthTestProducts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status 201 for Name within MaxLength, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMaxLength_PatchRejectsOversizedString tests that a PATCH updating a property to
+// exceed its MaxLength is also rejected.
+func TestMaxLength_PatchRejectsOversizedString(t *testing.T) {
+	service := setupMaxLengthTest(t)
+
+	createBody := []byte(`{"Name": "Short"}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/MaxLengthTestProducts", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createW := httptest.NewRecorder()
+	service.ServeHTTP(createW, createReq)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("setup: expected 201 creating product, got %d: %s", createW.Code, createW.Body.String())
+	}
+
+	location := createW.Header().Get("Location")
+	if location == "" {
+		t.Fatal("setup: missing Location header")
+	}
+	path := location[strings.Index(location, "/MaxLengthTestProducts"):]
+
+	patchBody := []byte(`{"Name": "ThisNameIsWayTooLong"}`)
+	patchReq := httptest.NewRequest(http.MethodPatch, path, bytes.NewReader(patchBody))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchW := httptest.NewRecorder()
+	service.ServeHTTP(patchW, patchReq)
+
+	if patchW.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for oversized Name on PATCH, got %d: %s", patchW.Code, patchW.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #768.

The CSDL metadata document correctly declares `MaxLength` on string properties (e.g. `<Property Name="Name" Type="Edm.String" MaxLength="100" />`), but nothing enforced it against incoming values on create/update — a string longer than the declared limit was silently accepted and persisted with `201`/`200`. Per OData CSDL §6.2.3 and Protocol §11.4.2, a value violating a declared facet makes the request body invalid per the data model, and the service MUST return `400 Bad Request`.

## Change

- `internal/handlers/validation.go`: new `validateMaxLength`, following the same map-based iteration pattern as the existing `validateRequiredFieldsNotNull` — checks each string value in the request body against its property's `MaxLength` metadata (already extracted from the `odata:"maxlength=N"` tag / CSDL facet), skipping properties with no declared limit.
- Wired into both `handlePostEntity` (`collection_write.go`) and `handlePatchEntity` (`entity_write.go`), alongside the existing required/null-value checks. PUT was left as-is since it doesn't go through the map-based validation pipeline at all today (it decodes directly into a struct) — out of scope for this fix.

## Test plan

- [x] Added `test/maxlength_validation_test.go` covering: POST with an oversized string (400), POST within the limit (201), and PATCH updating to an oversized string (400).
- [x] `go test ./...` passes.
- [x] `go build ./...` and `go vet ./...` pass.