### PR TITLE
fix: encode Edm.Binary properties using base64url per JSON Format spec

### DIFF
--- a/internal/handlers/binary_request.go
+++ b/internal/handlers/binary_request.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"fmt"
+	"reflect"
+)
+
+// binaryBase64Decoders lists the base64 alphabets accepted when decoding an
+// Edm.Binary property value supplied by a client. Per the OData JSON Format
+// spec (v4.0 §7.1; RFC 4648 §5), binary values must be encoded using the
+// URL and filename safe alphabet without padding (base64.RawURLEncoding).
+// The remaining alphabets are accepted leniently for interoperability with
+// clients that still send standard base64 (with or without padding).
+var binaryBase64Decoders = [...]*base64.Encoding{
+	base64.RawURLEncoding,
+	base64.URLEncoding,
+	base64.RawStdEncoding,
+	base64.StdEncoding,
+}
+
+// decodeBase64Lenient decodes a base64-encoded string, accepting both the
+// URL-safe alphabet required by the OData JSON Format spec and the standard
+// alphabet (with or without padding).
+func decodeBase64Lenient(s string) ([]byte, error) {
+	if s == "" {
+		return []byte{}, nil
+	}
+	var lastErr error
+	for _, enc := range binaryBase64Decoders {
+		if b, err := enc.DecodeString(s); err == nil {
+			return b, nil
+		} else {
+			lastErr = err
+		}
+	}
+	return nil, fmt.Errorf("illegal base64 data: %w", lastErr)
+}
+
+// isBinaryFieldType reports whether t (after unwrapping a pointer) is the Go
+// representation of an Edm.Binary property, i.e. []byte.
+func isBinaryFieldType(t reflect.Type) bool {
+	if t == nil {
+		return false
+	}
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8
+}
+
+// decodeBinaryPropertiesInPlace scans data for Edm.Binary properties (Go
+// []byte fields) and, where the JSON-decoded value is a string, replaces it
+// in-place with the decoded []byte value.
+//
+// Go's encoding/json only unmarshals []byte fields using the standard base64
+// alphabet with padding, so without this step base64url-encoded values sent
+// per the OData JSON Format spec (§7.1) would be rejected. Normalizing to raw
+// []byte here lets every downstream consumer (re-marshal into an entity
+// struct for POST/PUT, or GORM's Updates(map) for PATCH) work the same way
+// regardless of which base64 alphabet the client used.
+func (h *EntityHandler) decodeBinaryPropertiesInPlace(data map[string]interface{}) error {
+	for _, prop := range h.metadata.Properties {
+		if prop.IsNavigationProp || prop.IsStream || !isBinaryFieldType(prop.Type) {
+			continue
+		}
+
+		for _, key := range [...]string{prop.JsonName, prop.Name} {
+			raw, exists := data[key]
+			if !exists {
+				continue
+			}
+			s, ok := raw.(string)
+			if !ok {
+				// Not a string (nil, or already []byte) - leave as-is for
+				// existing validation/type-checking to handle.
+				continue
+			}
+			decoded, err := decodeBase64Lenient(s)
+			if err != nil {
+				return fmt.Errorf("property '%s': invalid base64-encoded binary value: %w", prop.JsonName, err)
+			}
+			data[key] = decoded
+		}
+	}
+	return nil
+}

--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -72,6 +72,11 @@ func (h *EntityHandler) handlePostEntity(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if err := h.decodeBinaryPropertiesInPlace(requestData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error())
+		return
+	}
+
 	if err := h.validatePropertiesExistForCreate(requestData, w, r); err != nil {
 		return
 	}
@@ -569,6 +574,11 @@ func (h *EntityHandler) handlePostEntityOverwrite(w http.ResponseWriter, r *http
 	if err := json.NewDecoder(r.Body).Decode(&requestData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
 			fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error()))
+		return
+	}
+
+	if err := h.decodeBinaryPropertiesInPlace(requestData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error())
 		return
 	}
 

--- a/internal/handlers/complex_properties.go
+++ b/internal/handlers/complex_properties.go
@@ -230,11 +230,11 @@ func (h *EntityHandler) writeComplexValueResponse(w http.ResponseWriter, r *http
 		for iter.Next() {
 			key := iter.Key()
 			if key.Kind() == reflect.String {
-				responseMap[key.String()] = iter.Value().Interface()
+				responseMap[key.String()] = response.EncodeEdmBinary(iter.Value().Interface())
 			}
 		}
 	default:
-		responseMap["value"] = value.Interface()
+		responseMap["value"] = response.EncodeEdmBinary(value.Interface())
 	}
 
 	if err := json.NewEncoder(w).Encode(responseMap); err != nil {
@@ -259,10 +259,10 @@ func (h *EntityHandler) writePrimitiveComplexPropertyResponse(w http.ResponseWri
 		if value.IsNil() {
 			valueInterface = nil
 		} else {
-			valueInterface = value.Elem().Interface()
+			valueInterface = response.EncodeEdmBinary(value.Elem().Interface())
 		}
 	} else {
-		valueInterface = value.Interface()
+		valueInterface = response.EncodeEdmBinary(value.Interface())
 	}
 
 	responseBody := map[string]interface{}{
@@ -451,7 +451,7 @@ func structValueToMap(value reflect.Value) map[string]interface{} {
 			jsonName = field.Name
 		}
 
-		result[jsonName] = value.Field(i).Interface()
+		result[jsonName] = response.EncodeEdmBinary(value.Field(i).Interface())
 	}
 	return result
 }

--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -197,6 +197,13 @@ func (h *EntityHandler) handlePatchEntity(w http.ResponseWriter, r *http.Request
 			return newTransactionHandledError(err)
 		}
 
+		if err := h.decodeBinaryPropertiesInPlace(updateData); err != nil {
+			if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error()); writeErr != nil {
+				h.logger.Error("Error writing error response", "error", writeErr)
+			}
+			return newTransactionHandledError(err)
+		}
+
 		if err := h.validateKeyPropertiesNotUpdated(updateData, w, r); err != nil {
 			return newTransactionHandledError(err)
 		}
@@ -407,9 +414,35 @@ func (h *EntityHandler) handlePutEntity(w http.ResponseWriter, r *http.Request, 
 		}
 
 		// Entity exists - perform full replacement
-		// Parse the replacement entity from the request body
+		// Parse the replacement entity from the request body via an intermediate
+		// map so that Edm.Binary properties can be normalized (see
+		// decodeBinaryPropertiesInPlace) before being unmarshaled into the
+		// strongly-typed entity struct.
+		var replacementData map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&replacementData); err != nil {
+			if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
+				fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error())); writeErr != nil {
+				h.logger.Error("Error writing error response", "error", writeErr)
+			}
+			return newTransactionHandledError(err)
+		}
+
+		if err := h.decodeBinaryPropertiesInPlace(replacementData); err != nil {
+			if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error()); writeErr != nil {
+				h.logger.Error("Error writing error response", "error", writeErr)
+			}
+			return newTransactionHandledError(err)
+		}
+
 		replacementEntity := reflect.New(h.metadata.EntityType).Interface()
-		if err := json.NewDecoder(r.Body).Decode(replacementEntity); err != nil {
+		replacementJSON, err := json.Marshal(replacementData)
+		if err != nil {
+			if writeErr := response.WriteError(w, r, http.StatusInternalServerError, ErrMsgInternalError, err.Error()); writeErr != nil {
+				h.logger.Error("Error writing error response", "error", writeErr)
+			}
+			return newTransactionHandledError(err)
+		}
+		if err := json.Unmarshal(replacementJSON, replacementEntity); err != nil {
 			if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
 				fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error())); writeErr != nil {
 				h.logger.Error("Error writing error response", "error", writeErr)
@@ -476,7 +509,6 @@ func (h *EntityHandler) handlePutEntity(w http.ResponseWriter, r *http.Request, 
 			changeEvents = append(changeEvents, changeEvent{entity: entity, changeType: trackchanges.ChangeTypeUpdated})
 		}
 
-
 		return nil
 	}); err != nil {
 		if isTransactionHandled(err) {
@@ -500,6 +532,7 @@ func (h *EntityHandler) handlePutEntity(w http.ResponseWriter, r *http.Request, 
 
 	h.writeUpdateResponse(w, r, pref, db)
 }
+
 // preserveKeyProperties copies key property values from source to destination
 func (h *EntityHandler) preserveKeyProperties(source, destination interface{}) error {
 	sourceVal := reflect.ValueOf(source).Elem()
@@ -757,6 +790,11 @@ func (h *EntityHandler) handleUpdateEntityOverwrite(w http.ResponseWriter, r *ht
 	if err := json.NewDecoder(r.Body).Decode(&updateData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
 			fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error()))
+		return
+	}
+
+	if err := h.decodeBinaryPropertiesInPlace(updateData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error())
 		return
 	}
 

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -575,7 +575,7 @@ func (h *EntityHandler) buildEntityResponseWithMetadata(navValue reflect.Value, 
 			if propMeta != nil {
 				jsonName = propMeta.JsonName
 			}
-			odataResponse.Set(jsonName, fieldValue.Interface())
+			odataResponse.Set(jsonName, response.EncodeEdmBinary(fieldValue.Interface()))
 		}
 	}
 
@@ -699,7 +699,7 @@ func (h *EntityHandler) buildOrderedEntityResponseWithMetadata(result interface{
 					}
 				}
 
-				odataResponse.Set(keyStr, normalizeDecimalForJSON(enumMapValue(value, mapPropMeta), ieee754Compatible))
+				odataResponse.Set(keyStr, response.EncodeEdmBinary(normalizeDecimalForJSON(enumMapValue(value, mapPropMeta), ieee754Compatible)))
 			}
 		}
 
@@ -843,7 +843,7 @@ func (h *EntityHandler) buildOrderedEntityResponseWithMetadata(result interface{
 				}
 			}
 			// Then include the property value (enum fields are serialized as strings)
-			odataResponse.Set(jsonName, normalizeDecimalForJSON(enumFieldValue(fieldValue, propMeta), ieee754Compatible))
+			odataResponse.Set(jsonName, response.EncodeEdmBinary(normalizeDecimalForJSON(enumFieldValue(fieldValue, propMeta), ieee754Compatible)))
 		}
 	}
 

--- a/internal/handlers/singleton.go
+++ b/internal/handlers/singleton.go
@@ -149,6 +149,13 @@ func (h *EntityHandler) handlePatchSingleton(w http.ResponseWriter, r *http.Requ
 	// These are not actual entity properties and should not be passed to the database
 	h.removeODataAnnotations(updateData)
 
+	if err := h.decodeBinaryPropertiesInPlace(updateData); err != nil {
+		if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error()); writeErr != nil {
+			h.logger.Error("Error writing error response", "error", writeErr)
+		}
+		return
+	}
+
 	// Apply updates to the entity
 	if err := h.db.Model(entityInstance).Updates(updateData).Error; err != nil {
 		h.writeDatabaseError(w, r, err)
@@ -202,9 +209,35 @@ func (h *EntityHandler) handlePutSingleton(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// Parse the new entity data from request body
+	// Parse the new entity data from request body via an intermediate map so
+	// that Edm.Binary properties can be normalized (see
+	// decodeBinaryPropertiesInPlace) before being unmarshaled into the
+	// strongly-typed entity struct.
+	var newEntityData map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&newEntityData); err != nil {
+		if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
+			fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error())); writeErr != nil {
+			h.logger.Error("Error writing error response", "error", writeErr)
+		}
+		return
+	}
+
+	if err := h.decodeBinaryPropertiesInPlace(newEntityData); err != nil {
+		if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error()); writeErr != nil {
+			h.logger.Error("Error writing error response", "error", writeErr)
+		}
+		return
+	}
+
 	newEntity := reflect.New(h.metadata.EntityType).Interface()
-	if err := json.NewDecoder(r.Body).Decode(newEntity); err != nil {
+	newEntityJSON, err := json.Marshal(newEntityData)
+	if err != nil {
+		if writeErr := response.WriteError(w, r, http.StatusInternalServerError, ErrMsgInternalError, err.Error()); writeErr != nil {
+			h.logger.Error("Error writing error response", "error", writeErr)
+		}
+		return
+	}
+	if err := json.Unmarshal(newEntityJSON, newEntity); err != nil {
 		if writeErr := response.WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
 			fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error())); writeErr != nil {
 			h.logger.Error("Error writing error response", "error", writeErr)

--- a/internal/handlers/structural_properties.go
+++ b/internal/handlers/structural_properties.go
@@ -130,7 +130,7 @@ func (h *EntityHandler) writePropertyResponse(w http.ResponseWriter, r *http.Req
 	metadataLevel := response.GetODataMetadataLevel(r)
 
 	odataResponse := map[string]interface{}{
-		"value": fieldValue.Interface(),
+		"value": response.EncodeEdmBinary(fieldValue.Interface()),
 	}
 
 	// Only include @odata.context for minimal and full metadata (not for none)

--- a/internal/response/binary.go
+++ b/internal/response/binary.go
@@ -1,0 +1,27 @@
+package response
+
+import "encoding/base64"
+
+// EncodeEdmBinary converts an Edm.Binary property value ([]byte) into the string
+// representation required by the OData JSON Format spec for binary values
+// (OData JSON Format v4.0 §7.1; RFC 4648 §5 - the URL and filename safe alphabet,
+// without padding).
+//
+// Go's encoding/json marshals []byte using the standard base64 alphabet
+// (base64.StdEncoding) with padding, which is not compliant with the OData JSON
+// Format spec. Call this on every property value immediately before it is placed
+// into a JSON response so that []byte values are pre-encoded as compliant strings
+// instead of being left for encoding/json to encode incorrectly.
+//
+// Non-[]byte values (and nil) are returned unchanged, so this can be called
+// unconditionally on any property value.
+func EncodeEdmBinary(value interface{}) interface{} {
+	b, ok := value.([]byte)
+	if !ok {
+		return value
+	}
+	if b == nil {
+		return nil
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/internal/response/expand_annotations.go
+++ b/internal/response/expand_annotations.go
@@ -331,7 +331,7 @@ func applyNestedExpandAnnotationsToStruct(entityVal reflect.Value, expandOptions
 			}
 		}
 
-		result[jsonName] = fieldVal.Interface()
+		result[jsonName] = EncodeEdmBinary(fieldVal.Interface())
 	}
 
 	return result
@@ -484,7 +484,7 @@ func filterEntityFieldsWithMetadata(entityVal reflect.Value, selectedPropMap map
 
 			fieldValue := entityVal.Field(j)
 			if fieldValue.IsValid() && fieldValue.CanInterface() {
-				filteredEntity[jsonName] = fieldValue.Interface()
+				filteredEntity[jsonName] = EncodeEdmBinary(fieldValue.Interface())
 			}
 		}
 	} else if entityVal.Kind() == reflect.Map {
@@ -493,7 +493,7 @@ func filterEntityFieldsWithMetadata(entityVal reflect.Value, selectedPropMap map
 		if entityMap, ok := entityMapVal.(map[string]interface{}); ok {
 			for key, val := range entityMap {
 				if selectedPropMap[key] || keyPropMap[key] || strings.HasPrefix(key, "@") {
-					filteredEntity[key] = val
+					filteredEntity[key] = EncodeEdmBinary(val)
 				}
 			}
 		}

--- a/internal/response/navigation_links.go
+++ b/internal/response/navigation_links.go
@@ -53,6 +53,12 @@ func processMapEntity(entity reflect.Value, metadata EntityMetadataProvider, exp
 		return nil
 	}
 
+	// Encode Edm.Binary ([]byte) property values as base64url strings per the
+	// OData JSON Format spec before any further processing serializes them.
+	for k, v := range entityMap {
+		entityMap[k] = EncodeEdmBinary(v)
+	}
+
 	// Add ETag if present and metadata level is not "none"
 	if fullMetadata != nil && fullMetadata.ETagProperty != nil && metadataLevel != "none" {
 		etagValue := etag.Generate(entityMap, fullMetadata)
@@ -277,7 +283,7 @@ func processStructEntityOrdered(entity reflect.Value, metadata EntityMetadataPro
 			}
 			// Then add the property value
 			fieldValue := entity.Field(j)
-			entityMap.Set(info.JsonName, enumOrRaw(fieldValue, fullPropMetaByName, info.Name))
+			entityMap.Set(info.JsonName, EncodeEdmBinary(enumOrRaw(fieldValue, fullPropMetaByName, info.Name)))
 		}
 	}
 

--- a/test/binary_encoding_test.go
+++ b/test/binary_encoding_test.go
@@ -1,0 +1,250 @@
+package odata_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestBinaryEncodingItem is used to verify that Edm.Binary property values are
+// serialized to/from JSON using the base64url alphabet without padding, per
+// the OData JSON Format spec v4.0 §7.1 (RFC 4648 §5), rather than Go's default
+// (standard base64 with padding) []byte JSON encoding. See issue #789.
+type TestBinaryEncodingItem struct {
+	ID   int    `json:"id" gorm:"primarykey" odata:"key"`
+	Name string `json:"name"`
+	Data []byte `json:"data" gorm:"type:blob" odata:"nullable"`
+}
+
+func setupBinaryEncodingTestService(t *testing.T) (*odata.Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	if err := db.AutoMigrate(&TestBinaryEncodingItem{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	if err := service.RegisterEntity(TestBinaryEncodingItem{}); err != nil {
+		t.Fatalf("Failed to register entity: %v", err)
+	}
+	return service, db
+}
+
+// binaryTestBytes produces a single byte whose standard base64 representation
+// requires both the '/' character and '==' padding ("/w=="), so that a test
+// asserting on its base64url form ("_w", no padding) actually exercises both
+// aspects of RFC 4648 §5 (alphabet substitution and padding removal).
+var binaryTestBytes = []byte{0xFF}
+
+func decodeJSONObject(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("Failed to decode JSON response: %v (body: %s)", err, body)
+	}
+	return m
+}
+
+// TestBinaryPropertyPostGet_UsesBase64URLAlphabetNoPadding verifies that POSTing
+// an Edm.Binary value encoded with the OData-mandated base64url alphabet is
+// accepted, and that reading it back returns the same base64url (unpadded)
+// representation rather than Go's default standard-alphabet, padded encoding.
+func TestBinaryPropertyPostGet_UsesBase64URLAlphabetNoPadding(t *testing.T) {
+	service, _ := setupBinaryEncodingTestService(t)
+
+	urlEncoded := base64.RawURLEncoding.EncodeToString(binaryTestBytes) // "_w"
+	stdEncoded := base64.StdEncoding.EncodeToString(binaryTestBytes)    // "/w=="
+	if urlEncoded != "_w" || stdEncoded != "/w==" {
+		t.Fatalf("test fixture assumption broken: url=%q std=%q", urlEncoded, stdEncoded)
+	}
+
+	postBody := `{"name":"widget","data":"` + urlEncoded + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/TestBinaryEncodingItems", bytes.NewBufferString(postBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST status = %d, want %d. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/TestBinaryEncodingItems(1)?$select=data", nil)
+	w2 := httptest.NewRecorder()
+	service.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d. Body: %s", w2.Code, http.StatusOK, w2.Body.String())
+	}
+
+	resp := decodeJSONObject(t, w2.Body.Bytes())
+	dataValue, ok := resp["data"].(string)
+	if !ok {
+		t.Fatalf("expected 'data' to be a string, got %T (%v)", resp["data"], resp["data"])
+	}
+
+	if dataValue != urlEncoded {
+		t.Errorf("data = %q, want base64url-encoded %q", dataValue, urlEncoded)
+	}
+	if strings.ContainsAny(dataValue, "+/=") {
+		t.Errorf("data %q contains standard-base64-only characters ('+' '/' '='); must use base64url without padding", dataValue)
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(dataValue)
+	if err != nil {
+		t.Fatalf("Failed to decode returned value as base64url: %v", err)
+	}
+	if !bytes.Equal(decoded, binaryTestBytes) {
+		t.Errorf("decoded bytes = %v, want %v", decoded, binaryTestBytes)
+	}
+}
+
+// TestBinaryPropertyPost_StandardBase64AlsoAccepted verifies that the write path
+// leniently accepts standard base64 (with padding) input for interoperability,
+// while the value read back is still normalized to base64url per the spec.
+func TestBinaryPropertyPost_StandardBase64AlsoAccepted(t *testing.T) {
+	service, _ := setupBinaryEncodingTestService(t)
+
+	stdEncoded := base64.StdEncoding.EncodeToString(binaryTestBytes) // "/w=="
+	postBody := `{"name":"widget","data":"` + stdEncoded + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/TestBinaryEncodingItems", bytes.NewBufferString(postBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST status = %d, want %d. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/TestBinaryEncodingItems(1)?$select=data", nil)
+	w2 := httptest.NewRecorder()
+	service.ServeHTTP(w2, req2)
+
+	resp := decodeJSONObject(t, w2.Body.Bytes())
+	dataValue, _ := resp["data"].(string)
+	wantURL := base64.RawURLEncoding.EncodeToString(binaryTestBytes)
+	if dataValue != wantURL {
+		t.Errorf("data = %q, want normalized base64url %q", dataValue, wantURL)
+	}
+}
+
+// TestBinaryPropertyPost_InvalidBase64Rejected verifies that a value which isn't
+// valid base64 under either alphabet is still rejected with a 400 error.
+func TestBinaryPropertyPost_InvalidBase64Rejected(t *testing.T) {
+	service, _ := setupBinaryEncodingTestService(t)
+
+	postBody := `{"name":"widget","data":"not-valid-base64!!!"}`
+	req := httptest.NewRequest(http.MethodPost, "/TestBinaryEncodingItems", bytes.NewBufferString(postBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST status = %d, want %d. Body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+// TestBinaryPropertyPatch_RoundTripsBase64URL verifies that PATCH accepts a
+// base64url-encoded binary value and that the updated value round-trips
+// correctly through a subsequent GET, using the base64url alphabet.
+func TestBinaryPropertyPatch_RoundTripsBase64URL(t *testing.T) {
+	service, db := setupBinaryEncodingTestService(t)
+
+	initial := TestBinaryEncodingItem{ID: 1, Name: "widget", Data: []byte{0x01, 0x02, 0x03}}
+	if err := db.Create(&initial).Error; err != nil {
+		t.Fatalf("failed to seed entity: %v", err)
+	}
+
+	newBytes := []byte{0xFF, 0xFE, 0xFD} // std base64 "//79" contains '/'
+	stdOfNew := base64.StdEncoding.EncodeToString(newBytes)
+	urlOfNew := base64.RawURLEncoding.EncodeToString(newBytes)
+	if !strings.ContainsAny(stdOfNew, "+/") {
+		t.Fatalf("test fixture assumption broken: std encoding %q does not contain +/", stdOfNew)
+	}
+
+	patchBody := `{"data":"` + urlOfNew + `"}`
+	req := httptest.NewRequest(http.MethodPatch, "/TestBinaryEncodingItems(1)", bytes.NewBufferString(patchBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent && w.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want 204 or 200. Body: %s", w.Code, w.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/TestBinaryEncodingItems(1)?$select=data", nil)
+	w2 := httptest.NewRecorder()
+	service.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d. Body: %s", w2.Code, http.StatusOK, w2.Body.String())
+	}
+
+	resp := decodeJSONObject(t, w2.Body.Bytes())
+	dataValue, ok := resp["data"].(string)
+	if !ok {
+		t.Fatalf("expected 'data' to be a string, got %T (%v)", resp["data"], resp["data"])
+	}
+	if dataValue != urlOfNew {
+		t.Errorf("data after PATCH = %q, want %q", dataValue, urlOfNew)
+	}
+	if strings.ContainsAny(dataValue, "+/=") {
+		t.Errorf("data %q after PATCH contains standard-base64-only characters", dataValue)
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(dataValue)
+	if err != nil {
+		t.Fatalf("Failed to decode returned value as base64url: %v", err)
+	}
+	if !bytes.Equal(decoded, newBytes) {
+		t.Errorf("decoded bytes after PATCH = %v, want %v", decoded, newBytes)
+	}
+}
+
+// TestBinaryPropertyCollectionGet_UsesBase64URLAlphabet verifies that binary
+// properties are correctly base64url-encoded when returned as part of a
+// collection response (a different serialization code path than a single
+// entity GET), both with and without $select.
+func TestBinaryPropertyCollectionGet_UsesBase64URLAlphabet(t *testing.T) {
+	service, db := setupBinaryEncodingTestService(t)
+
+	item := TestBinaryEncodingItem{ID: 1, Name: "widget", Data: binaryTestBytes}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatalf("failed to seed entity: %v", err)
+	}
+	wantURL := base64.RawURLEncoding.EncodeToString(binaryTestBytes)
+
+	// Collection GET without $select (struct-based serialization path).
+	req := httptest.NewRequest(http.MethodGet, "/TestBinaryEncodingItems", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d. Body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"data":"`+wantURL+`"`) {
+		t.Errorf("collection response does not contain expected base64url data %q: %s", wantURL, w.Body.String())
+	}
+
+	// Collection GET with $select (map-based serialization path).
+	reqSelect := httptest.NewRequest(http.MethodGet, "/TestBinaryEncodingItems?$select=data", nil)
+	wSelect := httptest.NewRecorder()
+	service.ServeHTTP(wSelect, reqSelect)
+	if wSelect.Code != http.StatusOK {
+		t.Fatalf("GET ($select) status = %d, want %d. Body: %s", wSelect.Code, http.StatusOK, wSelect.Body.String())
+	}
+	if !strings.Contains(wSelect.Body.String(), `"data":"`+wantURL+`"`) {
+		t.Errorf("$select collection response does not contain expected base64url data %q: %s", wantURL, wSelect.Body.String())
+	}
+}

--- a/test/structural_property_test.go
+++ b/test/structural_property_test.go
@@ -6,6 +6,7 @@ import (
 	odata "github.com/nlstn/go-odata"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"gorm.io/driver/sqlite"
@@ -585,12 +586,15 @@ func TestStructuralPropertyRead_Binary(t *testing.T) {
 		t.Error("Response missing @odata.context")
 	}
 
-	// Check the value is base64 encoded (Go's json.Marshal automatically encodes []byte as base64)
+	// Per OData JSON Format spec §7.1 (RFC 4648 §5), binary values must be
+	// base64url encoded (using '-'/'_' instead of '+'/'/') without padding.
 	if valueStr, ok := response["value"].(string); ok {
-		// Decode base64 and verify it matches original data
-		decoded, err := base64.StdEncoding.DecodeString(valueStr)
+		if strings.ContainsAny(valueStr, "+/=") {
+			t.Errorf("value %q uses standard base64 alphabet/padding, want base64url without padding", valueStr)
+		}
+		decoded, err := base64.RawURLEncoding.DecodeString(valueStr)
 		if err != nil {
-			t.Errorf("Failed to decode base64 value: %v", err)
+			t.Errorf("Failed to decode base64url value: %v", err)
 		}
 		if string(decoded) != string(binaryData) {
 			t.Errorf("Decoded binary data = %v, want %v", decoded, binaryData)


### PR DESCRIPTION
## Summary

Fixes #789.

`Edm.Binary` property values were serialized using Go's default `[]byte` JSON encoding (`encoding/base64.StdEncoding`, standard alphabet with padding) instead of the base64url alphabet without padding required by the [OData JSON Format spec v4.0 §7.1](https://docs.oasis-open.org/odata/odata-json-format/v4.0/errata03/os/odata-json-format-v4.0-errata03-os-complete.html#_Toc453766662) (RFC 4648 §5). The write path had a matching problem: POST/PATCH/PUT relied on `encoding/json`'s default `[]byte` unmarshaling, which only accepts padded standard base64, and PATCH even rejected *valid* base64 outright because request values were type-checked as strings before ever reaching the base64 decoder.

- Adds `response.EncodeEdmBinary`, applied everywhere a `[]byte` property value is placed into a JSON response (entity/collection GET, `$select` projections, `$expand`, structural and complex-type property endpoints), converting it to a `base64.RawURLEncoding` string instead of leaving it for `encoding/json` to encode with the wrong alphabet.
- Adds `EntityHandler.decodeBinaryPropertiesInPlace`, run on the request body map before POST/PUT/PATCH persist it, which decodes `Edm.Binary` string values leniently (base64url, or standard base64 with/without padding) into raw `[]byte` so writes round-trip correctly regardless of which alphabet the client used.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean for touched files
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] New tests: `TestBinaryPropertyPostGet_UsesBase64URLAlphabetNoPadding`, `TestBinaryPropertyPost_StandardBase64AlsoAccepted`, `TestBinaryPropertyPost_InvalidBase64Rejected`, `TestBinaryPropertyPatch_RoundTripsBase64URL`, `TestBinaryPropertyCollectionGet_UsesBase64URLAlphabet`
- [x] Updated `TestStructuralPropertyRead_Binary`, which previously asserted the non-compliant standard-base64 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)