### PR TITLE
fix: support namespace-qualified invocation of bound actions and functions

### DIFF
--- a/internal/service/router/router.go
+++ b/internal/service/router/router.go
@@ -61,6 +61,14 @@ type Router struct {
 	asyncMu            sync.RWMutex
 	asyncManager       *async.Manager
 	asyncMonitorPrefix string
+
+	// namespace is the schema namespace advertised in $metadata. It is used to
+	// resolve namespace-qualified action/function path segments (e.g.
+	// "ComplianceService.GetTotalPrice") to the unqualified name under which
+	// the operation is registered. Protected by namespaceMu since it can be
+	// updated concurrently with request handling via Service.SetNamespace.
+	namespaceMu sync.RWMutex
+	namespace   string
 }
 
 // NewRouter creates a new Router instance.
@@ -95,6 +103,20 @@ func (r *Router) SetLogger(logger *slog.Logger) {
 		logger = slog.Default()
 	}
 	r.logger = logger
+}
+
+// SetNamespace updates the schema namespace used to resolve namespace-qualified
+// action/function invocations (OData v4 Part 2 §4.5).
+func (r *Router) SetNamespace(namespace string) {
+	r.namespaceMu.Lock()
+	r.namespace = namespace
+	r.namespaceMu.Unlock()
+}
+
+func (r *Router) getNamespace() string {
+	r.namespaceMu.RLock()
+	defer r.namespaceMu.RUnlock()
+	return r.namespace
 }
 
 // ServeHTTP implements http.Handler interface.
@@ -155,19 +177,21 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case http.MethodGet, http.MethodHead:
 		if !strings.Contains(path, "(") && !strings.Contains(path, ")") {
-			if _, exists := r.functions[path]; exists {
-				supportsNoParens := negotiatedVersion.Major > 4 || (negotiatedVersion.Major == 4 && negotiatedVersion.Minor >= 1)
-				if !supportsNoParens {
-					if writeErr := response.WriteError(w, req, http.StatusBadRequest, "Invalid function invocation",
-						"Function invocations without parentheses require OData 4.01 negotiation; use parentheses syntax (FunctionName())"); writeErr != nil {
-						r.logger.Error("Error writing error response", "error", writeErr)
+			if resolved, ok := r.resolveBoundName(path); ok {
+				if _, exists := r.functions[resolved]; exists {
+					supportsNoParens := negotiatedVersion.Major > 4 || (negotiatedVersion.Major == 4 && negotiatedVersion.Minor >= 1)
+					if !supportsNoParens {
+						if writeErr := response.WriteError(w, req, http.StatusBadRequest, "Invalid function invocation",
+							"Function invocations without parentheses require OData 4.01 negotiation; use parentheses syntax (FunctionName())"); writeErr != nil {
+							r.logger.Error("Error writing error response", "error", writeErr)
+						}
+						return
 					}
-					return
-				}
 
-				if r.hasUnboundParameterlessFunction(path) && !hasNonSystemQueryParams(req.URL.Query()) {
-					r.actionInvoker(w, req, path, "", false, "")
-					return
+					if r.hasUnboundParameterlessFunction(resolved) && !hasNonSystemQueryParams(req.URL.Query()) {
+						r.actionInvoker(w, req, resolved, "", false, "")
+						return
+					}
 				}
 			}
 		}
@@ -177,14 +201,14 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			if idx := strings.Index(path, "("); idx != -1 {
 				pathWithoutParams = path[:idx]
 			}
-			if r.isActionOrFunction(pathWithoutParams) {
-				r.actionInvoker(w, req, pathWithoutParams, "", false, "")
+			if resolved, ok := r.resolveBoundName(pathWithoutParams); ok && r.isActionOrFunction(resolved) {
+				r.actionInvoker(w, req, resolved, "", false, "")
 				return
 			}
 		}
 	case http.MethodPost:
-		if r.isActionOrFunction(path) {
-			r.actionInvoker(w, req, path, "", false, "")
+		if resolved, ok := r.resolveBoundName(path); ok && r.isActionOrFunction(resolved) {
+			r.actionInvoker(w, req, resolved, "", false, "")
 			return
 		}
 	case http.MethodPut, http.MethodPatch, http.MethodDelete:
@@ -192,14 +216,14 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if idx := strings.Index(path, "("); idx != -1 {
 			pathWithoutParams = path[:idx]
 		}
-		if r.isActionOrFunction(pathWithoutParams) {
+		if r.isBoundOperationSegment(pathWithoutParams) {
 			if writeErr := response.WriteMethodNotAllowed(w, req, "GET, HEAD, POST, OPTIONS", "Method not allowed",
 				fmt.Sprintf("Method %s is not allowed for actions or functions", req.Method)); writeErr != nil {
 				r.logger.Error("Error writing error response", "error", writeErr)
 			}
 			return
 		}
-		if r.isActionOrFunction(path) {
+		if r.isBoundOperationSegment(path) {
 			if writeErr := response.WriteMethodNotAllowed(w, req, "GET, HEAD, POST, OPTIONS", "Method not allowed",
 				fmt.Sprintf("Method %s is not allowed for actions or functions", req.Method)); writeErr != nil {
 				r.logger.Error("Error writing error response", "error", writeErr)
@@ -223,6 +247,27 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			r.logger.Error("Error writing error response", "error", writeErr)
 		}
 		return
+	}
+
+	// A namespace-qualified action/function segment without parentheses (e.g.
+	// "ComplianceService.ApplyDiscount") is syntactically indistinguishable
+	// from a derived-type cast segment (e.g. "ComplianceService.Manager") and
+	// so gets parsed as components.TypeCast above. Reinterpret it as an
+	// operation invocation when it actually resolves to a registered bound or
+	// unbound action/function; otherwise leave the type-cast parsing as-is.
+	if components.TypeCast != "" && components.NavigationProperty == "" {
+		if resolved, ok := r.resolveBoundName(components.TypeCast); ok && r.isActionOrFunction(resolved) {
+			components.NavigationProperty = resolved
+			components.PropertySegments = []string{resolved}
+			components.PropertyPath = resolved
+			components.TypeCast = ""
+		} else if r.isUnresolvableQualifiedOperation(components.TypeCast) {
+			if writeErr := response.WriteError(w, req, http.StatusNotFound, "Action or function not found",
+				fmt.Sprintf("'%s' does not match the service namespace", components.TypeCast)); writeErr != nil {
+				r.logger.Error("Error writing error response", "error", writeErr)
+			}
+			return
+		}
 	}
 
 	if components.TypeCast != "" {
@@ -364,7 +409,7 @@ func (r *Router) routeRequest(w http.ResponseWriter, req *http.Request, handler 
 				!handler.IsStructuralProperty(potentialKey) &&
 				!handler.IsStreamProperty(potentialKey) &&
 				!handler.IsComplexTypeProperty(potentialKey) &&
-				!r.isActionOrFunction(operationName) {
+				!r.isBoundOperationSegment(operationName) {
 				components = resolveKeyAsSegment(components)
 				hasKey = true
 			}
@@ -411,8 +456,8 @@ func (r *Router) routeRequest(w http.ResponseWriter, req *http.Request, handler 
 			if idx := strings.Index(operationName, "("); idx != -1 {
 				operationName = operationName[:idx]
 			}
-			if r.isActionOrFunction(operationName) {
-				r.actionInvoker(w, req, operationName, "", true, components.EntitySet)
+			if resolved, ok := r.resolveBoundName(operationName); ok && r.isActionOrFunction(resolved) {
+				r.actionInvoker(w, req, resolved, "", true, components.EntitySet)
 				return
 			}
 		}
@@ -445,8 +490,8 @@ func (r *Router) handlePropertyRequest(w http.ResponseWriter, req *http.Request,
 		operationName = operationName[:idx]
 	}
 
-	if r.isActionOrFunction(operationName) {
-		r.actionInvoker(w, req, operationName, keyString, true, components.EntitySet)
+	if resolved, ok := r.resolveBoundName(operationName); ok && r.isActionOrFunction(resolved) {
+		r.actionInvoker(w, req, resolved, keyString, true, components.EntitySet)
 		return
 	}
 
@@ -465,6 +510,9 @@ func (r *Router) handlePropertyRequest(w http.ResponseWriter, req *http.Request,
 		lastOperationName := lastSegment
 		if idx := strings.Index(lastSegment, "("); idx != -1 {
 			lastOperationName = lastSegment[:idx]
+		}
+		if resolved, ok := r.resolveBoundName(lastOperationName); ok {
+			lastOperationName = resolved
 		}
 
 		// Check if first segment is a navigation property and last segment is an operation
@@ -622,6 +670,69 @@ func (r *Router) isActionOrFunction(name string) bool {
 		return true
 	}
 	return false
+}
+
+// splitLastDot splits name at its last '.' character, returning the portion
+// before ("prefix") and after ("suffix") the dot. ok is false when name
+// contains no dot, in which case suffix equals name unchanged.
+func splitLastDot(name string) (prefix, suffix string, ok bool) {
+	idx := strings.LastIndex(name, ".")
+	if idx == -1 {
+		return "", name, false
+	}
+	return name[:idx], name[idx+1:], true
+}
+
+// resolveBoundName resolves a possibly namespace- or alias-qualified action or
+// function segment to its unqualified registered name.
+//
+// Per OData v4.0 Part 2 §4.5 ("Invoking Actions") and the equivalent function
+// invocation rules, a bound (or unbound) action or function MUST be invocable
+// using its namespace-qualified name (e.g. "ComplianceService.GetTotalPrice"),
+// in addition to the short/unqualified name where that is unambiguous.
+//
+// If name contains no '.', it is not qualified and is returned unchanged. If
+// it is qualified, the namespace portion must exactly match the service's
+// configured schema namespace; otherwise resolution fails so that operations
+// cannot be invoked under an arbitrary or incorrect namespace.
+func (r *Router) resolveBoundName(name string) (string, bool) {
+	ns, local, hasNamespace := splitLastDot(name)
+	if !hasNamespace {
+		return name, true
+	}
+	if local == "" {
+		return "", false
+	}
+	serviceNamespace := r.getNamespace()
+	if serviceNamespace == "" || ns != serviceNamespace {
+		return "", false
+	}
+	return local, true
+}
+
+// isBoundOperationSegment reports whether name (which may be namespace-
+// qualified) resolves to a registered action or function.
+func (r *Router) isBoundOperationSegment(name string) bool {
+	resolved, ok := r.resolveBoundName(name)
+	return ok && r.isActionOrFunction(resolved)
+}
+
+// isUnresolvableQualifiedOperation reports whether name looks like an attempt
+// to invoke a registered action or function using a namespace qualifier that
+// does not match the service's schema namespace (e.g.
+// "WrongNamespace.ApplyDiscount" when the real action is "ApplyDiscount").
+// This lets callers distinguish "unknown namespace for a real operation"
+// (which should 404) from an unrelated segment such as a genuine derived-type
+// cast (e.g. "ComplianceService.SpecialProduct").
+func (r *Router) isUnresolvableQualifiedOperation(name string) bool {
+	_, local, hasNamespace := splitLastDot(name)
+	if !hasNamespace {
+		return false
+	}
+	if _, ok := r.resolveBoundName(name); ok {
+		return false
+	}
+	return r.isActionOrFunction(local)
 }
 
 // getNavigationTargetEntitySet returns the target entity set name for a navigation property

--- a/odata.go
+++ b/odata.go
@@ -564,6 +564,7 @@ func NewServiceWithConfig(db *gorm.DB, cfg ServiceConfig) (*Service, error) {
 		logger,
 	)
 	s.router.SetAsyncMonitor(s.asyncMonitorPrefix, s.asyncManager)
+	s.router.SetNamespace(s.namespace)
 	s.runtime = servruntime.New(s.router, logger)
 
 	if err := s.RegisterKeyGenerator("uuid", func(context.Context) (interface{}, error) {
@@ -1698,6 +1699,7 @@ func (s *Service) SetNamespace(namespace string) error {
 	s.namespace = trimmed
 	s.metadataHandler.SetNamespace(trimmed)
 	s.operationsHandler.SetNamespace(trimmed)
+	s.router.SetNamespace(trimmed)
 	for _, handler := range s.handlers {
 		handler.SetNamespace(trimmed)
 	}

--- a/test/actions_functions_test.go
+++ b/test/actions_functions_test.go
@@ -950,3 +950,176 @@ func TestFunctionParameterTypeValidation(t *testing.T) {
 		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusBadRequest, w.Body.String())
 	}
 }
+
+// TestBoundFunctionNamespaceQualifiedName verifies that a bound function can
+// be invoked using its namespace-qualified name (OData v4.0 Part 2 §4.5), in
+// addition to the short/unqualified name. See issue #787.
+func TestBoundFunctionNamespaceQualifiedName(t *testing.T) {
+	service, db := setupActionFunctionTestService(t)
+
+	if err := service.SetNamespace("ContosoService"); err != nil {
+		t.Fatalf("SetNamespace() error: %v", err)
+	}
+
+	err := service.RegisterFunction(odata.FunctionDefinition{
+		Name:      "GetDiscountedPrice",
+		IsBound:   true,
+		EntitySet: "ActionTestProducts",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "discount", Type: reflect.TypeOf(float64(0)), Required: true},
+		},
+		ReturnType: reflect.TypeOf(float64(0)),
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) (interface{}, error) {
+			discount := params["discount"].(float64)
+
+			var product ActionTestProduct
+			if err := db.First(&product, 1).Error; err != nil {
+				return nil, err
+			}
+
+			return product.Price * (1 - discount/100), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to register function: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ActionTestProducts(1)/ContosoService.GetDiscountedPrice(discount=10)", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Status = %v, want %v. Body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	value, ok := response["value"].(float64)
+	if !ok {
+		t.Fatalf("Response missing numeric value: %v", response)
+	}
+	if value != 900.0 {
+		t.Errorf("value = %v, want %v", value, 900.0)
+	}
+}
+
+// TestBoundActionNamespaceQualifiedName verifies that a bound action can be
+// invoked using its namespace-qualified name (OData v4.0 Part 2 §4.5), in
+// addition to the short/unqualified name. See issue #787.
+func TestBoundActionNamespaceQualifiedName(t *testing.T) {
+	service, db := setupActionFunctionTestService(t)
+
+	if err := service.SetNamespace("ContosoService"); err != nil {
+		t.Fatalf("SetNamespace() error: %v", err)
+	}
+
+	err := service.RegisterAction(odata.ActionDefinition{
+		Name:      "UpdatePrice",
+		IsBound:   true,
+		EntitySet: "ActionTestProducts",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "newPrice", Type: reflect.TypeOf(float64(0)), Required: true},
+		},
+		ReturnType: nil,
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			newPrice := params["newPrice"].(float64)
+
+			if err := db.Model(&ActionTestProduct{}).Where("id = ?", 1).Update("price", newPrice).Error; err != nil {
+				return err
+			}
+
+			w.WriteHeader(http.StatusNoContent)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to register action: %v", err)
+	}
+
+	body := []byte(`{"newPrice": 500.0}`)
+	req := httptest.NewRequest(http.MethodPost, "/ActionTestProducts(1)/ContosoService.UpdatePrice", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Status = %v, want %v. Body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+
+	var product ActionTestProduct
+	if err := db.First(&product, 1).Error; err != nil {
+		t.Fatalf("Failed to fetch product: %v", err)
+	}
+	if product.Price != 500.0 {
+		t.Errorf("Product price = %v, want 500.0", product.Price)
+	}
+}
+
+// TestBoundOperationUnknownNamespaceReturns404 verifies that qualifying a
+// bound function or action with a namespace that does not match the
+// service's configured schema namespace is rejected with 404, rather than
+// silently matching the operation under any namespace. See issue #787.
+func TestBoundOperationUnknownNamespaceReturns404(t *testing.T) {
+	service, _ := setupActionFunctionTestService(t)
+
+	if err := service.SetNamespace("ContosoService"); err != nil {
+		t.Fatalf("SetNamespace() error: %v", err)
+	}
+
+	err := service.RegisterFunction(odata.FunctionDefinition{
+		Name:      "GetDiscountedPrice",
+		IsBound:   true,
+		EntitySet: "ActionTestProducts",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "discount", Type: reflect.TypeOf(float64(0)), Required: true},
+		},
+		ReturnType: reflect.TypeOf(float64(0)),
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) (interface{}, error) {
+			return 0.0, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to register function: %v", err)
+	}
+
+	err = service.RegisterAction(odata.ActionDefinition{
+		Name:      "UpdatePrice",
+		IsBound:   true,
+		EntitySet: "ActionTestProducts",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "newPrice", Type: reflect.TypeOf(float64(0)), Required: true},
+		},
+		ReturnType: nil,
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			t.Error("action handler should not be invoked for an unknown-namespace-qualified request")
+			w.WriteHeader(http.StatusNoContent)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to register action: %v", err)
+	}
+
+	// Wrong namespace on a function call (has parentheses).
+	funcReq := httptest.NewRequest(http.MethodGet, "/ActionTestProducts(1)/WrongNamespace.GetDiscountedPrice(discount=10)", nil)
+	funcW := httptest.NewRecorder()
+	service.ServeHTTP(funcW, funcReq)
+	if funcW.Code != http.StatusNotFound {
+		t.Errorf("function: Status = %v, want %v. Body: %s", funcW.Code, http.StatusNotFound, funcW.Body.String())
+	}
+
+	// Wrong namespace on an action call (no parentheses).
+	actionBody := []byte(`{"newPrice": 1.0}`)
+	actionReq := httptest.NewRequest(http.MethodPost, "/ActionTestProducts(1)/WrongNamespace.UpdatePrice", bytes.NewReader(actionBody))
+	actionReq.Header.Set("Content-Type", "application/json")
+	actionW := httptest.NewRecorder()
+	service.ServeHTTP(actionW, actionReq)
+	if actionW.Code != http.StatusNotFound {
+		t.Errorf("action: Status = %v, want %v. Body: %s", actionW.Code, http.StatusNotFound, actionW.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #787: bound actions and functions could previously only be invoked with their short (unqualified) name. Per OData v4.0 Part 2 §4.5, the namespace-qualified form (e.g. `Products(id)/ComplianceService.GetTotalPrice(taxRate=0.08)` for functions, `Products(id)/ComplianceService.ApplyDiscount` for actions) must also be accepted.
- Root cause: the router looked up actions/functions by exact unqualified name only. For qualified GET calls (with parentheses) the segment was left unrecognized and fell through to property resolution (404 "not a valid property"). For qualified POST calls without parentheses, the `Namespace.Operation` segment was syntactically indistinguishable from a derived-type-cast segment and got parsed as one, routing to entity-level handling instead of the action invoker (405 "Method not allowed").
- Fix: the router now resolves `Namespace.Operation` segments against the service's configured schema namespace (`Service.SetNamespace`) before matching against registered actions/functions, for both the function/parenthesized case and the action/type-cast-shaped case. Segments qualified with a namespace that doesn't match the service's namespace are rejected with 404 rather than silently matching under any namespace. Unqualified short-name invocation continues to work unchanged, and genuine derived-type casts (e.g. `Products(id)/ComplianceService.SpecialProduct`) are unaffected.
- As a side effect, unbound actions/functions can now also be invoked with their namespace-qualified name at the service root (e.g. `POST /ComplianceService.ResetAllPrices`), consistent with the same spec section.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l` clean on changed files
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass (pre-existing flaky `TestJobSetRetryAfter` in `internal/async` reproduces identically on unmodified `main`, unrelated to this change)
- [x] Manually reproduced the bug against `cmd/complianceserver` before the fix (404 for qualified function, 405 for qualified action) and confirmed both now return 200, while unqualified short-name calls and unknown-namespace calls (404) still behave correctly
- [x] Added `TestBoundFunctionNamespaceQualifiedName`, `TestBoundActionNamespaceQualifiedName`, and `TestBoundOperationUnknownNamespaceReturns404` in `test/actions_functions_test.go`

Fixes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)