### PR TITLE
fix: return single-entity response for keyed collection nav property

### DIFF
--- a/http_runtime_test.go
+++ b/http_runtime_test.go
@@ -112,6 +112,10 @@ func (h *mockEntityHandler) IsNavigationProperty(_ string) bool {
 	return false
 }
 
+func (h *mockEntityHandler) IsCollectionNavigationProperty(_ string) bool {
+	return false
+}
+
 func (h *mockEntityHandler) IsStreamProperty(_ string) bool {
 	return false
 }

--- a/internal/handlers/navigation_properties.go
+++ b/internal/handlers/navigation_properties.go
@@ -616,12 +616,16 @@ func (h *EntityHandler) handleNavigationCollectionItem(w http.ResponseWriter, r 
 		if err := response.WriteEntityReference(w, r, entityPath); err != nil {
 			h.logger.Error("Error writing entity reference", "error", err)
 		}
-	} else {
-		// Write the full entity
-		navigationPath := fmt.Sprintf("%s(%s)/%s(%s)", h.metadata.EntitySetName, entityKey, navProp.JsonName, targetKey)
-		if err := response.WriteODataCollection(w, r, navigationPath, []interface{}{targetEntity}, nil, nil); err != nil {
-			h.logger.Error("Error writing navigation property entity", "error", err)
-		}
+		return
+	}
+
+	// A key predicate applied to a collection-valued navigation property addresses a single entity
+	// within that collection (OData v4.0 Part 2 §4.11), so the response must be a single-entity
+	// object rather than a collection wrapped in "value": [...].
+	navigationPath := fmt.Sprintf("%s(%s)/%s(%s)", h.metadata.EntitySetName, entityKey, navProp.JsonName, targetKey)
+	targetAdapter := newMetadataAdapter(targetMetadata, h.namespaceOrDefault())
+	if err := response.WriteODataEntityFromNavigationPath(w, r, navigationPath, targetMetadata.EntitySetName, targetEntity, targetAdapter, targetMetadata); err != nil {
+		h.logger.Error("Error writing navigation property entity", "error", err)
 	}
 }
 

--- a/internal/handlers/property_helpers.go
+++ b/internal/handlers/property_helpers.go
@@ -26,6 +26,15 @@ func (h *EntityHandler) IsNavigationProperty(propertyName string) bool {
 	return h.findNavigationProperty(navPropName) != nil
 }
 
+// IsCollectionNavigationProperty checks if a property name is a collection-valued (to-many)
+// navigation property. Used by the router to distinguish a raw key-as-segments key segment from a
+// chained navigation property name when a segment immediately follows a navigation property.
+func (h *EntityHandler) IsCollectionNavigationProperty(propertyName string) bool {
+	navPropName, _ := h.parseNavigationPropertyWithKey(propertyName)
+	navProp := h.findNavigationProperty(navPropName)
+	return navProp != nil && navProp.NavigationIsArray
+}
+
 // IsStructuralProperty checks if a property name is a structural property
 func (h *EntityHandler) IsStructuralProperty(propertyName string) bool {
 	return h.findStructuralProperty(propertyName) != nil

--- a/internal/response/navigation_links.go
+++ b/internal/response/navigation_links.go
@@ -151,12 +151,19 @@ func processMapEntity(entity reflect.Value, metadata EntityMetadataProvider, exp
 }
 
 func processStructEntityOrdered(entity reflect.Value, metadata EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, baseURL, entitySetName string, metadataLevel string, fullMetadata *internalMetadata.EntityMetadata, annotationFilter *string) *OrderedMap {
-	fieldInfos := getFieldInfos(entity.Type())
-
 	// Pre-calculate capacity: fields + potential metadata annotations (etag, id, type)
 	capacity := entity.NumField() + 3
 	// Use pooled OrderedMap for better performance
 	entityMap := AcquireOrderedMapWithCapacity(capacity)
+	processStructEntityOrderedInto(entityMap, entity, metadata, expandOptions, selectedNavProps, baseURL, entitySetName, metadataLevel, fullMetadata, annotationFilter)
+	return entityMap
+}
+
+// processStructEntityOrderedInto populates entityMap with the ordered representation of entity.
+// entityMap must already be acquired by the caller, and may be pre-seeded with entries (such as
+// "@odata.context") that need to appear before the metadata/property entries added here.
+func processStructEntityOrderedInto(entityMap *OrderedMap, entity reflect.Value, metadata EntityMetadataProvider, expandOptions []query.ExpandOption, selectedNavProps []string, baseURL, entitySetName string, metadataLevel string, fullMetadata *internalMetadata.EntityMetadata, annotationFilter *string) {
+	fieldInfos := getFieldInfos(entity.Type())
 
 	// Pre-compute key segment and entity ID if needed (reuse across annotations)
 	var keySegment string
@@ -298,8 +305,66 @@ func processStructEntityOrdered(entity reflect.Value, metadata EntityMetadataPro
 			}
 		}
 	}
+}
 
-	return entityMap
+// WriteODataEntityFromNavigationPath writes a single-entity JSON response for an entity reached via a
+// navigation path — for example, addressing a single member of a collection-valued navigation
+// property by key (e.g. Categories(1)/Products(2)). Per OData v4.0 Part 2 §4.11, applying a key
+// predicate to a collection-valued navigation property addresses a single entity within that
+// collection, so the response must be a single-entity object (not a collection wrapped in
+// "value": [...]), with @odata.context ending in "/$entity".
+//
+// contextPath is the URL path segment(s) preceding "/$entity" in the resulting @odata.context (e.g.
+// "Categories(1)/Products(2)"). entitySetName, md, and fullMetadata describe the entity actually being
+// written, which may belong to a different entity set than the one the request path started from.
+func WriteODataEntityFromNavigationPath(w http.ResponseWriter, r *http.Request, contextPath string, entitySetName string, entity interface{}, md EntityMetadataProvider, fullMetadata *internalMetadata.EntityMetadata) error {
+	if !IsAcceptableFormat(r) {
+		return WriteError(w, r, http.StatusNotAcceptable, "Not Acceptable",
+			"The requested format is not supported. Only application/json and application/atom+xml are supported for data responses.")
+	}
+
+	metadataLevel := GetODataMetadataLevel(r)
+	baseURL := buildBaseURL(r)
+
+	entityValue := reflect.ValueOf(entity)
+	for entityValue.Kind() == reflect.Ptr {
+		entityValue = entityValue.Elem()
+	}
+
+	var annotationFilter *string
+	if pref := preference.ParsePrefer(r); pref.IncludeAnnotations != nil {
+		annotationFilter = pref.IncludeAnnotations
+	}
+
+	capacity := entityValue.NumField() + 4
+	entityMap := AcquireOrderedMapWithCapacity(capacity)
+	if metadataLevel != "none" {
+		entityMap.Set("@odata.context", baseURL+"/$metadata#"+contextPath+"/$entity")
+	}
+	processStructEntityOrderedInto(entityMap, entityValue, md, nil, nil, baseURL, entitySetName, metadataLevel, fullMetadata, annotationFilter)
+
+	w.Header().Set("Content-Type", fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
+
+	if r.Method == http.MethodHead {
+		jsonBytes, err := entityMap.MarshalJSON()
+		entityMap.Release()
+		if err != nil {
+			return err
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(jsonBytes)))
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+
+	responseBytes, err := entityMap.MarshalJSON()
+	entityMap.Release()
+	if err != nil {
+		return err
+	}
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(responseBytes)))
+	w.WriteHeader(http.StatusOK)
+	_, writeErr := w.Write(responseBytes)
+	return writeErr
 }
 
 func isPropertyExpanded(prop PropertyMetadata, expandOptions []query.ExpandOption) bool {

--- a/internal/service/router/router.go
+++ b/internal/service/router/router.go
@@ -31,6 +31,7 @@ type EntityHandler interface {
 	HandleComplexTypeProperty(http.ResponseWriter, *http.Request, string, []string, bool)
 	HandleMediaEntityValue(http.ResponseWriter, *http.Request, string)
 	IsNavigationProperty(string) bool
+	IsCollectionNavigationProperty(string) bool
 	IsStreamProperty(string) bool
 	IsStructuralProperty(string) bool
 	IsComplexTypeProperty(string) bool
@@ -460,6 +461,36 @@ func (r *Router) handlePropertyRequest(w http.ResponseWriter, req *http.Request,
 	if len(propertySegments) > 1 {
 		firstSegment := propertySegments[0]
 		lastSegment := propertySegments[len(propertySegments)-1]
+
+		// OData 4.01 key-as-segments: a raw key segment immediately following a collection-valued
+		// navigation property addresses a single entity within that collection (e.g.
+		// Categories/1/Products/2 addresses Products(2) within Categories(1)'s Products collection,
+		// per OData v4.0 Part 2 §4.11). This must resolve the same way as the equivalent parenthetical
+		// form Categories(1)/Products(2), not as chained navigation into another navigation property.
+		if len(propertySegments) == 2 && handler.IsNavigationProperty(firstSegment) && handler.IsCollectionNavigationProperty(firstSegment) {
+			if ver := version.GetVersion(req.Context()); ver.Supports("key-as-segments") {
+				candidateOperationName := lastSegment
+				if idx := strings.Index(candidateOperationName, "("); idx != -1 {
+					candidateOperationName = candidateOperationName[:idx]
+				}
+				if !handler.IsNavigationProperty(lastSegment) &&
+					!handler.IsStructuralProperty(lastSegment) &&
+					!handler.IsStreamProperty(lastSegment) &&
+					!handler.IsComplexTypeProperty(lastSegment) &&
+					!r.isActionOrFunction(candidateOperationName) {
+					if components.IsValue {
+						if writeErr := response.WriteError(w, req, http.StatusBadRequest, "Invalid request",
+							"$value is not supported on navigation properties"); writeErr != nil {
+							r.logger.Error("Error writing error response", "error", writeErr)
+						}
+						return
+					}
+					navPropWithKey := firstSegment + "(" + lastSegment + ")"
+					handler.HandleNavigationProperty(w, req, keyString, navPropWithKey, components.IsRef)
+					return
+				}
+			}
+		}
 
 		// Extract operation name from last segment (remove parameters)
 		lastOperationName := lastSegment

--- a/internal/service/router/router_test.go
+++ b/internal/service/router/router_test.go
@@ -31,23 +31,25 @@ func newTestAsyncManager(t *testing.T) *async.Manager {
 }
 
 type stubEntityHandler struct {
-	isSingleton         bool
-	navigationProps     map[string]bool
-	navigationTargets   map[string]string
-	streamProps         map[string]bool
-	structuralProps     map[string]bool
-	complexProps        map[string]bool
-	calls               []string
-	fetchNavEntityKeyFn func(entityKey, navPropName string) (string, error)
+	isSingleton               bool
+	navigationProps           map[string]bool
+	collectionNavigationProps map[string]bool
+	navigationTargets         map[string]string
+	streamProps               map[string]bool
+	structuralProps           map[string]bool
+	complexProps              map[string]bool
+	calls                     []string
+	fetchNavEntityKeyFn       func(entityKey, navPropName string) (string, error)
 }
 
 func newStubEntityHandler() *stubEntityHandler {
 	return &stubEntityHandler{
-		navigationProps:   make(map[string]bool),
-		navigationTargets: make(map[string]string),
-		streamProps:       make(map[string]bool),
-		structuralProps:   make(map[string]bool),
-		complexProps:      make(map[string]bool),
+		navigationProps:           make(map[string]bool),
+		collectionNavigationProps: make(map[string]bool),
+		navigationTargets:         make(map[string]string),
+		streamProps:               make(map[string]bool),
+		structuralProps:           make(map[string]bool),
+		complexProps:              make(map[string]bool),
 	}
 }
 
@@ -107,6 +109,10 @@ func (h *stubEntityHandler) HandleMediaEntityValue(_ http.ResponseWriter, _ *htt
 
 func (h *stubEntityHandler) IsNavigationProperty(name string) bool {
 	return h.navigationProps[name]
+}
+
+func (h *stubEntityHandler) IsCollectionNavigationProperty(name string) bool {
+	return h.collectionNavigationProps[name]
 }
 
 func (h *stubEntityHandler) IsStreamProperty(name string) bool {

--- a/test/navigation_collection_key_predicate_test.go
+++ b/test/navigation_collection_key_predicate_test.go
@@ -1,0 +1,190 @@
+package odata_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Entities used to reproduce issue #786: addressing a single entity through a
+// collection-valued navigation property with a key predicate, e.g.
+// Categories(1)/Products(1).
+type NavKeyPredicateCategory struct {
+	ID       uint                     `json:"ID" gorm:"primarykey" odata:"key"`
+	Name     string                   `json:"Name"`
+	Products []NavKeyPredicateProduct `json:"Products" gorm:"foreignKey:CategoryID"`
+}
+
+type NavKeyPredicateProduct struct {
+	ID         uint   `json:"ID" gorm:"primarykey" odata:"key"`
+	Name       string `json:"Name"`
+	CategoryID *uint  `json:"CategoryID"`
+}
+
+func setupNavKeyPredicateService(t *testing.T) (*odata.Service, *gorm.DB) {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	if err := db.AutoMigrate(&NavKeyPredicateCategory{}, &NavKeyPredicateProduct{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	if err := service.RegisterEntity(&NavKeyPredicateCategory{}); err != nil {
+		t.Fatalf("Failed to register NavKeyPredicateCategory: %v", err)
+	}
+	if err := service.RegisterEntity(&NavKeyPredicateProduct{}); err != nil {
+		t.Fatalf("Failed to register NavKeyPredicateProduct: %v", err)
+	}
+
+	categoryID := uint(1)
+	db.Create(&NavKeyPredicateCategory{ID: categoryID, Name: "Electronics"})
+	db.Create(&NavKeyPredicateProduct{ID: 1, Name: "Mouse", CategoryID: &categoryID})
+	db.Create(&NavKeyPredicateProduct{ID: 2, Name: "Keyboard", CategoryID: &categoryID})
+	// A product that does not belong to the category above, to exercise the
+	// "not related to parent" 404 case.
+	db.Create(&NavKeyPredicateProduct{ID: 3, Name: "Orphan"})
+
+	return service, db
+}
+
+// assertSingleNavEntity checks that body represents a single-entity JSON object (not a
+// collection wrapped in "value": [...]) whose @odata.context ends in "/$entity", per OData
+// v4.0 Part 2 §4.11.
+func assertSingleNavEntity(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to parse response: %v (body: %s)", err, body)
+	}
+
+	if _, ok := result["value"]; ok {
+		t.Fatalf("expected a single-entity object, got a collection wrapped in \"value\": %s", body)
+	}
+
+	contextURL, _ := result["@odata.context"].(string)
+	if !strings.HasSuffix(contextURL, "/$entity") {
+		t.Errorf("expected @odata.context to end with '/$entity', got %q", contextURL)
+	}
+
+	return result
+}
+
+// TestNavigationCollectionKeyPredicate_ParentheticalForm covers the primary regression from
+// issue #786: GET /Categories(id)/Products(id) must return the Product entity directly, not a
+// collection response.
+func TestNavigationCollectionKeyPredicate_ParentheticalForm(t *testing.T) {
+	service, _ := setupNavKeyPredicateService(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/NavKeyPredicateCategories(1)/Products(1)", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	entity := assertSingleNavEntity(t, w.Body.Bytes())
+	if entity["ID"] != float64(1) {
+		t.Errorf("expected ID 1, got %v", entity["ID"])
+	}
+	if entity["Name"] != "Mouse" {
+		t.Errorf("expected Name 'Mouse', got %v", entity["Name"])
+	}
+}
+
+// TestNavigationCollectionKeyPredicate_KeyAsSegments covers the second regression from issue
+// #786: under OData 4.01 key-as-segments negotiation, GET /Categories/id/Products/id must
+// resolve the same way as the parenthetical form instead of crashing with a 500.
+func TestNavigationCollectionKeyPredicate_KeyAsSegments(t *testing.T) {
+	service, _ := setupNavKeyPredicateService(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/NavKeyPredicateCategories/1/Products/1", nil)
+	req.Header.Set("OData-MaxVersion", "4.01")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	entity := assertSingleNavEntity(t, w.Body.Bytes())
+	if entity["ID"] != float64(1) {
+		t.Errorf("expected ID 1, got %v", entity["ID"])
+	}
+	if entity["Name"] != "Mouse" {
+		t.Errorf("expected Name 'Mouse', got %v", entity["Name"])
+	}
+}
+
+// TestNavigationCollectionKeyPredicate_KeyAsSegmentsNotActiveUnder40 verifies that the
+// key-as-segments form of collection-nav-plus-key addressing is only active when the client
+// negotiates OData 4.01, per this repo's convention of gating 4.01-only behavior.
+func TestNavigationCollectionKeyPredicate_KeyAsSegmentsNotActiveUnder40(t *testing.T) {
+	service, _ := setupNavKeyPredicateService(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/NavKeyPredicateCategories/1/Products/1", nil)
+	req.Header.Set("OData-MaxVersion", "4.0")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	// Under OData 4.0, "1" right after "Categories" is not resolved as a key-as-segments key,
+	// so this path is invalid. It must not be interpreted as collection-nav-plus-key addressing,
+	// and it must never crash with a 500.
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected key-as-segments form to be inactive under OData 4.0, got 200: %s", w.Body.String())
+	}
+	if w.Code == http.StatusInternalServerError {
+		t.Fatalf("expected a client error, got 500 (crash): %s", w.Body.String())
+	}
+}
+
+// TestNavigationCollectionKeyPredicate_NotFound verifies that a key that does not belong to the
+// parent's collection still 404s, for both URL forms.
+func TestNavigationCollectionKeyPredicate_NotFound(t *testing.T) {
+	service, _ := setupNavKeyPredicateService(t)
+
+	t.Run("parenthetical", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/NavKeyPredicateCategories(1)/Products(999)", nil)
+		w := httptest.NewRecorder()
+		service.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 for nonexistent key, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not related to parent", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/NavKeyPredicateCategories(1)/Products(3)", nil)
+		w := httptest.NewRecorder()
+		service.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 for a key not related to the parent, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("key-as-segments", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/NavKeyPredicateCategories/1/Products/999", nil)
+		req.Header.Set("OData-MaxVersion", "4.01")
+		w := httptest.NewRecorder()
+		service.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 for nonexistent key under key-as-segments, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/test/navigation_composite_key_test.go
+++ b/test/navigation_composite_key_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	odata "github.com/nlstn/go-odata"
@@ -78,24 +79,24 @@ func TestNavigationCompositeKey_SingleItem(t *testing.T) {
 		return
 	}
 
-	var response map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+	var desc map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &desc); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
 
-	// Should have a value array with exactly one item
-	values, ok := response["value"].([]interface{})
-	if !ok {
-		t.Fatal("Expected value array in response")
+	// A key predicate on a collection-valued navigation property addresses a single entity
+	// (OData v4.0 Part 2 §4.11): the response must be a single entity object, not a
+	// collection wrapped in "value": [...].
+	if _, ok := desc["value"]; ok {
+		t.Fatal("Expected a single-entity object, not a collection wrapped in \"value\"")
 	}
 
-	if len(values) != 1 {
-		t.Errorf("Expected 1 description, got %d", len(values))
-		return
+	contextURL, _ := desc["@odata.context"].(string)
+	if !strings.HasSuffix(contextURL, "/$entity") {
+		t.Errorf("Expected @odata.context to end with '/$entity', got %q", contextURL)
 	}
 
 	// Verify the correct description was returned
-	desc := values[0].(map[string]interface{})
 	if desc["ProductID"] != float64(1) {
 		t.Errorf("Expected ProductID 1, got %v", desc["ProductID"])
 	}
@@ -122,22 +123,15 @@ func TestNavigationCompositeKey_DifferentLanguage(t *testing.T) {
 		return
 	}
 
-	var response map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+	var desc map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &desc); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
 
-	values, ok := response["value"].([]interface{})
-	if !ok {
-		t.Fatal("Expected value array in response")
+	if _, ok := desc["value"]; ok {
+		t.Fatal("Expected a single-entity object, not a collection wrapped in \"value\"")
 	}
 
-	if len(values) != 1 {
-		t.Errorf("Expected 1 description, got %d", len(values))
-		return
-	}
-
-	desc := values[0].(map[string]interface{})
 	if desc["LanguageKey"] != "FR" {
 		t.Errorf("Expected LanguageKey FR, got %v", desc["LanguageKey"])
 	}


### PR DESCRIPTION
## Summary

Fixes #786

- `GET /Categories(id)/Products(id)` (a key predicate on a collection-valued navigation property) was returning a collection-shaped response (`{"value": [...]}`with `@odata.context` missing the `/$entity` suffix) instead of the single `Product` entity, because `handleNavigationCollectionItem` wrote the matched item through `WriteODataCollection`. Per OData v4.0 Part 2 §4.11, a key predicate applied to a collection-valued navigation property addresses a single entity, so the response must match the shape of a direct entity read.
- The equivalent OData 4.01 key-as-segments form, `GET /Categories/id/Products/id` with `OData-MaxVersion: 4.01`, crashed with a 500 "Navigation path error" because the router's chained-navigation resolver treated the trailing raw key segment as another navigation property name to chain into, and rejected it since `Products` is collection-valued.

## Fix

- Added `response.WriteODataEntityFromNavigationPath`, which reuses the existing metadata-driven entity-field builder (previously private to top-level collection responses) to render a proper single-entity JSON object — correct `@odata.context` (`.../Products(id)/$entity`), `@odata.etag`, `@odata.id`, and `@odata.type` — for an entity reached via a navigation path, regardless of which entity handler is doing the writing.
- Added `EntityHandler.IsCollectionNavigationProperty` so the router can detect a raw key-as-segments key segment following a collection-valued navigation property and resolve it via the same `HandleNavigationProperty` path as the parenthetical form, instead of misinterpreting it as chained navigation.
- Non-existent keys, and keys that exist but don't belong to the parent's collection, still correctly 404 in both URL forms.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] Manually reproduced both bugs against `cmd/complianceserver` before the fix, and confirmed correct single-entity output (matching `/Products(id)` field-for-field, including `@odata.etag`/nulls/media links) and no 500 after the fix
- [x] Added `TestNavigationCollectionKeyPredicate_*` in `test/navigation_collection_key_predicate_test.go` covering the parenthetical form, the 4.01 key-as-segments form, that key-as-segments stays inactive under 4.0 negotiation (no 500), and 404s for out-of-collection/nonexistent keys
- [x] Updated `TestNavigationCompositeKey_SingleItem`/`_DifferentLanguage`, which previously asserted the buggy collection-wrapped shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)