### PR TITLE
fix: accept unpadded base64url $filter binary literals

### DIFF
--- a/internal/query/ast_parser_arithmetic.go
+++ b/internal/query/ast_parser_arithmetic.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"encoding/base64"
 	"fmt"
 	"math"
 	"strconv"
@@ -257,7 +256,7 @@ func (p *ASTParser) parseIdentifierOrFunctionCall(token *Token) (ASTNode, error)
 
 		switch lowerIdent {
 		case "binary":
-			decoded, err := base64.StdEncoding.DecodeString(literalValue)
+			decoded, err := decodeBase64Lenient(literalValue)
 			if err != nil {
 				return nil, fmt.Errorf("invalid binary literal: %w", err)
 			}

--- a/internal/query/ast_parser_test.go
+++ b/internal/query/ast_parser_test.go
@@ -247,6 +247,13 @@ func TestASTParser_LiteralTyping(t *testing.T) {
 			skipConvert:  true,
 		},
 		{
+			name:         "Binary prefixed literal unpadded base64url (spec-mandated form)",
+			filter:       "Price eq binary'dGVzdA'",
+			expectErr:    false,
+			expectedType: "binary",
+			skipConvert:  true,
+		},
+		{
 			name:         "Boolean literal true",
 			filter:       "Name eq true",
 			expectErr:    false,

--- a/internal/query/binary_literal.go
+++ b/internal/query/binary_literal.go
@@ -1,0 +1,38 @@
+package query
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// binaryLiteralDecoders lists the base64 alphabets accepted when decoding a
+// $filter binary literal (binary'...'). Per the OData ABNF (binaryValue) and
+// the OData JSON Format spec (v4.0 §7.1; RFC 4648 §5), binary values must be
+// encoded using the URL and filename safe alphabet without padding
+// (base64.RawURLEncoding). The remaining alphabets are accepted leniently for
+// interoperability with clients that still send standard base64 (with or
+// without padding).
+var binaryLiteralDecoders = [...]*base64.Encoding{
+	base64.RawURLEncoding,
+	base64.URLEncoding,
+	base64.RawStdEncoding,
+	base64.StdEncoding,
+}
+
+// decodeBase64Lenient decodes a base64-encoded string, accepting both the
+// URL-safe alphabet required by the OData spec and the standard alphabet
+// (with or without padding).
+func decodeBase64Lenient(s string) ([]byte, error) {
+	if s == "" {
+		return []byte{}, nil
+	}
+	var lastErr error
+	for _, enc := range binaryLiteralDecoders {
+		if b, err := enc.DecodeString(s); err == nil {
+			return b, nil
+		} else {
+			lastErr = err
+		}
+	}
+	return nil, fmt.Errorf("illegal base64 data: %w", lastErr)
+}


### PR DESCRIPTION
## Summary

The `$filter` binary literal parser (`binary'...'`) decoded using `base64.StdEncoding`, which requires padded standard-alphabet base64. This rejects the unpadded base64url form that the OData ABNF `binaryValue` grammar actually mandates — and that this server's own JSON serialization of `Edm.Binary` values already produces (`EncodeEdmBinary` in `internal/response/binary.go` uses `base64.RawURLEncoding`). A client could not copy a `Data` value straight out of a GET response and reuse it in a `$filter` binary literal without manually adding padding first.

## Fix

Decode `binary'...'` literals leniently across all four base64 alphabets (`RawURLEncoding`, `URLEncoding`, `RawStdEncoding`, `StdEncoding`), prioritizing the spec-mandated unpadded base64url form first. This mirrors the existing `decodeBase64Lenient` pattern already used for binary request bodies in `internal/handlers/binary_request.go` (duplicated locally in `internal/query` to avoid a package import cycle between `query` and `handlers`).

Previously-accepted padded literals continue to work, so this is purely additive.

Fixes #801

## Test plan

- [x] Added a regression test case (`Binary prefixed literal unpadded base64url`) to `TestASTParser_LiteralTyping` in `internal/query/ast_parser_test.go`
- [x] `go test ./internal/query/...` passes
- [x] Manually verified against `cmd/complianceserver`: `GET /Products?$filter=Data eq binary'dGVzdA'` (unpadded) now returns 200 with the Laptop entity, matching the issue's expected behavior; the previously-working padded form (`binary'dGVzdA=='`) still works too