### PR TITLE
Fix $apply=filter() JSON naming and M2M nested lambda filter crash

### DIFF
--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
+
+	gormschema "gorm.io/gorm/schema"
 )
 
 // EntityMetadata holds metadata information about an OData entity
@@ -88,7 +91,16 @@ type PropertyMetadata struct {
 	NavigationTarget          string // Entity type name for navigation properties
 	NavigationTargetTableName string // Database table name for navigation target (computed once)
 	ForeignKeyColumnName      string // Foreign key column name for navigation properties (computed once)
-	NavigationIsArray         bool   // True for collection navigation properties
+	IsManyToMany              bool   // True if this is a many-to-many navigation property (GORM many2many tag)
+	JoinTableName             string // Join/bridge table name for many-to-many relationships (computed once)
+	// JoinTableForeignKey is the join table column (or comma-separated columns for
+	// composite keys) referencing this entity's own key. JoinTableReferencesColumn is
+	// the join table column(s) referencing the related entity's key. Both are empty
+	// unless IsManyToMany is true and the join could be resolved via GORM's schema
+	// parser (see resolveManyToManyJoinInfo).
+	JoinTableForeignKey       string
+	JoinTableReferencesColumn string
+	NavigationIsArray         bool // True for collection navigation properties
 	NavigationContainsTarget  bool   // True if this is a containment navigation property (ContainsTarget="true")
 	IsETag                    bool   // True if this property should be used for ETag generation
 	IsComplexType             bool   // True if this property is a complex type (embedded struct)
@@ -436,7 +448,7 @@ func analyzeField(field reflect.StructField, metadata *EntityMetadata) (Property
 	}
 
 	// Check if this is a navigation property
-	analyzeNavigationProperty(&property, field)
+	analyzeNavigationProperty(&property, field, metadata.EntityType)
 
 	// Compute and cache the column name (respects GORM column: tags)
 	property.ColumnName = getColumnNameFromProperty(&property)
@@ -503,7 +515,7 @@ func analyzeField(field reflect.StructField, metadata *EntityMetadata) (Property
 }
 
 // analyzeNavigationProperty determines if a field is a navigation property or complex type
-func analyzeNavigationProperty(property *PropertyMetadata, field reflect.StructField) {
+func analyzeNavigationProperty(property *PropertyMetadata, field reflect.StructField, ownerType reflect.Type) {
 	fieldType := field.Type
 	isSlice := fieldType.Kind() == reflect.Slice
 	if isSlice {
@@ -518,17 +530,28 @@ func analyzeNavigationProperty(property *PropertyMetadata, field reflect.StructF
 	// If it's a struct type, determine if it's navigation property or complex type
 	if fieldType.Kind() == reflect.Struct {
 		gormTag := field.Tag.Get("gorm")
+		isManyToMany := strings.Contains(gormTag, "many2many")
 
 		// Check if it's a navigation property (has foreign key, references, or many2many)
-		if strings.Contains(gormTag, "foreignKey") || strings.Contains(gormTag, "references") || strings.Contains(gormTag, "many2many") {
+		if strings.Contains(gormTag, "foreignKey") || strings.Contains(gormTag, "references") || isManyToMany {
 			property.IsNavigationProp = true
 			property.NavigationTarget = fieldType.Name()
 			// Use fieldType (already dereferenced) to get the table name for the target entity
 			property.NavigationTargetTableName = getTableNameFromReflectType(fieldType)
 			property.NavigationIsArray = isSlice
 
-			// Compute and cache the foreign key column name (respects GORM foreignKey: tags)
-			property.ForeignKeyColumnName = getForeignKeyColumnName(property)
+			if isManyToMany {
+				// Many-to-many relationships join through a bridge/join table rather than a
+				// direct foreign key column on the related table, so ForeignKeyColumnName's
+				// naive "<property>_id" convention does not apply here. Resolve the actual
+				// join table name and columns via GORM's own schema parser instead of
+				// re-implementing its (self-referential-aware) naming heuristic.
+				property.IsManyToMany = true
+				resolveManyToManyJoinInfo(property, ownerType)
+			} else {
+				// Compute and cache the foreign key column name (respects GORM foreignKey: tags)
+				property.ForeignKeyColumnName = getForeignKeyColumnName(property)
+			}
 
 			// Extract referential constraints from GORM tags (only for foreignKey/references)
 			if strings.Contains(gormTag, "foreignKey") || strings.Contains(gormTag, "references") {
@@ -573,7 +596,7 @@ func analyzeComplexTypeFields(property *PropertyMetadata, fieldType reflect.Type
 			GormTag:   field.Tag.Get("gorm"),
 		}
 
-		analyzeNavigationProperty(&nestedProp, field)
+		analyzeNavigationProperty(&nestedProp, field, nil)
 
 		// Compute and cache the column name for complex type fields
 		nestedProp.ColumnName = getColumnNameFromProperty(&nestedProp)
@@ -1613,6 +1636,58 @@ func getColumnNameFromProperty(prop *PropertyMetadata) string {
 
 // getForeignKeyColumnName computes the foreign key column name for a navigation property
 // This respects GORM foreignKey: tags and falls back to <navigation_property_name>_id convention
+// resolveManyToManyJoinInfo resolves the join/bridge table name and its foreign key
+// columns for a many-to-many navigation property by parsing the owning entity's
+// struct with GORM's own schema parser. This mirrors exactly what GORM itself does
+// when it builds the join query for Preload (used by $expand), including its
+// self-referential naming rules (e.g. a self-join field like
+// "RelatedProducts []Product `gorm:"many2many:product_relations;"`" on Product
+// produces join columns "product_id" and "related_product_id", not the naive
+// "related_products_id" convention used for direct foreign keys). Re-implementing
+// that heuristic ourselves would be fragile across GORM versions, so we ask GORM
+// directly instead. If parsing fails or no matching relationship is found (e.g. an
+// unusual tag GORM itself would reject), the join fields are left empty and callers
+// must treat that as "join info unavailable".
+func resolveManyToManyJoinInfo(property *PropertyMetadata, ownerType reflect.Type) {
+	if property == nil || ownerType == nil {
+		return
+	}
+	for ownerType.Kind() == reflect.Ptr {
+		ownerType = ownerType.Elem()
+	}
+	if ownerType.Kind() != reflect.Struct {
+		return
+	}
+
+	sch, err := gormschema.Parse(reflect.New(ownerType).Interface(), &sync.Map{}, gormschema.NamingStrategy{})
+	if err != nil || sch == nil {
+		return
+	}
+
+	for _, rel := range sch.Relationships.Many2Many {
+		if rel == nil || rel.Field == nil || rel.Field.Name != property.FieldName || rel.JoinTable == nil {
+			continue
+		}
+
+		property.JoinTableName = rel.JoinTable.Table
+
+		var ownColumns, refColumns []string
+		for _, ref := range rel.References {
+			if ref == nil || ref.ForeignKey == nil {
+				continue
+			}
+			if ref.OwnPrimaryKey {
+				ownColumns = append(ownColumns, ref.ForeignKey.DBName)
+			} else {
+				refColumns = append(refColumns, ref.ForeignKey.DBName)
+			}
+		}
+		property.JoinTableForeignKey = strings.Join(ownColumns, ",")
+		property.JoinTableReferencesColumn = strings.Join(refColumns, ",")
+		return
+	}
+}
+
 func getForeignKeyColumnName(prop *PropertyMetadata) string {
 	if prop == nil || !prop.IsNavigationProp {
 		return ""

--- a/internal/metadata/analyzer_test.go
+++ b/internal/metadata/analyzer_test.go
@@ -1237,3 +1237,47 @@ func TestIsNotAbstract(t *testing.T) {
 		t.Error("IsAbstract should be false for entities without IsAbstract() method")
 	}
 }
+
+// Widget is a self-referential many-to-many entity used to verify that
+// IsManyToMany navigation properties resolve their bridge/join table name and columns
+// via GORM's own schema parser (see resolveManyToManyJoinInfo), rather than the naive
+// "<property>_id" convention used for direct foreign keys, which does not apply to
+// many-to-many relationships (see #783).
+type Widget struct {
+	ID             uint `gorm:"primaryKey"`
+	Name           string
+	RelatedWidgets []Widget `gorm:"many2many:widget_relations;"`
+}
+
+func TestAnalyzeEntity_ManyToManySelfReferential(t *testing.T) {
+	meta, err := AnalyzeEntity(&Widget{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity() error = %v", err)
+	}
+
+	var prop *PropertyMetadata
+	for i := range meta.Properties {
+		if meta.Properties[i].Name == "RelatedWidgets" {
+			prop = &meta.Properties[i]
+		}
+	}
+	if prop == nil {
+		t.Fatal("RelatedWidgets property not found")
+	}
+
+	if !prop.IsManyToMany {
+		t.Error("expected IsManyToMany=true for a many2many navigation property")
+	}
+	if !prop.IsNavigationProp {
+		t.Error("expected IsNavigationProp=true for a many2many navigation property")
+	}
+	if prop.JoinTableName != "widget_relations" {
+		t.Errorf("expected JoinTableName %q, got %q", "widget_relations", prop.JoinTableName)
+	}
+	if prop.JoinTableForeignKey != "widget_id" {
+		t.Errorf("expected JoinTableForeignKey %q, got %q", "widget_id", prop.JoinTableForeignKey)
+	}
+	if prop.JoinTableReferencesColumn != "related_widget_id" {
+		t.Errorf("expected JoinTableReferencesColumn %q, got %q", "related_widget_id", prop.JoinTableReferencesColumn)
+	}
+}

--- a/internal/query/apply_filter.go
+++ b/internal/query/apply_filter.go
@@ -706,7 +706,7 @@ func buildComplexTypeNullComparison(dialect string, op FilterOperator, complexPr
 func buildComparisonConditionWithDB(db *gorm.DB, dialect string, filter *FilterExpression, entityMetadata *metadata.EntityMetadata) (string, []interface{}) {
 	// Handle lambda operators (any, all)
 	if filter.Operator == OpAny || filter.Operator == OpAll {
-		return buildLambdaCondition(dialect, filter, entityMetadata)
+		return buildLambdaCondition(dialect, filter, entityMetadata, "")
 	}
 
 	// Handle function comparisons (e.g., tolower(Name) eq 'john')
@@ -790,8 +790,17 @@ func buildEntityTypeFilter(dialect string, typeName string, entityMetadata *meta
 	return fmt.Sprintf("%s = ?", quotedColumn), []interface{}{simpleTypeName}
 }
 
-// buildLambdaCondition builds SQL for lambda operators (any/all) using EXISTS subquery
-func buildLambdaCondition(dialect string, filter *FilterExpression, entityMetadata *metadata.EntityMetadata) (string, []interface{}) {
+// buildLambdaCondition builds SQL for lambda operators (any/all) using EXISTS subquery.
+// parentAlias, when non-empty, is the table alias that refers to "the current row" of
+// entityMetadata in the enclosing SQL scope, and is used instead of
+// entityMetadata.TableName to correlate this EXISTS subquery back to it. This matters
+// for a lambda nested inside another lambda's predicate: if the outer lambda reached
+// its "current" entity through a many-to-many join, that entity is referenced via an
+// alias (see buildManyToManyLambdaCondition), not its bare table name — using the bare
+// table name here would silently (and incorrectly) correlate against the outermost
+// query's table instead of the actual enclosing row. Pass "" at the top level, where
+// entityMetadata.TableName unambiguously refers to the row being filtered.
+func buildLambdaCondition(dialect string, filter *FilterExpression, entityMetadata *metadata.EntityMetadata, parentAlias string) (string, []interface{}) {
 	navProp := findNavigationProperty(filter.Property, entityMetadata)
 	if navProp == nil {
 		return "", nil
@@ -799,11 +808,24 @@ func buildLambdaCondition(dialect string, filter *FilterExpression, entityMetada
 
 	navTargetMetadata := getNavigationTargetMetadata(entityMetadata, navProp)
 
+	// Many-to-many navigation properties join through a bridge/join table rather than
+	// a direct foreign key column on the related table, so they need a different EXISTS
+	// shape (join table + related table, correlated back to the parent through the join
+	// table's own-side column).
+	if navProp.IsManyToMany {
+		return buildManyToManyLambdaCondition(dialect, filter, entityMetadata, navProp, navTargetMetadata, parentAlias)
+	}
+
 	// Use cached table name from metadata (computed once during entity registration)
 	relatedTableName := navProp.NavigationTargetTableName
 
-	// Use cached table name from parent entity metadata
+	// Use cached table name from parent entity metadata, unless the caller supplied an
+	// alias that actually refers to the current row in the enclosing scope (see doc
+	// comment above).
 	parentTableName := entityMetadata.TableName
+	if parentAlias != "" {
+		parentTableName = parentAlias
+	}
 
 	// Use cached foreign key column name from metadata
 	// This was computed once during entity registration and respects GORM foreignKey: tags
@@ -886,7 +908,7 @@ func buildLambdaCondition(dialect string, filter *FilterExpression, entityMetada
 		return "", nil
 	}
 
-	predicateSQL, predicateArgs := buildFilterConditionForLambda(dialect, predicate, navTargetMetadata)
+	predicateSQL, predicateArgs := buildFilterConditionForLambda(dialect, predicate, navTargetMetadata, "")
 	if predicateSQL == "" {
 		return "", nil
 	}
@@ -898,6 +920,98 @@ func buildLambdaCondition(dialect string, filter *FilterExpression, entityMetada
 	} else {
 		sql = fmt.Sprintf("NOT EXISTS (SELECT 1 FROM %s WHERE %s AND NOT (%s))",
 			quoteIdent(dialect, relatedTableName), joinCondition, predicateSQL)
+	}
+
+	return sql, predicateArgs
+}
+
+// buildManyToManyLambdaCondition builds SQL for a lambda operator (any/all) over a
+// many-to-many navigation property. Unlike a direct foreign key relationship, the
+// related rows are reached through a join/bridge table, so the EXISTS subquery joins
+// the bridge table to the related table and correlates the bridge table's own-side
+// column back to the parent (outer) table. The related table is aliased because for
+// self-referential many-to-many relationships (e.g. Product.RelatedProducts), the
+// related table and the parent table are the same table, and an unaliased join would
+// make predicate columns and the parent correlation ambiguous.
+func buildManyToManyLambdaCondition(dialect string, filter *FilterExpression, entityMetadata *metadata.EntityMetadata, navProp *metadata.PropertyMetadata, navTargetMetadata *metadata.EntityMetadata, parentAlias string) (string, []interface{}) {
+	if navProp.JoinTableName == "" || navProp.JoinTableForeignKey == "" || navProp.JoinTableReferencesColumn == "" {
+		// Join info could not be resolved (e.g. a hand-rolled many2many tag GORM itself
+		// would reject). There is no safe convention to fall back to here.
+		return "", nil
+	}
+	if entityMetadata == nil || navTargetMetadata == nil || len(entityMetadata.KeyProperties) == 0 || len(navTargetMetadata.KeyProperties) == 0 {
+		return "", nil
+	}
+
+	ownColumns := strings.Split(navProp.JoinTableForeignKey, ",")
+	refColumns := strings.Split(navProp.JoinTableReferencesColumn, ",")
+	if len(ownColumns) != len(entityMetadata.KeyProperties) || len(refColumns) != len(navTargetMetadata.KeyProperties) {
+		return "", nil
+	}
+
+	// The parent table reference used to correlate the join table back to the
+	// enclosing row defaults to entityMetadata's own table, unless the caller supplied
+	// an alias that already refers to that row (see buildLambdaCondition's doc comment).
+	parentTableRef := entityMetadata.TableName
+	if parentAlias != "" {
+		parentTableRef = parentAlias
+	}
+
+	quotedJoinTable := quoteIdent(dialect, navProp.JoinTableName)
+	quotedParentTable := quoteIdent(dialect, parentTableRef)
+	quotedRelatedTable := quoteIdent(dialect, navProp.NavigationTargetTableName)
+	// Derive the related-table alias from parentAlias (when present) so that a lambda
+	// nested inside another many-to-many lambda on the same relation (e.g.
+	// RelatedProducts/any(r: r/RelatedProducts/any(r2: ...))) gets a distinct alias per
+	// nesting level rather than colliding with the alias the outer level already
+	// introduced in the same (lexically nested, and therefore visible) SQL scope.
+	relatedAlias := navProp.NavigationTargetTableName + "_m2m"
+	if parentAlias != "" {
+		relatedAlias = parentAlias + "_" + relatedAlias
+	}
+	quotedRelatedAlias := quoteIdent(dialect, relatedAlias)
+
+	joinToRelatedConditions := make([]string, 0, len(refColumns))
+	for i, refCol := range refColumns {
+		joinToRelatedConditions = append(joinToRelatedConditions,
+			fmt.Sprintf("%s.%s = %s.%s", quotedJoinTable, quoteIdent(dialect, strings.TrimSpace(refCol)),
+				quotedRelatedAlias, quoteIdent(dialect, navTargetMetadata.KeyProperties[i].ColumnName)))
+	}
+
+	correlateToParentConditions := make([]string, 0, len(ownColumns))
+	for i, ownCol := range ownColumns {
+		correlateToParentConditions = append(correlateToParentConditions,
+			fmt.Sprintf("%s.%s = %s.%s", quotedJoinTable, quoteIdent(dialect, strings.TrimSpace(ownCol)),
+				quotedParentTable, quoteIdent(dialect, entityMetadata.KeyProperties[i].ColumnName)))
+	}
+
+	fromClause := fmt.Sprintf("%s JOIN %s AS %s ON %s",
+		quotedJoinTable, quotedRelatedTable, quotedRelatedAlias, strings.Join(joinToRelatedConditions, " AND "))
+	correlateCondition := strings.Join(correlateToParentConditions, " AND ")
+
+	if filter.Value == nil || filter.Left == nil {
+		if filter.Operator == OpAny {
+			return fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s)", fromClause, correlateCondition), []interface{}{}
+		}
+		return fmt.Sprintf("NOT EXISTS (SELECT 1 FROM %s WHERE %s) OR EXISTS (SELECT 1 FROM %s WHERE %s)",
+			fromClause, correlateCondition, fromClause, correlateCondition), []interface{}{}
+	}
+
+	predicate := filter.Left
+	if predicate == nil {
+		return "", nil
+	}
+
+	predicateSQL, predicateArgs := buildFilterConditionForLambda(dialect, predicate, navTargetMetadata, relatedAlias)
+	if predicateSQL == "" {
+		return "", nil
+	}
+
+	var sql string
+	if filter.Operator == OpAny {
+		sql = fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s AND (%s))", fromClause, correlateCondition, predicateSQL)
+	} else {
+		sql = fmt.Sprintf("NOT EXISTS (SELECT 1 FROM %s WHERE %s AND NOT (%s))", fromClause, correlateCondition, predicateSQL)
 	}
 
 	return sql, predicateArgs
@@ -916,31 +1030,47 @@ func getNavigationTargetMetadata(entityMetadata *metadata.EntityMetadata, navPro
 	return targetMeta
 }
 
-// buildFilterConditionForLambda builds a filter condition for lambda subquery predicates
-func buildFilterConditionForLambda(dialect string, filter *FilterExpression, navTargetMetadata *metadata.EntityMetadata) (string, []interface{}) {
+// buildFilterConditionForLambda builds a filter condition for lambda subquery predicates.
+// tableQualifier, when non-empty, qualifies plain property column references with an
+// explicit table/alias prefix (e.g. "products_m2m"."price"). This is required for
+// many-to-many lambda predicates, where the EXISTS subquery's FROM clause joins two
+// tables (the bridge table and the aliased related table) so an unqualified column
+// name would otherwise be ambiguous or could shadow the outer parent table reference
+// for self-referential relationships. It is passed through empty ("") for the direct
+// foreign-key case, where the subquery only ever has one table in scope and the
+// generated SQL must stay unqualified to match existing behavior/tests.
+func buildFilterConditionForLambda(dialect string, filter *FilterExpression, navTargetMetadata *metadata.EntityMetadata, tableQualifier string) (string, []interface{}) {
 	if filter == nil {
 		return "", nil
 	}
 
 	if filter.Logical != "" {
-		return buildLogicalConditionForLambda(dialect, filter, navTargetMetadata)
+		return buildLogicalConditionForLambda(dialect, filter, navTargetMetadata, tableQualifier)
 	}
 
 	// Handle nested lambda operators (any/all within any/all), e.g.
 	// CollectionA/any(a: a/CollectionB/any(b: b/Property eq 'value')). navTargetMetadata
 	// is the entity the outer lambda's range variable ranges over, which is exactly the
 	// "current" entity metadata that buildLambdaCondition needs to resolve the nested
-	// navigation property and recurse into a nested EXISTS subquery.
+	// navigation property and recurse into a nested EXISTS subquery. tableQualifier is
+	// passed through as the nested call's parentAlias: if the outer lambda's "current"
+	// row is only reachable via an alias (e.g. the aliased related table of a
+	// many-to-many join), the nested EXISTS must correlate against that same alias
+	// rather than navTargetMetadata's bare table name, which could refer to a different
+	// row (or even the outermost query's row, for a self-referential relationship).
 	if filter.Operator == OpAny || filter.Operator == OpAll {
-		return buildLambdaCondition(dialect, filter, navTargetMetadata)
+		return buildLambdaCondition(dialect, filter, navTargetMetadata, tableQualifier)
 	}
 
 	if filter.Left != nil && filter.Left.Operator != "" {
-		return buildFunctionComparisonForLambda(dialect, filter, navTargetMetadata)
+		return buildFunctionComparisonForLambda(dialect, filter, navTargetMetadata, tableQualifier)
 	}
 
 	// Quote the column name for proper database compatibility
 	columnName := quoteIdent(dialect, GetColumnName(filter.Property, navTargetMetadata))
+	if tableQualifier != "" {
+		columnName = quoteIdent(dialect, tableQualifier) + "." + columnName
+	}
 
 	switch filter.Operator {
 	case OpEqual:
@@ -975,9 +1105,9 @@ func buildFilterConditionForLambda(dialect string, filter *FilterExpression, nav
 }
 
 // buildLogicalConditionForLambda builds a logical condition for lambda predicates
-func buildLogicalConditionForLambda(dialect string, filter *FilterExpression, navTargetMetadata *metadata.EntityMetadata) (string, []interface{}) {
-	leftQuery, leftArgs := buildFilterConditionForLambda(dialect, filter.Left, navTargetMetadata)
-	rightQuery, rightArgs := buildFilterConditionForLambda(dialect, filter.Right, navTargetMetadata)
+func buildLogicalConditionForLambda(dialect string, filter *FilterExpression, navTargetMetadata *metadata.EntityMetadata, tableQualifier string) (string, []interface{}) {
+	leftQuery, leftArgs := buildFilterConditionForLambda(dialect, filter.Left, navTargetMetadata, tableQualifier)
+	rightQuery, rightArgs := buildFilterConditionForLambda(dialect, filter.Right, navTargetMetadata, tableQualifier)
 
 	var query string
 	switch filter.Logical {
@@ -994,7 +1124,7 @@ func buildLogicalConditionForLambda(dialect string, filter *FilterExpression, na
 }
 
 // buildFunctionComparisonForLambda builds a function comparison for lambda predicates
-func buildFunctionComparisonForLambda(dialect string, filter *FilterExpression, navTargetMetadata *metadata.EntityMetadata) (string, []interface{}) {
+func buildFunctionComparisonForLambda(dialect string, filter *FilterExpression, navTargetMetadata *metadata.EntityMetadata, tableQualifier string) (string, []interface{}) {
 	funcExpr := filter.Left
 	var funcSQL string
 	var funcArgs []interface{}
@@ -1006,6 +1136,9 @@ func buildFunctionComparisonForLambda(dialect string, filter *FilterExpression, 
 	} else {
 		// Quote the column name for proper database compatibility
 		columnName := quoteIdent(dialect, GetColumnName(funcExpr.Property, navTargetMetadata))
+		if tableQualifier != "" {
+			columnName = quoteIdent(dialect, tableQualifier) + "." + columnName
+		}
 		funcSQL, funcArgs = buildFunctionSQL(dialect, funcExpr.Operator, columnName, funcExpr.Value)
 		if funcSQL == "" {
 			return "", nil

--- a/internal/query/apply_filter_test.go
+++ b/internal/query/apply_filter_test.go
@@ -161,7 +161,7 @@ func TestBuildLambdaConditionLogsForeignKeyMismatch(t *testing.T) {
 	})
 	os.Stdout = stdoutWriter
 
-	_, _ = buildLambdaCondition("sqlite", filterExpr, parentMeta)
+	_, _ = buildLambdaCondition("sqlite", filterExpr, parentMeta, "")
 
 	if err := stdoutWriter.Close(); err != nil {
 		t.Fatalf("Failed to close stdout writer: %v", err)

--- a/internal/query/apply_transform.go
+++ b/internal/query/apply_transform.go
@@ -48,6 +48,15 @@ func applyTransformations(db *gorm.DB, transformations []ApplyTransformation, en
 
 	dialect := getDatabaseDialect(db)
 
+	// Apply a default SELECT that aliases every scalar column to its JSON property
+	// name. $apply always produces map results ([]map[string]interface{}), so without
+	// an explicit alias GORM's "SELECT *" returns raw snake_case DB column names (e.g.
+	// "category_id") instead of the OData property name ("CategoryID"). Transformations
+	// that need a different projection (groupby, aggregate, compute) overwrite this
+	// with their own db.Select call further down, since GORM's Select replaces rather
+	// than appends to the prior selection.
+	db = applyDefaultMapResultSelect(db, dialect, entityMetadata)
+
 	hasGrouping := false
 	// Initialize alias expressions map in GORM context for this query
 	db = setAliasExprsInDB(db, make(map[string]string))
@@ -137,6 +146,33 @@ func applyTransformations(db *gorm.DB, transformations []ApplyTransformation, en
 		}
 	}
 	return db, hasGrouping
+}
+
+// applyDefaultMapResultSelect builds a SELECT clause that aliases every scalar
+// (non-navigation, non-computed, non-complex-type, non-stream) property column with
+// its JSON name, so that map-result rows are keyed by OData property names rather
+// than raw database column names. Mirrors the aliasing done by applyGroupByWithRollup
+// and applyCompute for the same reason.
+func applyDefaultMapResultSelect(db *gorm.DB, dialect string, entityMetadata *metadata.EntityMetadata) *gorm.DB {
+	if entityMetadata == nil {
+		return db
+	}
+
+	tableName := entityMetadata.TableName
+	selectColumns := make([]string, 0, len(entityMetadata.Properties))
+	for _, prop := range entityMetadata.Properties {
+		if prop.IsNavigationProp || prop.IsComputed || prop.IsComplexType || prop.IsStream {
+			continue
+		}
+		qualified := quoteTableName(dialect, tableName) + "." + quoteIdent(dialect, prop.ColumnName)
+		selectColumns = append(selectColumns, fmt.Sprintf("%s as %s", qualified, quoteIdent(dialect, prop.JsonName)))
+	}
+
+	if len(selectColumns) > 0 {
+		db = db.Select(strings.Join(selectColumns, ", "))
+	}
+
+	return db
 }
 
 func applySearchTransformation(db *gorm.DB, search *string, entityMetadata *metadata.EntityMetadata) *gorm.DB {

--- a/internal/query/lambda_test.go
+++ b/internal/query/lambda_test.go
@@ -535,7 +535,7 @@ func TestLambdaOrPredicateSQL(t *testing.T) {
 		},
 	}
 
-	sql, _ := buildFilterConditionForLambda("sqlite", predicate, nil)
+	sql, _ := buildFilterConditionForLambda("sqlite", predicate, nil, "")
 
 	// The OR predicate itself must be produced correctly.
 	if !strings.Contains(sql, " OR ") {

--- a/test/apply_integration_test.go
+++ b/test/apply_integration_test.go
@@ -511,6 +511,78 @@ func TestIntegrationApplyFilter(t *testing.T) {
 	}
 }
 
+// TestIntegrationApplyFilterOnly reproduces #784: a bare $apply=filter(expr), with no
+// groupby/aggregate/compute in the pipeline, must return the same entities as the
+// equivalent $filter=expr, keyed by their OData JSON property names (e.g. "Price"),
+// not the raw snake_case database column names (e.g. "price"). Only groupby/aggregate/
+// compute transformations built an explicit JSON-aliased SELECT; a plain filter()
+// pipeline fell through to GORM's default "SELECT *", which uses raw DB column names
+// when scanning into map results.
+func TestIntegrationApplyFilterOnly(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&ApplyTestProduct{}); err != nil {
+		t.Fatalf("Failed to migrate: %v", err)
+	}
+
+	products := []ApplyTestProduct{
+		{ID: 1, Name: "Laptop", Price: 999.99, Category: "Electronics", Quantity: 10},
+		{ID: 2, Name: "Mouse", Price: 29.99, Category: "Electronics", Quantity: 50},
+		{ID: 3, Name: "Keyboard", Price: 149.99, Category: "Electronics", Quantity: 30},
+	}
+	for _, product := range products {
+		if err := db.Create(&product).Error; err != nil {
+			t.Fatalf("Failed to create product: %v", err)
+		}
+	}
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	_ = service.RegisterEntity(&ApplyTestProduct{})
+
+	req := httptest.NewRequest("GET", "/ApplyTestProducts?$apply=filter(Price%20gt%2050)", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	body, _ := io.ReadAll(w.Body)
+	var response map[string]interface{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("Failed to parse JSON: %v", err)
+	}
+
+	value, ok := response["value"].([]interface{})
+	if !ok {
+		t.Fatal("value is not an array")
+	}
+	if len(value) != 2 {
+		t.Fatalf("Expected 2 entities (Laptop, Keyboard), got %d: %v", len(value), value)
+	}
+
+	row, ok := value[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("row is not an object")
+	}
+	for _, jsonName := range []string{"ID", "Name", "Price", "Category", "Quantity"} {
+		if _, ok := row[jsonName]; !ok {
+			t.Errorf("Expected row to have JSON property %q, got keys: %v", jsonName, row)
+		}
+	}
+	for _, snakeName := range []string{"id", "name", "price", "category", "quantity"} {
+		if _, ok := row[snakeName]; ok {
+			t.Errorf("Row unexpectedly has raw DB column name %q instead of its JSON name", snakeName)
+		}
+	}
+}
+
 func TestIntegrationApplyConcat_StrictSemantics(t *testing.T) {
 	// Initialize database
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})

--- a/test/lambda_many_to_many_test.go
+++ b/test/lambda_many_to_many_test.go
@@ -1,0 +1,151 @@
+package odata_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// RelationProduct/RelationDescription form a self-referential many-to-many navigation property
+// (RelatedProducts) plus a one-to-many navigation property (Descriptions), used to
+// exercise a lambda filter nested inside a many-to-many lambda filter, i.e.
+// RelatedProducts/any(r: r/Descriptions/any(d: ...)).
+type RelationProduct struct {
+	ID              uint                  `json:"ID" gorm:"primaryKey" odata:"key"`
+	Name            string                `json:"Name"`
+	Descriptions    []RelationDescription `json:"Descriptions" gorm:"foreignKey:ProductID"`
+	RelatedProducts []RelationProduct     `json:"RelatedProducts,omitempty" gorm:"many2many:relation_product_relations;"`
+}
+
+type RelationDescription struct {
+	ID          uint   `json:"ID" gorm:"primaryKey" odata:"key"`
+	ProductID   uint   `json:"ProductID"`
+	LanguageKey string `json:"LanguageKey"`
+}
+
+func setupLambdaManyToManyTest(t *testing.T) *odata.Service {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&RelationProduct{}, &RelationDescription{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	// Product 1 (Laptop) has an EN description.
+	db.Create(&RelationProduct{ID: 1, Name: "Laptop"})
+	db.Create(&RelationDescription{ID: 1, ProductID: 1, LanguageKey: "EN"})
+
+	// Product 2 (Mouse) has only a DE description.
+	db.Create(&RelationProduct{ID: 2, Name: "Mouse"})
+	db.Create(&RelationDescription{ID: 2, ProductID: 2, LanguageKey: "DE"})
+
+	// Product 3 (Chair) is related to Product 1 (Laptop), which has an EN description.
+	db.Create(&RelationProduct{ID: 3, Name: "Chair"})
+	if err := db.Exec("INSERT INTO relation_product_relations (relation_product_id, related_product_id) VALUES (3, 1)").Error; err != nil {
+		t.Fatalf("Failed to seed product_relations: %v", err)
+	}
+
+	// Product 4 (Desk) is related to Product 2 (Mouse), which has no EN description.
+	db.Create(&RelationProduct{ID: 4, Name: "Desk"})
+	if err := db.Exec("INSERT INTO relation_product_relations (relation_product_id, related_product_id) VALUES (4, 2)").Error; err != nil {
+		t.Fatalf("Failed to seed product_relations: %v", err)
+	}
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	if err := service.RegisterEntity(&RelationProduct{}); err != nil {
+		t.Fatalf("Failed to register RelationProduct entity: %v", err)
+	}
+	if err := service.RegisterEntity(&RelationDescription{}); err != nil {
+		t.Fatalf("Failed to register RelationDescription entity: %v", err)
+	}
+
+	return service
+}
+
+func queryRelationProductIDs(t *testing.T, service *odata.Service, filterQuery string) []float64 {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/RelationProducts?$filter="+url.QueryEscape(filterQuery), nil)
+	rec := httptest.NewRecorder()
+	service.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	value, ok := response["value"].([]interface{})
+	if !ok {
+		t.Fatal("Response missing 'value' array")
+	}
+
+	ids := make([]float64, 0, len(value))
+	for _, item := range value {
+		product := item.(map[string]interface{})
+		ids = append(ids, product["ID"].(float64))
+	}
+	return ids
+}
+
+// TestLambdaManyToMany_SimplePredicate reproduces the base case from #783: a lambda
+// filter directly over a many-to-many self-referential navigation property must join
+// through the bridge table rather than assume a direct foreign key column exists on
+// the related table.
+func TestLambdaManyToMany_SimplePredicate(t *testing.T) {
+	service := setupLambdaManyToManyTest(t)
+
+	ids := queryRelationProductIDs(t, service, "RelatedProducts/any(r: r/Name eq 'Laptop')")
+
+	if len(ids) != 1 || ids[0] != 3 {
+		t.Fatalf("Expected only Chair (3), got %v", ids)
+	}
+}
+
+// TestLambdaManyToMany_NestedLambda reproduces #783: a two-level nested lambda filter
+// where the outer lambda ranges over a many-to-many self-referential navigation
+// property (RelatedProducts) and the inner lambda ranges over a one-to-many navigation
+// property (Descriptions) on the related entity must return 200 with the correct
+// result, not a 500 ("no such column") caused by assuming a direct foreign key column
+// exists for the many-to-many relation.
+func TestLambdaManyToMany_NestedLambda(t *testing.T) {
+	service := setupLambdaManyToManyTest(t)
+
+	ids := queryRelationProductIDs(t, service,
+		"RelatedProducts/any(r: r/Descriptions/any(d: d/LanguageKey eq 'EN'))")
+
+	if len(ids) != 1 || ids[0] != 3 {
+		t.Fatalf("Expected only Chair (3), got %v", ids)
+	}
+}
+
+// TestLambdaManyToMany_NestedLambda_NoMatchIsVacuouslyFalse verifies that when the
+// related product does not satisfy the inner predicate (Desk -> Mouse, which has no EN
+// description), the outer lambda correctly excludes it rather than matching due to a
+// mis-correlated subquery.
+func TestLambdaManyToMany_NestedLambda_NoMatchIsVacuouslyFalse(t *testing.T) {
+	service := setupLambdaManyToManyTest(t)
+
+	ids := queryRelationProductIDs(t, service,
+		"RelatedProducts/any(r: r/Descriptions/any(d: d/LanguageKey eq 'ZZ'))")
+
+	if len(ids) != 0 {
+		t.Fatalf("Expected no products to match, got %v", ids)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #784: `$apply=filter(...)` (and any $apply pipeline without groupby/aggregate/compute) returned map results keyed by raw snake_case DB column names instead of OData JSON property names, causing clients that match rows by property name to silently see 0/1 matches.
- Fixes #783: A lambda filter nested inside another lambda over a many-to-many navigation property (e.g. `RelatedProducts/any(r: r/Descriptions/any(d: ...))`) crashed with a 500 ("no such column") because the SQL builder assumed a direct foreign key column exists for many-to-many relations, and mis-correlated the nested EXISTS subquery once the many-to-many join required aliasing.

## Changes
- `internal/query/apply_transform.go`: apply a default JSON-aliasing `SELECT` at the start of the `$apply` pipeline so plain `filter()`/`orderby()`/etc. map results use OData property names; groupby/aggregate/compute still override it with their own projection.
- `internal/metadata/analyzer.go`: resolve many-to-many join table/column info via GORM's own schema parser (`gorm.io/gorm/schema.Parse`) instead of the naive `<property>_id` convention, which doesn't apply to bridge-table relations.
- `internal/query/apply_filter.go`: build a bridge-table `JOIN` for many-to-many lambda filters, and thread the aliasing table qualifier through to nested lambda predicates so a lambda nested inside a many-to-many lambda correlates against the correct (possibly aliased) row instead of the wrong table.

## Test plan
- [x] `go test ./...` passes
- [x] New regression tests: `internal/metadata/analyzer_test.go` (M2M join metadata resolution), `test/apply_integration_test.go` (`$apply=filter()` JSON naming), `test/lambda_many_to_many_test.go` (simple + nested M2M lambda filters, including a vacuously-false case)
- [x] Manually verified end-to-end against a rebuilt `cmd/complianceserver`: `$apply=filter(Price gt 50)` now returns all 5 matching products with `Price`/`Name`/etc. keys; `RelatedProducts/any(r: r/Descriptions/any(d: d/LanguageKey eq 'EN'))` returns 200 with the correct product instead of a 500