### PR TITLE
fix: recurse into nested first argument of contains()/startswith()/endswith()

### DIFF
--- a/internal/query/apply_filter.go
+++ b/internal/query/apply_filter.go
@@ -1145,6 +1145,21 @@ func buildFunctionComparisonForLambda(dialect string, filter *FilterExpression, 
 		}
 	}
 
+	// contains()/startswith()/endswith() wrapping a nested function call as their
+	// first argument, e.g. any(n: contains(tolower(n/Name),'laptop')). See the
+	// matching branch in buildFunctionComparison for details.
+	switch filter.Operator {
+	case OpContains:
+		likeSQL, likeArgs := buildLikeComparison(dialect, funcSQL, filter.Value, true, true)
+		return likeSQL, append(funcArgs, likeArgs...)
+	case OpStartsWith:
+		likeSQL, likeArgs := buildLikeComparison(dialect, funcSQL, filter.Value, false, true)
+		return likeSQL, append(funcArgs, likeArgs...)
+	case OpEndsWith:
+		likeSQL, likeArgs := buildLikeComparison(dialect, funcSQL, filter.Value, true, false)
+		return likeSQL, append(funcArgs, likeArgs...)
+	}
+
 	compSQL := buildComparisonSQL(filter.Operator, funcSQL)
 	if compSQL == "" {
 		return "", nil
@@ -1179,6 +1194,24 @@ func buildFunctionComparison(dialect string, filter *FilterExpression, entityMet
 		if funcSQL == "" {
 			return "", nil
 		}
+	}
+
+	// contains()/startswith()/endswith() wrapping a nested function call as their
+	// first argument, e.g. contains(tolower(Name),'laptop'). funcSQL above is the
+	// SQL expression that evaluates that first argument (e.g. "LOWER(name)" or
+	// "CONCAT(name, ?)"); build the same ordinal (case-sensitive) LIKE comparison
+	// against it that buildStandardComparison builds for a bare property reference,
+	// preserving any bind arguments funcSQL itself required.
+	switch filter.Operator {
+	case OpContains:
+		likeSQL, likeArgs := buildLikeComparison(dialect, funcSQL, filter.Value, true, true)
+		return likeSQL, append(funcArgs, likeArgs...)
+	case OpStartsWith:
+		likeSQL, likeArgs := buildLikeComparison(dialect, funcSQL, filter.Value, false, true)
+		return likeSQL, append(funcArgs, likeArgs...)
+	case OpEndsWith:
+		likeSQL, likeArgs := buildLikeComparison(dialect, funcSQL, filter.Value, true, false)
+		return likeSQL, append(funcArgs, likeArgs...)
 	}
 
 	// Check if right side is a FilterExpression (converted from FunctionCallExpr)

--- a/internal/query/ast_parser_functions.go
+++ b/internal/query/ast_parser_functions.go
@@ -180,15 +180,43 @@ func convertSingleArgFunctionWithContext(n *FunctionCallExpr, functionName strin
 	return expr, nil
 }
 
+// isLikeMatchFunction reports whether functionName is one of contains, startswith,
+// or endswith - the OData string-matching functions whose first argument must be
+// evaluated as an arbitrary expression (e.g. tolower(Name), concat(Name,'x')),
+// rather than assumed to always be a bare property reference.
+func isLikeMatchFunction(name string) bool {
+	return name == "contains" || name == "startswith" || name == "endswith"
+}
+
 // convertTwoArgFunctionWithContext converts two-argument functions using the provided context
 func convertTwoArgFunctionWithContext(n *FunctionCallExpr, functionName string, entityMetadata *metadata.EntityMetadata, ctx *conversionContext) (*FilterExpression, error) {
 	if len(n.Args) != 2 {
 		return nil, fmt.Errorf("function %s requires 2 arguments", functionName)
 	}
 
-	property, err := extractPropertyFromFunctionArgWithContext(n.Args[0], functionName, entityMetadata, ctx)
-	if err != nil {
-		return nil, err
+	var property string
+	var leftExpr *FilterExpression
+
+	if funcCall, ok := n.Args[0].(*FunctionCallExpr); ok && isLikeMatchFunction(functionName) {
+		// contains()/startswith()/endswith() must recursively evaluate their first
+		// argument as a general SQL expression when it is itself a function call
+		// (e.g. tolower(Name), concat(Name,'x')). Keep the fully converted inner
+		// expression via Left, mirroring the convention already used for
+		// "tolower(Name) eq 'x'" style comparisons (see
+		// convertComparisonExprWithContext), instead of collapsing it down to the
+		// inner property name, which previously discarded the outer function call
+		// entirely.
+		innerExpr, err := convertFunctionCallExprWithContext(funcCall, entityMetadata, ctx)
+		if err != nil {
+			return nil, err
+		}
+		leftExpr = innerExpr
+	} else {
+		p, err := extractPropertyFromFunctionArgWithContext(n.Args[0], functionName, entityMetadata, ctx)
+		if err != nil {
+			return nil, err
+		}
+		property = p
 	}
 
 	// Second argument can be a literal, property, or function call
@@ -209,6 +237,7 @@ func convertTwoArgFunctionWithContext(n *FunctionCallExpr, functionName string, 
 
 	expr := acquireFilterExpression()
 	expr.Property = property
+	expr.Left = leftExpr
 	expr.Operator = FilterOperator(functionName)
 	expr.Value = value
 	return expr, nil

--- a/test/string_filter_case_sensitivity_test.go
+++ b/test/string_filter_case_sensitivity_test.go
@@ -37,6 +37,7 @@ func setupCaseSensitivityTestDB(t *testing.T) *gorm.DB {
 	products := []CaseSensitivityProduct{
 		{ID: 1, Name: "Laptop"},
 		{ID: 2, Name: "Premium Laptop Pro"},
+		{ID: 3, Name: "Wireless Mouse"},
 	}
 	if err := db.Create(&products).Error; err != nil {
 		t.Fatalf("Failed to seed products: %v", err)
@@ -144,6 +145,63 @@ func TestFilterEndsWithIsCaseSensitive(t *testing.T) {
 		results := queryCaseSensitivityProducts(t, service, "endswith(Name,'Pro')")
 		if len(results) != 1 {
 			t.Errorf("Expected 1 result for endswith(Name,'Pro'), got %d: %v", len(results), results)
+		}
+	})
+}
+
+// TestFilterLikeFunctionsRecurseIntoNestedFirstArgument is a regression test for
+// https://github.com/NLstn/go-odata/issues/797: the ordinal case-sensitivity fix
+// for contains()/startswith()/endswith() (issue #790) stopped evaluating a nested
+// function call passed as the first argument (e.g. contains(tolower(Name),'x')),
+// silently collapsing it down to a bare property reference and discarding the
+// outer function entirely. These functions must recurse into evaluating their
+// first argument as a general SQL expression - the standard OData idiom for
+// case-insensitive search is tolower(Name)/toupper(Name) wrapped in contains()/
+// startswith()/endswith() - while still performing ordinal (case-sensitive)
+// matching against the *result* of that expression.
+func TestFilterLikeFunctionsRecurseIntoNestedFirstArgument(t *testing.T) {
+	db := setupCaseSensitivityTestDB(t)
+	service := newCaseSensitivityService(t, db)
+
+	t.Run("contains(tolower(Name),...) matches regardless of source casing", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "contains(tolower(Name),'laptop')")
+		if len(results) != 2 {
+			t.Errorf("Expected 2 results for contains(tolower(Name),'laptop'), got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("contains(tolower(Name),...) is still ordinal against the lowered value", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "contains(tolower(Name),'LAPTOP')")
+		if len(results) != 0 {
+			t.Errorf("Expected 0 results for contains(tolower(Name),'LAPTOP') since tolower() always produces lowercase, got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("startswith(tolower(Name),...) matches regardless of source casing", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "startswith(tolower(Name),'laptop')")
+		if len(results) != 1 {
+			t.Errorf("Expected 1 result for startswith(tolower(Name),'laptop'), got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("endswith(tolower(Name),...) matches regardless of source casing", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "endswith(tolower(Name),'mouse')")
+		if len(results) != 1 {
+			t.Errorf("Expected 1 result for endswith(tolower(Name),'mouse'), got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("contains(toupper(Name),...) matches regardless of source casing", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "contains(toupper(Name),'LAPTOP')")
+		if len(results) != 2 {
+			t.Errorf("Expected 2 results for contains(toupper(Name),'LAPTOP'), got %d: %v", len(results), results)
+		}
+	})
+
+	t.Run("contains(concat(Name,'x'),...) evaluates the nested concat expression", func(t *testing.T) {
+		results := queryCaseSensitivityProducts(t, service, "contains(concat(Name,'x'),'Laptopx')")
+		if len(results) != 1 {
+			t.Errorf("Expected 1 result for contains(concat(Name,'x'),'Laptopx'), got %d: %v", len(results), results)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #797.

The ordinal case-sensitivity fix for `contains()`/`startswith()`/`endswith()` (PR #793, closing #790) exposed a latent bug: when the first argument to one of these functions is itself a function call (e.g. `tolower(Name)`, `concat(Name,'x')`), `convertTwoArgFunctionWithContext` collapsed it down to just the inner property name via `extractPropertyFromFunctionArgWithContext`, silently discarding the outer function entirely.

Before #793, SQL `LIKE` was case-insensitive by default on most dialects, so `contains(tolower(Name),'laptop')` "accidentally" matched `"Laptop"` via a plain case-insensitive `name LIKE '%laptop%'` (the discarded `tolower()` didn't matter). Once `LIKE` became ordinal/case-sensitive, the comparison ran against the original, differently-cased column value and always returned zero rows — breaking the standard OData case-insensitive-search idiom.

## Fix

- `convertTwoArgFunctionWithContext` (`internal/query/ast_parser_functions.go`) now recognizes when the first argument of `contains()`/`startswith()`/`endswith()` is a nested function call and preserves the fully converted expression via `FilterExpression.Left`, mirroring the existing convention used for `tolower(Name) eq 'x'`-style comparisons.
- `buildFunctionComparison` and `buildFunctionComparisonForLambda` (`internal/query/apply_filter.go`, the latter used inside `any()`/`all()` lambda predicates) now build the ordinal LIKE comparison against that expression's generated SQL (e.g. `LOWER(name) LIKE ? ESCAPE '\'`) instead of only supporting `eq`/`ne`/`gt`/`lt` for function-wrapped left-hand sides.

The case-sensitivity fix from #790 is preserved — this only makes the first-argument evaluation recurse correctly; ordinal matching is unchanged.

## Test plan

- [x] Added `TestFilterLikeFunctionsRecurseIntoNestedFirstArgument` (`test/string_filter_case_sensitivity_test.go`) covering `contains(tolower(Name),...)`, `startswith(tolower(Name),...)`, `endswith(tolower(Name),...)`, `contains(toupper(Name),...)`, and `contains(concat(Name,'x'),...)`, plus a negative case confirming ordinal case-sensitivity still holds against the transformed value.
- [x] Existing `TestFilterContainsIsCaseSensitive`/`TestFilterStartsWithIsCaseSensitive`/`TestFilterEndsWithIsCaseSensitive` (#790 regression tests) still pass.
- [x] `go build ./...`, `go test ./...`, `gofmt -l .` (no new issues), `golangci-lint run ./...` (no new issues vs. baseline) all clean.
- [x] Manually verified against `cmd/complianceserver -db sqlite`: `GET /Products?$filter=contains(tolower(Name),'laptop')` now returns the expected 2 rows instead of 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)