### PR TITLE
fix: make contains(), startswith(), endswith() ordinal (case-sensitive)

### DIFF
--- a/internal/handlers/collection_read.go
+++ b/internal/handlers/collection_read.go
@@ -1022,11 +1022,13 @@ func evaluateFilterComparison(left interface{}, op query.FilterOperator, right i
 	case query.OpLessThanOrEqual:
 		return compareMapValue(left, right) <= 0
 	case query.OpContains:
-		return strings.Contains(strings.ToLower(fmt.Sprintf("%v", left)), strings.ToLower(fmt.Sprintf("%v", right)))
+		// contains()/startswith()/endswith() use ordinal (case-sensitive) string
+		// comparison per the OData v4.0 URL Conventions spec (Part 2, Sec. 5.1.1.7).
+		return strings.Contains(fmt.Sprintf("%v", left), fmt.Sprintf("%v", right))
 	case query.OpStartsWith:
-		return strings.HasPrefix(strings.ToLower(fmt.Sprintf("%v", left)), strings.ToLower(fmt.Sprintf("%v", right)))
+		return strings.HasPrefix(fmt.Sprintf("%v", left), fmt.Sprintf("%v", right))
 	case query.OpEndsWith:
-		return strings.HasSuffix(strings.ToLower(fmt.Sprintf("%v", left)), strings.ToLower(fmt.Sprintf("%v", right)))
+		return strings.HasSuffix(fmt.Sprintf("%v", left), fmt.Sprintf("%v", right))
 	default:
 		return false
 	}

--- a/internal/query/like_escape.go
+++ b/internal/query/like_escape.go
@@ -27,6 +27,21 @@ func escapeLikePattern(value string) string {
 	return replacer.Replace(value)
 }
 
+// buildLikeComparison builds a SQL LIKE-based comparison for the OData
+// contains()/startswith()/endswith() filter functions.
+//
+// Per the OData v4.0 URL Conventions spec (Part 2, Sec. 5.1.1.7), these
+// functions use ordinal (case-sensitive) string comparison. Plain SQL LIKE
+// does not guarantee that on its own - its case sensitivity depends on the
+// database engine's default collation (e.g. MySQL/MariaDB and SQL Server
+// commonly default to case-insensitive collations, while PostgreSQL's LIKE
+// is always case-sensitive). Each dialect branch below therefore forces an
+// explicit, deterministic byte-wise comparison rather than relying on
+// whatever collation happens to be configured. SQLite is handled separately:
+// its LIKE operator is case-insensitive for ASCII by default and can only be
+// made case-sensitive via the connection-wide "case_sensitive_like" pragma,
+// which is enabled in ensureSQLiteRegexp (sqlite.go) for every connection
+// this library opens.
 func buildLikeComparison(dialect string, columnName string, value interface{}, prefixWildcard bool, suffixWildcard bool) (string, []interface{}) {
 	pattern := escapeLikePattern(fmt.Sprint(value))
 	if prefixWildcard {
@@ -37,7 +52,25 @@ func buildLikeComparison(dialect string, columnName string, value interface{}, p
 	}
 
 	escapeClause := getLikeEscapeClause(dialect)
-	return fmt.Sprintf("%s LIKE ? %s", columnName, escapeClause), []interface{}{pattern}
+
+	switch dialect {
+	case "mysql", "mariadb":
+		// MySQL/MariaDB's default collation is usually case-insensitive
+		// (e.g. *_ci). Casting the column to BINARY forces a byte-wise
+		// comparison regardless of the column's configured collation/charset.
+		return fmt.Sprintf("BINARY %s LIKE ? %s", columnName, escapeClause), []interface{}{pattern}
+
+	case "sqlserver", "mssql":
+		// SQL Server's default collation is usually case-insensitive
+		// (e.g. *_CI_AS). Applying an explicit binary collation forces an
+		// ordinal, case-sensitive comparison regardless of database/column defaults.
+		return fmt.Sprintf("%s COLLATE Latin1_General_BIN2 LIKE ? %s", columnName, escapeClause), []interface{}{pattern}
+
+	default:
+		// PostgreSQL and SQLite (with case_sensitive_like enabled) already
+		// perform byte-wise, case-sensitive LIKE matching.
+		return fmt.Sprintf("%s LIKE ? %s", columnName, escapeClause), []interface{}{pattern}
+	}
 }
 
 // buildRegexComparison builds a SQL regex comparison for the OData v4.01 matchesPattern function.

--- a/internal/query/like_escape_test.go
+++ b/internal/query/like_escape_test.go
@@ -64,7 +64,7 @@ func TestBuildFilterCondition_LikeEscapes_MySQL(t *testing.T) {
 	}
 
 	sql, args := buildFilterCondition("mysql", filterExpr, meta)
-	expectedSQL := "name LIKE ? ESCAPE '\\\\'"
+	expectedSQL := "BINARY name LIKE ? ESCAPE '\\\\'"
 	if !sqlEquivalent(expectedSQL, sql) {
 		t.Fatalf("expected SQL %q, got %q", expectedSQL, sql)
 	}
@@ -98,7 +98,58 @@ func TestBuildLikeComparison_SQLite(t *testing.T) {
 
 func TestBuildLikeComparison_MySQL(t *testing.T) {
 	sql, args := buildLikeComparison("mysql", "title", "%_", false, true)
-	expectedSQL := "title LIKE ? ESCAPE '\\\\'"
+	expectedSQL := "BINARY title LIKE ? ESCAPE '\\\\'"
+	if sql != expectedSQL {
+		t.Fatalf("expected SQL %q, got %q", expectedSQL, sql)
+	}
+
+	if len(args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(args))
+	}
+
+	expectedArg := "\\%\\_%"
+	if args[0] != expectedArg {
+		t.Fatalf("expected arg %q, got %q", expectedArg, args[0])
+	}
+}
+
+func TestBuildLikeComparison_MariaDB(t *testing.T) {
+	sql, args := buildLikeComparison("mariadb", "title", "%_", false, true)
+	expectedSQL := "BINARY title LIKE ? ESCAPE '\\'"
+	if sql != expectedSQL {
+		t.Fatalf("expected SQL %q, got %q", expectedSQL, sql)
+	}
+
+	if len(args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(args))
+	}
+
+	expectedArg := "\\%\\_%"
+	if args[0] != expectedArg {
+		t.Fatalf("expected arg %q, got %q", expectedArg, args[0])
+	}
+}
+
+func TestBuildLikeComparison_SQLServer(t *testing.T) {
+	sql, args := buildLikeComparison("sqlserver", "title", "%_", false, true)
+	expectedSQL := "title COLLATE Latin1_General_BIN2 LIKE ? ESCAPE '\\'"
+	if sql != expectedSQL {
+		t.Fatalf("expected SQL %q, got %q", expectedSQL, sql)
+	}
+
+	if len(args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(args))
+	}
+
+	expectedArg := "\\%\\_%"
+	if args[0] != expectedArg {
+		t.Fatalf("expected arg %q, got %q", expectedArg, args[0])
+	}
+}
+
+func TestBuildLikeComparison_Postgres(t *testing.T) {
+	sql, args := buildLikeComparison("postgres", "title", "%_", false, true)
+	expectedSQL := "title LIKE ? ESCAPE '\\'"
 	if sql != expectedSQL {
 		t.Fatalf("expected SQL %q, got %q", expectedSQL, sql)
 	}

--- a/sqlite.go
+++ b/sqlite.go
@@ -24,9 +24,11 @@ func init() {
 	})
 }
 
-// ensureSQLiteRegexp ensures the REGEXP function is registered on SQLite connections.
-// This function is called automatically when creating a service with SQLite,
-// so users don't need to do anything special - just use sqlite.Open() normally.
+// ensureSQLiteRegexp ensures every SQLite connection this library opens has the
+// REGEXP function available and performs ordinal (case-sensitive) string
+// comparisons for LIKE. This function is called automatically when creating a
+// service with SQLite, so users don't need to do anything special - just use
+// sqlite.Open() normally.
 //
 // Because mattn/go-sqlite3 registers user-defined functions per-connection (not
 // globally), we must make sure that every connection the OData service uses has
@@ -37,6 +39,15 @@ func init() {
 // that single connection. Single-connection SQLite pools are also the common
 // recommendation for SQLite because writes are serialized and in-memory
 // databases are not shared between connections.
+//
+// The same pinned connection is used to enable the "case_sensitive_like"
+// pragma. SQLite's LIKE operator is case-insensitive for ASCII characters by
+// default, which is at odds with the OData v4.0 URL Conventions spec (Part 2,
+// Sec. 5.1.1.7) requirement that contains()/startswith()/endswith() perform
+// ordinal (case-sensitive) string comparison. Unlike other dialects, SQLite
+// has no per-query syntax (e.g. an explicit COLLATE clause) to force LIKE to
+// be case-sensitive - the pragma is the only mechanism, hence it is set here
+// alongside the REGEXP registration rather than in the SQL-generation layer.
 func ensureSQLiteRegexp(db *gorm.DB) error {
 	if db.Name() != "sqlite" {
 		return nil
@@ -49,9 +60,11 @@ func ensureSQLiteRegexp(db *gorm.DB) error {
 	}
 
 	// Pin the pool to a single connection so the REGEXP function we register
-	// below is available for every query. Without this, new connections
-	// created by database/sql would not have the function and any
-	// matchesPattern() filter would fail with "no such function: REGEXP".
+	// below, and the case_sensitive_like pragma, are available/in effect for
+	// every query. Without this, new connections created by database/sql
+	// would not have the function and any matchesPattern() filter would fail
+	// with "no such function: REGEXP", and LIKE-based filters could silently
+	// fall back to case-insensitive matching.
 	sqlDB.SetMaxOpenConns(1)
 	sqlDB.SetMaxIdleConns(1)
 	sqlDB.SetConnMaxIdleTime(0)
@@ -66,6 +79,14 @@ func ensureSQLiteRegexp(db *gorm.DB) error {
 		return err
 	}
 	defer conn.Close() //nolint:errcheck
+
+	// Force ordinal (case-sensitive) matching for LIKE, which backs the
+	// contains()/startswith()/endswith() filter functions. See the doc
+	// comment above for why this must be a connection-level pragma rather
+	// than SQL generated per-query.
+	if _, err := conn.ExecContext(ctx, "PRAGMA case_sensitive_like = ON"); err != nil {
+		return err
+	}
 
 	return conn.Raw(func(driverConn interface{}) error {
 		sqliteConn, ok := driverConn.(*sqlite3.SQLiteConn)

--- a/test/string_filter_case_sensitivity_test.go
+++ b/test/string_filter_case_sensitivity_test.go
@@ -1,0 +1,149 @@
+package odata_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// CaseSensitivityProduct is a minimal entity used to verify that the
+// contains()/startswith()/endswith() OData filter functions perform ordinal
+// (case-sensitive) string comparison, per the OData v4.0 URL Conventions spec
+// (Part 2, Sec. 5.1.1.7). Regression test for
+// https://github.com/NLstn/go-odata/issues/790.
+type CaseSensitivityProduct struct {
+	ID   uint   `json:"ID" gorm:"primaryKey" odata:"key"`
+	Name string `json:"Name" gorm:"not null"`
+}
+
+func setupCaseSensitivityTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&CaseSensitivityProduct{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	products := []CaseSensitivityProduct{
+		{ID: 1, Name: "Laptop"},
+		{ID: 2, Name: "Premium Laptop Pro"},
+	}
+	if err := db.Create(&products).Error; err != nil {
+		t.Fatalf("Failed to seed products: %v", err)
+	}
+
+	return db
+}
+
+func newCaseSensitivityService(t *testing.T, db *gorm.DB) *odata.Service {
+	t.Helper()
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	if err := service.RegisterEntity(&CaseSensitivityProduct{}); err != nil {
+		t.Fatalf("Failed to register CaseSensitivityProduct entity: %v", err)
+	}
+	return service
+}
+
+func queryCaseSensitivityProducts(t *testing.T, service *odata.Service, filter string) []interface{} {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", "/CaseSensitivityProducts?$filter="+url.QueryEscape(filter), nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	value, ok := response["value"].([]interface{})
+	if !ok {
+		t.Fatalf("Response does not contain value array: %s", w.Body.String())
+	}
+
+	return value
+}
+
+// TestFilterContainsIsCaseSensitive verifies that contains() only matches
+// substrings with the exact case supplied by the client. A lowercase
+// 'laptop' must not match the differently-cased "Laptop" or
+// "Premium Laptop Pro" substrings.
+func TestFilterContainsIsCaseSensitive(t *testing.T) {
+	db := setupCaseSensitivityTestDB(t)
+	service := newCaseSensitivityService(t, db)
+
+	t.Run("differently-cased substring does not match", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "contains(Name,'laptop')")
+		if len(results) != 0 {
+			t.Errorf("Expected 0 results for contains(Name,'laptop'), got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("exact-case substring still matches", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "contains(Name,'Laptop')")
+		if len(results) != 2 {
+			t.Errorf("Expected 2 results for contains(Name,'Laptop'), got %d: %v", len(results), results)
+		}
+	})
+}
+
+// TestFilterStartsWithIsCaseSensitive verifies that startswith() performs
+// ordinal (case-sensitive) matching.
+func TestFilterStartsWithIsCaseSensitive(t *testing.T) {
+	db := setupCaseSensitivityTestDB(t)
+	service := newCaseSensitivityService(t, db)
+
+	t.Run("differently-cased prefix does not match", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "startswith(Name,'laptop')")
+		if len(results) != 0 {
+			t.Errorf("Expected 0 results for startswith(Name,'laptop'), got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("exact-case prefix still matches", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "startswith(Name,'Laptop')")
+		if len(results) != 1 {
+			t.Errorf("Expected 1 result for startswith(Name,'Laptop'), got %d: %v", len(results), results)
+		}
+	})
+}
+
+// TestFilterEndsWithIsCaseSensitive verifies that endswith() performs
+// ordinal (case-sensitive) matching.
+func TestFilterEndsWithIsCaseSensitive(t *testing.T) {
+	db := setupCaseSensitivityTestDB(t)
+	service := newCaseSensitivityService(t, db)
+
+	t.Run("differently-cased suffix does not match", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "endswith(Name,'pro')")
+		if len(results) != 0 {
+			t.Errorf("Expected 0 results for endswith(Name,'pro'), got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("exact-case suffix still matches", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "endswith(Name,'Pro')")
+		if len(results) != 1 {
+			t.Errorf("Expected 1 result for endswith(Name,'Pro'), got %d: %v", len(results), results)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #790.

`contains()`, `startswith()`, and `endswith()` were performing case-insensitive matching because the generated SQL `LIKE` comparison relied on each database's default collation, which is case-insensitive on SQLite (ASCII `LIKE`), MySQL/MariaDB (`*_ci` collations), and SQL Server (`*_CI_AS` collations) by default. Per the [OData v4.0 URL Conventions spec (Part 2, Sec. 5.1.1.7)](https://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#sec_BuiltinFilterOperations), these functions must use ordinal (case-sensitive) string comparison.

Verified against `cmd/complianceserver -db sqlite`: `$filter=contains(Name,'laptop')` against seed data `"Laptop"` / `"Premium Laptop Pro"` returned 2 matches before the fix, 0 after. Confirmed `startswith()`/`endswith()` were independently affected the same way (not just theoretically, via live requests).

## Changes

- `internal/query/like_escape.go`: `buildLikeComparison` now forces a deterministic, byte-wise comparison per dialect:
  - MySQL/MariaDB: `BINARY <column> LIKE ...`
  - SQL Server: `<column> COLLATE Latin1_General_BIN2 LIKE ...`
  - PostgreSQL: unchanged (`LIKE` is already case-sensitive by default; `ILIKE` is the case-insensitive variant)
- `sqlite.go`: `ensureSQLiteRegexp` now also enables the connection-level `PRAGMA case_sensitive_like = ON`, since SQLite's `LIKE` is case-insensitive for ASCII by default and has no per-query syntax to override this (unlike the other dialects).
- `internal/handlers/collection_read.go`: fixed the Go-side fallback filter evaluator (`evaluateFilterComparison`, used by `$apply`'s `filter()` transformation over post-groupby in-memory rows), which independently lower-cased both operands before comparing.

## Test plan

- [x] Added `TestFilterContainsIsCaseSensitive`, `TestFilterStartsWithIsCaseSensitive`, `TestFilterEndsWithIsCaseSensitive` in `test/string_filter_case_sensitivity_test.go`, each with a differently-cased negative case and an exact-case positive case against the SQLite backend.
- [x] Updated/added dialect-specific unit tests in `internal/query/like_escape_test.go` for SQLite, MySQL, MariaDB, SQL Server, and PostgreSQL.
- [x] `gofmt -w .`, `golangci-lint run ./...` (0 issues), `go test ./...` (all pass), `go build ./...` all clean.
- [x] Manually reproduced the issue's exact scenario against `cmd/complianceserver -db sqlite` before and after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)