### PR TITLE
fix: honor $count composed after a bound function-call segment

### DIFF
--- a/internal/actions/context.go
+++ b/internal/actions/context.go
@@ -84,3 +84,31 @@ func NavigationBindingContextFromRequest(r *http.Request) *NavigationBindingCont
 	}
 	return navCtx
 }
+
+// countRequestedContextKey is the unexported key type used to mark a request
+// as a composed $count invocation appended to a function-call segment.
+type countRequestedContextKey struct{}
+
+// WithCountRequested returns a shallow copy of r whose context signals that
+// the caller appended a $count segment after a function-call segment, e.g.
+// Products(1)/GetRelatedProducts()/$count. Per OData v4.0 Part 1 §12.1,
+// functions that return a collection are composable and may be followed by
+// further path segments such as $count. The stored flag can later be read
+// with CountRequested so the function-invocation handler can return the
+// result collection's count instead of the full result.
+func WithCountRequested(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), countRequestedContextKey{}, true))
+}
+
+// CountRequested reports whether the request was dispatched as a composed
+// $count invocation appended to a function-call segment.
+func CountRequested(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	requested, ok := r.Context().Value(countRequestedContextKey{}).(bool)
+	if !ok {
+		return false
+	}
+	return requested
+}

--- a/internal/service/operations/handler.go
+++ b/internal/service/operations/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 
 	"github.com/nlstn/go-odata/internal/actions"
@@ -96,6 +97,17 @@ func (h *Handler) HandleActionOrFunction(w http.ResponseWriter, r *http.Request,
 	}
 	r = actions.WithQueryOptions(r, queryOpts)
 
+	// Actions are never composable per OData v4.0 Part 1 §12.1: a $count (or
+	// any other) segment can never legally follow an action invocation.
+	if actions.CountRequested(r) && r.Method == http.MethodPost {
+		h.writeError(w, r, &invocationError{
+			status:  http.StatusBadRequest,
+			message: "Invalid request",
+			detail:  fmt.Sprintf("$count is not supported after invoking action '%s'; actions are not composable", name),
+		})
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPost:
 		actionDef, params, invErr := resolveInvocation(r, name, "Action", h.actions, actions.ResolveActionOverload, isBound, entitySet)
@@ -131,6 +143,16 @@ func (h *Handler) HandleActionOrFunction(w http.ResponseWriter, r *http.Request,
 			return
 		}
 
+		countRequested := actions.CountRequested(r)
+		if countRequested && !isCollectionReturnType(functionDef.ReturnType) {
+			h.writeError(w, r, &invocationError{
+				status:  http.StatusBadRequest,
+				message: "Invalid request",
+				detail:  fmt.Sprintf("$count is not supported after function '%s' because it does not return a collection", name),
+			})
+			return
+		}
+
 		// Check authorization before executing function
 		resource := h.buildResourceDescriptor(entitySet, name, isBound)
 		if !h.authorizeRequest(w, r, resource, auth.OperationFunction) {
@@ -150,6 +172,15 @@ func (h *Handler) HandleActionOrFunction(w http.ResponseWriter, r *http.Request,
 		result, err := functionDef.Handler(w, r, ctx, params)
 		if err != nil {
 			h.writeHandlerError(w, r, err, "Function failed")
+			return
+		}
+
+		// A $count segment appended after a composable function-call segment
+		// (e.g. Products(1)/GetRelatedProducts()/$count) resolves against the
+		// function's result collection per OData v4.0 Part 1 §12.1, returning
+		// a plain-text integer rather than the full collection payload.
+		if countRequested {
+			h.writeCollectionCount(w, r, result)
 			return
 		}
 
@@ -199,6 +230,51 @@ func (h *Handler) HandleActionOrFunction(w http.ResponseWriter, r *http.Request,
 			fmt.Sprintf("Method %s is not allowed for actions or functions", r.Method)); writeErr != nil {
 			h.logError("Error writing error response", writeErr)
 		}
+	}
+}
+
+// isCollectionReturnType reports whether t represents a function return type
+// that produces a collection (a slice or array, excluding byte slices/arrays
+// which map to Edm.Binary rather than a composable collection).
+func isCollectionReturnType(t reflect.Type) bool {
+	if t == nil {
+		return false
+	}
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.Slice, reflect.Array:
+		return t.Elem().Kind() != reflect.Uint8
+	default:
+		return false
+	}
+}
+
+// writeCollectionCount writes the size of a function's result collection as a
+// plain-text integer, per the OData v4 $count response format (§11.2.9 /
+// §11.5.3).
+func (h *Handler) writeCollectionCount(w http.ResponseWriter, r *http.Request, result interface{}) {
+	count := 0
+	if result != nil {
+		v := reflect.ValueOf(result)
+		if v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+		if v.IsValid() && (v.Kind() == reflect.Slice || v.Kind() == reflect.Array) {
+			count = v.Len()
+		}
+	}
+
+	w.Header().Set(handlers.HeaderContentType, "text/plain")
+	w.WriteHeader(http.StatusOK)
+
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	if _, err := fmt.Fprintf(w, "%d", count); err != nil {
+		h.logError("Error writing count response", err)
 	}
 }
 

--- a/internal/service/router/router.go
+++ b/internal/service/router/router.go
@@ -419,6 +419,23 @@ func (r *Router) routeRequest(w http.ResponseWriter, req *http.Request, handler 
 	if components.IsCount {
 		if hasKey && components.NavigationProperty != "" {
 			keyString := r.getKeyString(components)
+
+			// A trailing $count segment can also follow a bound function-call
+			// segment, e.g. Products(1)/GetRelatedProducts()/$count. Per OData
+			// v4.0 Part 1 §12.1, functions returning a collection are
+			// composable, so $count must resolve against the function's
+			// result collection rather than being treated as an (invalid)
+			// navigation property named "GetRelatedProducts()".
+			operationName := components.NavigationProperty
+			if idx := strings.Index(operationName, "("); idx != -1 {
+				operationName = operationName[:idx]
+			}
+			if r.isActionOrFunction(operationName) {
+				req = actions.WithCountRequested(req)
+				r.actionInvoker(w, req, operationName, keyString, true, components.EntitySet)
+				return
+			}
+
 			handler.HandleNavigationPropertyCount(w, req, keyString, components.NavigationProperty)
 		} else if !hasKey && components.NavigationProperty == "" {
 			handler.HandleCount(w, req)

--- a/test/actions_functions_test.go
+++ b/test/actions_functions_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1121,5 +1122,156 @@ func TestBoundOperationUnknownNamespaceReturns404(t *testing.T) {
 	service.ServeHTTP(actionW, actionReq)
 	if actionW.Code != http.StatusNotFound {
 		t.Errorf("action: Status = %v, want %v. Body: %s", actionW.Code, http.StatusNotFound, actionW.Body.String())
+	}
+}
+
+// TestBoundFunctionCollectionComposedWithCount verifies that a bound function
+// returning a collection is composable: appending /$count after the
+// function-call segment returns the count of the function's result
+// collection, matching the size of the "value" array returned by the direct,
+// non-composed call. Regression test for issue #758/#788: functions
+// returning a collection must support the $count composition per OData v4.0
+// Part 1 §12.1.
+func TestBoundFunctionCollectionComposedWithCount(t *testing.T) {
+	service, db := setupActionFunctionTestService(t)
+
+	err := service.RegisterFunction(odata.FunctionDefinition{
+		Name:       "GetRelatedProducts",
+		IsBound:    true,
+		EntitySet:  "ActionTestProducts",
+		Parameters: []odata.ParameterDefinition{},
+		ReturnType: reflect.TypeOf([]ActionTestProduct{}),
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) (interface{}, error) {
+			var products []ActionTestProduct
+			if err := db.Find(&products).Error; err != nil {
+				return nil, err
+			}
+			return products, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to register function: %v", err)
+	}
+
+	// Direct, non-composed call: establishes the expected collection size.
+	directReq := httptest.NewRequest(http.MethodGet, "/ActionTestProducts(1)/GetRelatedProducts()", nil)
+	directW := httptest.NewRecorder()
+	service.ServeHTTP(directW, directReq)
+
+	if directW.Code != http.StatusOK {
+		t.Fatalf("direct call status = %v, want %v. Body: %s", directW.Code, http.StatusOK, directW.Body.String())
+	}
+
+	var directResponse struct {
+		Value []map[string]interface{} `json:"value"`
+	}
+	if err := json.NewDecoder(directW.Body).Decode(&directResponse); err != nil {
+		t.Fatalf("Failed to decode direct response: %v", err)
+	}
+	expectedCount := len(directResponse.Value)
+	if expectedCount == 0 {
+		t.Fatal("expected direct call to return a non-empty collection")
+	}
+
+	// Composed call: /$count appended after the function-call segment.
+	countReq := httptest.NewRequest(http.MethodGet, "/ActionTestProducts(1)/GetRelatedProducts()/$count", nil)
+	countW := httptest.NewRecorder()
+	service.ServeHTTP(countW, countReq)
+
+	if countW.Code != http.StatusOK {
+		t.Fatalf("$count call status = %v, want %v. Body: %s", countW.Code, http.StatusOK, countW.Body.String())
+	}
+
+	if contentType := countW.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "text/plain") {
+		t.Errorf("Content-Type = %q, want prefix %q", contentType, "text/plain")
+	}
+
+	gotCount, err := strconv.Atoi(strings.TrimSpace(countW.Body.String()))
+	if err != nil {
+		t.Fatalf("Failed to parse count response %q: %v", countW.Body.String(), err)
+	}
+	if gotCount != expectedCount {
+		t.Errorf("$count = %d, want %d (size of direct call's value array)", gotCount, expectedCount)
+	}
+}
+
+// TestBoundFunctionScalarRejectsCount verifies that a bound function which
+// does not return a collection is not composable: appending /$count after
+// its call segment must be rejected rather than silently succeeding, since
+// $count only makes sense against a collection result.
+func TestBoundFunctionScalarRejectsCount(t *testing.T) {
+	service, _ := setupActionFunctionTestService(t)
+
+	err := service.RegisterFunction(odata.FunctionDefinition{
+		Name:       "GetScalarPrice",
+		IsBound:    true,
+		EntitySet:  "ActionTestProducts",
+		Parameters: []odata.ParameterDefinition{},
+		ReturnType: reflect.TypeOf(float64(0)),
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) (interface{}, error) {
+			return 42.0, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to register function: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ActionTestProducts(1)/GetScalarPrice()/$count", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+// TestBoundActionRejectsCount verifies that actions - which are never
+// composable per OData v4.0 Part 1 §12.1 regardless of return type - reject a
+// trailing /$count segment rather than being misinterpreted as a valid
+// composition.
+func TestBoundActionRejectsCount(t *testing.T) {
+	service, db := setupActionFunctionTestService(t)
+
+	err := service.RegisterAction(odata.ActionDefinition{
+		Name:      "RaisePricesForCount",
+		IsBound:   true,
+		EntitySet: "ActionTestProducts",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "amount", Type: reflect.TypeOf(float64(0)), Required: true},
+		},
+		ReturnType: nil,
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			amount := params["amount"].(float64)
+			if err := db.Model(&ActionTestProduct{}).Where("1 = 1").
+				Update("price", gorm.Expr("price + ?", amount)).Error; err != nil {
+				return err
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to register action: %v", err)
+	}
+
+	// POST is the correct invocation method for actions; appending /$count
+	// must still be rejected since actions are never composable.
+	req := httptest.NewRequest(http.MethodPost, "/ActionTestProducts(1)/RaisePricesForCount/$count", bytes.NewReader([]byte(`{"amount": 10}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code < 400 {
+		t.Errorf("Status = %v, want a 4xx rejection. Body: %s", w.Code, w.Body.String())
+	}
+
+	// GET is not a valid invocation method for actions either, with or
+	// without a composed $count segment.
+	getReq := httptest.NewRequest(http.MethodGet, "/ActionTestProducts(1)/RaisePricesForCount/$count", nil)
+	getW := httptest.NewRecorder()
+	service.ServeHTTP(getW, getReq)
+
+	if getW.Code < 400 {
+		t.Errorf("GET status = %v, want a 4xx rejection. Body: %s", getW.Code, getW.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #788: a bound function marked composable (returning a collection) rejected a further `/$count` path segment appended after the function-call segment.

```
GET /Products({id})/GetRelatedProducts()/$count
```

previously returned `404 Navigation property not found` ("'GetRelatedProducts()' is not a valid navigation property for Products"), because the router only recognized `$count` as valid when the preceding segment was a navigation property — never when it was a bound function-call segment. Per [OData v4.0 Part 1 §12.1](https://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part1-protocol/odata-v4.0-errata03-os-part1-protocol-complete.html#sec_InvokingaFunction), functions that return a collection are composable and support further segments such as `$count`.

I confirmed the bug is real by reproducing it both via a targeted Go test and by running the actual `cmd/complianceserver` and curling the endpoint directly — both showed the reported 404 before the fix, and a correct `200` with the matching count after.

## Fix

- `internal/actions/context.go`: adds `WithCountRequested`/`CountRequested`, a small request-context flag (same pattern as the existing `NavigationBindingContext` helper) used to signal that a `$count` segment was composed after a function-call segment.
- `internal/service/router/router.go`: when a trailing `$count` segment follows a segment that resolves to a registered bound action/function, the router now dispatches to the action/function invoker (with the count flag set) instead of misinterpreting the function-call segment as an invalid navigation property.
- `internal/service/operations/handler.go`: the function invoker now recognizes the count-requested flag. It rejects `$count` with `400` for functions that don't return a collection, and for actions (which are never composable per the spec, regardless of return type), and otherwise invokes the function and writes the size of its result collection as a plain-text integer per `$count` semantics.

This is scoped to `$count`; no other composed system query options are implemented, matching the issue and its compliance test.

## Test plan

- [x] Added `TestBoundFunctionCollectionComposedWithCount` — verifies the composed `/$count` call returns a count matching the size of the `value` array from the direct, non-composed call.
- [x] Added `TestBoundFunctionScalarRejectsCount` — a bound function returning a scalar rejects a trailing `/$count` with `400` rather than silently succeeding.
- [x] Added `TestBoundActionRejectsCount` — bound actions (POST and GET) still correctly reject a trailing `/$count`.
- [x] `gofmt -w .`, `golangci-lint run ./...`, `go test ./...`, `go build ./...` all clean.
- [x] Manually verified against a running `cmd/complianceserver` instance: `GET /Products({id})/GetRelatedProducts()` returns a 4-item collection, and `GET /Products({id})/GetRelatedProducts()/$count` now returns `200` with body `4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)