### PR TITLE
fix: type-check $filter date/time functions and literals against declared EDM type

### DIFF
--- a/cmd/complianceserver/entities/product.go
+++ b/cmd/complianceserver/entities/product.go
@@ -10,8 +10,49 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	odata "github.com/nlstn/go-odata"
 	"gorm.io/gorm"
 )
+
+// ReleaseDateValue is a string-backed named type declared as Edm.Date via an
+// explicit UnderlyingType override (Go has no distinct native type for Edm.Date).
+// Holds ISO-8601 date strings, e.g. "2024-01-15".
+type ReleaseDateValue string
+
+// TimeOfDayValue is a string-backed named type declared as Edm.TimeOfDay via an
+// explicit UnderlyingType override. Holds ISO-8601 time-of-day strings, e.g. "09:30:00".
+type TimeOfDayValue string
+
+// DurationValue is a string-backed named type declared as Edm.Duration via an
+// explicit UnderlyingType override. Holds ISO-8601 duration strings, e.g. "P1D", "PT45S".
+type DurationValue string
+
+func init() {
+	if err := odata.RegisterTypeDefinition(ReleaseDateValue(""), "ReleaseDateValue", odata.TypeDefinitionFacets{UnderlyingType: "Edm.Date"}); err != nil {
+		panic("failed to register ReleaseDateValue TypeDefinition: " + err.Error())
+	}
+	if err := odata.RegisterTypeDefinition(TimeOfDayValue(""), "TimeOfDayValue", odata.TypeDefinitionFacets{UnderlyingType: "Edm.TimeOfDay"}); err != nil {
+		panic("failed to register TimeOfDayValue TypeDefinition: " + err.Error())
+	}
+	if err := odata.RegisterTypeDefinition(DurationValue(""), "DurationValue", odata.TypeDefinitionFacets{UnderlyingType: "Edm.Duration"}); err != nil {
+		panic("failed to register DurationValue TypeDefinition: " + err.Error())
+	}
+}
+
+func releaseDatePtr(s string) *ReleaseDateValue {
+	v := ReleaseDateValue(s)
+	return &v
+}
+
+func timeOfDayPtr(s string) *TimeOfDayValue {
+	v := TimeOfDayValue(s)
+	return &v
+}
+
+func durationPtr(s string) *DurationValue {
+	v := DurationValue(s)
+	return &v
+}
 
 // ProductStatus represents product status as a flags enum
 type ProductStatus int32
@@ -229,28 +270,28 @@ func (ProductStatus) EnumMembers() map[string]int {
 
 // Product represents a product entity for the compliance server
 type Product struct {
-	ID              uuid.UUID        `json:"ID" gorm:"type:char(36);primaryKey" odata:"key,generate=uuid"`
-	Name            string           `json:"Name" gorm:"not null" odata:"required,maxlength=100,searchable,annotation:Core.Description=Product display name"`
-	Description     *string          `json:"Description" odata:"nullable,maxlength=500,annotation:Core.Description=Detailed product description"` // Nullable description field
-	Price           float64          `json:"Price" gorm:"not null" odata:"required,precision=10,scale=2"`
-	Rating          RatingValue      `json:"Rating" odata:""`
-	Temperature     TemperatureValue `json:"Temperature" odata:""`
-	Quantity        QuantityValue    `json:"Quantity" odata:""`
-	Weight          float32          `json:"Weight" odata:""`
-	Data            []byte           `json:"Data,omitempty" odata:"nullable"`
-	ReleaseDate     *string          `json:"ReleaseDate,omitempty" odata:"nullable"`
-	OpenTime        *string          `json:"OpenTime,omitempty" odata:"nullable"`
-	ShippingTime    *string          `json:"ShippingTime,omitempty" odata:"nullable"`
-	ProcessingTime  *string          `json:"ProcessingTime,omitempty" odata:"nullable"`
-	Offset          *string          `json:"Offset,omitempty" odata:"nullable"`
-	CategoryID      *uuid.UUID       `json:"CategoryID" gorm:"type:char(36)" odata:"nullable"` // Foreign key for Category navigation property
-	Status          ProductStatus    `json:"Status" gorm:"not null" odata:"enum=ProductStatus,flags"`
-	Version         int              `json:"Version" gorm:"default:1" odata:"etag"` // Version field used for optimistic concurrency control via ETag
-	CreatedAt       time.Time        `json:"CreatedAt" gorm:"not null" odata:"annotation:Core.Computed"`
-	SerialNumber    *string          `json:"SerialNumber,omitempty" gorm:"type:varchar(50)" odata:"nullable,maxlength=50,annotation:Core.Immutable,annotation:Core.Description=Unique serial number assigned at creation"`
-	ProductType     string           `json:"ProductType,omitempty" gorm:"default:'Product'" odata:"maxlength=50"` // Discriminator for type inheritance
-	SpecialProperty *string          `json:"SpecialProperty,omitempty" odata:"nullable,maxlength=200"`            // Property for SpecialProduct derived type
-	SpecialFeature  *string          `json:"SpecialFeature,omitempty" odata:"nullable,maxlength=100"`             // Property for SpecialProduct derived type
+	ID              uuid.UUID         `json:"ID" gorm:"type:char(36);primaryKey" odata:"key,generate=uuid"`
+	Name            string            `json:"Name" gorm:"not null" odata:"required,maxlength=100,searchable,annotation:Core.Description=Product display name"`
+	Description     *string           `json:"Description" odata:"nullable,maxlength=500,annotation:Core.Description=Detailed product description"` // Nullable description field
+	Price           float64           `json:"Price" gorm:"not null" odata:"required,precision=10,scale=2"`
+	Rating          RatingValue       `json:"Rating" odata:""`
+	Temperature     TemperatureValue  `json:"Temperature" odata:""`
+	Quantity        QuantityValue     `json:"Quantity" odata:""`
+	Weight          float32           `json:"Weight" odata:""`
+	Data            []byte            `json:"Data,omitempty" odata:"nullable"`
+	ReleaseDate     *ReleaseDateValue `json:"ReleaseDate,omitempty" odata:"nullable"`
+	OpenTime        *TimeOfDayValue   `json:"OpenTime,omitempty" odata:"nullable"`
+	ShippingTime    *DurationValue    `json:"ShippingTime,omitempty" odata:"nullable"`
+	ProcessingTime  *DurationValue    `json:"ProcessingTime,omitempty" odata:"nullable"`
+	Offset          *DurationValue    `json:"Offset,omitempty" odata:"nullable"`
+	CategoryID      *uuid.UUID        `json:"CategoryID" gorm:"type:char(36)" odata:"nullable"` // Foreign key for Category navigation property
+	Status          ProductStatus     `json:"Status" gorm:"not null" odata:"enum=ProductStatus,flags"`
+	Version         int               `json:"Version" gorm:"default:1" odata:"etag"` // Version field used for optimistic concurrency control via ETag
+	CreatedAt       time.Time         `json:"CreatedAt" gorm:"not null" odata:"annotation:Core.Computed"`
+	SerialNumber    *string           `json:"SerialNumber,omitempty" gorm:"type:varchar(50)" odata:"nullable,maxlength=50,annotation:Core.Immutable,annotation:Core.Description=Unique serial number assigned at creation"`
+	ProductType     string            `json:"ProductType,omitempty" gorm:"default:'Product'" odata:"maxlength=50"` // Discriminator for type inheritance
+	SpecialProperty *string           `json:"SpecialProperty,omitempty" odata:"nullable,maxlength=200"`            // Property for SpecialProduct derived type
+	SpecialFeature  *string           `json:"SpecialFeature,omitempty" odata:"nullable,maxlength=100"`             // Property for SpecialProduct derived type
 	// Complex type properties
 	ShippingAddress *Address    `json:"ShippingAddress,omitempty" gorm:"embedded;embeddedPrefix:shipping_" odata:"nullable"`
 	Dimensions      *Dimensions `json:"Dimensions,omitempty" gorm:"embedded;embeddedPrefix:dim_" odata:"nullable"`
@@ -312,11 +353,11 @@ func GetSampleProducts() []Product {
 			Quantity:        1200,
 			Weight:          3.14,
 			Data:            []byte("test"),
-			ReleaseDate:     stringPtr("2024-01-15"),
-			OpenTime:        stringPtr("09:30:00"),
-			ShippingTime:    stringPtr("P1D"),
-			ProcessingTime:  stringPtr("PT45S"),
-			Offset:          stringPtr("P0D"),
+			ReleaseDate:     releaseDatePtr("2024-01-15"),
+			OpenTime:        timeOfDayPtr("09:30:00"),
+			ShippingTime:    durationPtr("P1D"),
+			ProcessingTime:  durationPtr("PT45S"),
+			Offset:          durationPtr("P0D"),
 			CategoryID:      nil, // Will be set during seeding after categories are created
 			Status:          ProductStatusInStock | ProductStatusFeatured,
 			Version:         1,
@@ -349,11 +390,11 @@ func GetSampleProducts() []Product {
 			Quantity:       300,
 			Weight:         0.09,
 			Data:           []byte{0x01, 0x02, 0x03},
-			ReleaseDate:    stringPtr("2024-01-20"),
-			OpenTime:       stringPtr("08:15:00"),
-			ShippingTime:   stringPtr("PT2H"),
-			ProcessingTime: stringPtr("PT1.5S"),
-			Offset:         stringPtr("-P1D"),
+			ReleaseDate:    releaseDatePtr("2024-01-20"),
+			OpenTime:       timeOfDayPtr("08:15:00"),
+			ShippingTime:   durationPtr("PT2H"),
+			ProcessingTime: durationPtr("PT1.5S"),
+			Offset:         durationPtr("-P1D"),
 			CategoryID:     nil,                                        // Will be set during seeding
 			Status:         ProductStatusInStock | ProductStatusOnSale, // In stock and on sale
 			Version:        1,
@@ -384,11 +425,11 @@ func GetSampleProducts() []Product {
 			Quantity:       -200,
 			Weight:         0.0,
 			Data:           []byte{},
-			ReleaseDate:    stringPtr("2024-01-01"),
-			OpenTime:       stringPtr("00:00:00"),
-			ShippingTime:   stringPtr("P2D"),
-			ProcessingTime: stringPtr("PT30M"),
-			Offset:         stringPtr("P0D"),
+			ReleaseDate:    releaseDatePtr("2024-01-01"),
+			OpenTime:       timeOfDayPtr("00:00:00"),
+			ShippingTime:   durationPtr("P2D"),
+			ProcessingTime: durationPtr("PT30M"),
+			Offset:         durationPtr("P0D"),
 			CategoryID:     nil,                  // Will be set during seeding
 			Status:         ProductStatusInStock, // Only in stock
 			Version:        1,
@@ -418,11 +459,11 @@ func GetSampleProducts() []Product {
 			Temperature:    127,
 			Quantity:       32767,
 			Weight:         150.0,
-			ReleaseDate:    stringPtr("2024-12-31"),
-			OpenTime:       stringPtr("23:59:59"),
-			ShippingTime:   stringPtr("P1DT2H30M"),
-			ProcessingTime: stringPtr("PT45S"),
-			Offset:         stringPtr("P0D"),
+			ReleaseDate:    releaseDatePtr("2024-12-31"),
+			OpenTime:       timeOfDayPtr("23:59:59"),
+			ShippingTime:   durationPtr("P1DT2H30M"),
+			ProcessingTime: durationPtr("PT45S"),
+			Offset:         durationPtr("P0D"),
 			CategoryID:     nil,                       // Will be set during seeding
 			Status:         ProductStatusDiscontinued, // Discontinued
 			Version:        1,

--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -128,6 +128,12 @@ type PropertyMetadata struct {
 	// TypeDefinition properties
 	IsTypeDefinition   bool   // True if this property uses a registered TypeDefinition
 	TypeDefinitionName string // OData name of the TypeDefinition (for metadata generation)
+	// EdmType is the resolved EDM primitive type (e.g. "Edm.String", "Edm.Date",
+	// "Edm.Duration") for this property, honoring a registered TypeDefinition's
+	// UnderlyingType where present. Used by $filter to type-check literals and
+	// function arguments against the property's declared type rather than just
+	// its Go reflect.Kind. Empty for navigation properties and complex types.
+	EdmType string
 	// Binary properties
 	ContentType string // MIME type for binary properties (e.g., "image/svg+xml"), used when serving /$value
 	// Stream properties
@@ -495,15 +501,31 @@ func analyzeField(field reflect.StructField, metadata *EntityMetadata) (Property
 
 	// Auto-detect TypeDefinition: if the field type (or its element after deref) is registered
 	// as a TypeDefinition and the property is not already an enum, mark it accordingly.
+	fieldType := field.Type
+	for fieldType.Kind() == reflect.Ptr {
+		fieldType = fieldType.Elem()
+	}
+	var typeDefInfo *TypeDefinitionInfo
 	if !property.IsEnum && !property.IsTypeDefinition {
-		fieldType := field.Type
-		for fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
 		if tdInfo, ok := GetTypeDefinition(fieldType); ok {
 			property.IsTypeDefinition = true
 			if property.TypeDefinitionName == "" {
 				property.TypeDefinitionName = tdInfo.Name
+			}
+			typeDefInfo = tdInfo
+		}
+	}
+
+	// Resolve the property's EDM primitive type. A registered TypeDefinition's
+	// UnderlyingType takes precedence over the type inferred from the Go field
+	// type, so a string-backed field can be declared e.g. Edm.Date instead of
+	// defaulting to Edm.String.
+	if !property.IsNavigationProp && !property.IsComplexType && !property.IsUntyped {
+		if typeDefInfo != nil {
+			property.EdmType = typeDefInfo.UnderlyingType
+		} else if !property.IsEnum {
+			if edmType, err := inferUnderlyingEdmType(fieldType); err == nil {
+				property.EdmType = edmType
 			}
 		}
 	}

--- a/internal/query/ast_parser_functions.go
+++ b/internal/query/ast_parser_functions.go
@@ -173,11 +173,55 @@ func convertSingleArgFunctionWithContext(n *FunctionCallExpr, functionName strin
 		return nil, err
 	}
 
+	if entityMetadata != nil {
+		if err := validateDateTimeFunctionArgType(functionName, property, entityMetadata); err != nil {
+			return nil, err
+		}
+	}
+
 	expr := acquireFilterExpression()
 	expr.Property = property
 	expr.Operator = FilterOperator(functionName)
 	expr.Value = nil
 	return expr, nil
+}
+
+// dateTimeFunctionCompatibleEdmTypes maps each date/time-extraction function to the
+// set of EDM primitive types its argument may be declared as. Per OData Protocol
+// §11.2.5.1, these functions only apply to Edm.Date/Edm.TimeOfDay/Edm.DateTimeOffset/
+// Edm.Duration values - applying them to e.g. an Edm.String property is a type error.
+var dateTimeFunctionCompatibleEdmTypes = map[string]map[string]bool{
+	"year":               {"Edm.Date": true, "Edm.DateTimeOffset": true},
+	"month":              {"Edm.Date": true, "Edm.DateTimeOffset": true},
+	"day":                {"Edm.Date": true, "Edm.DateTimeOffset": true},
+	"hour":               {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
+	"minute":             {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
+	"second":             {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
+	"fractionalseconds":  {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
+	"date":               {"Edm.Date": true, "Edm.DateTimeOffset": true},
+	"time":               {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
+	"totaloffsetminutes": {"Edm.DateTimeOffset": true},
+	"totalseconds":       {"Edm.Duration": true},
+}
+
+// validateDateTimeFunctionArgType rejects date/time-extraction functions applied to a
+// property whose declared EDM type (honoring a registered TypeDefinition's
+// UnderlyingType, see metadata.PropertyMetadata.EdmType) isn't a compatible temporal
+// type. Properties without a resolvable EDM type (computed aliases, complex types,
+// navigation paths) are left unvalidated.
+func validateDateTimeFunctionArgType(functionName, property string, entityMetadata *metadata.EntityMetadata) error {
+	compatible, ok := dateTimeFunctionCompatibleEdmTypes[functionName]
+	if !ok {
+		return nil
+	}
+	prop := entityMetadata.FindProperty(property)
+	if prop == nil || prop.EdmType == "" {
+		return nil
+	}
+	if !compatible[prop.EdmType] {
+		return fmt.Errorf("type mismatch: function %s cannot be applied to property '%s' of type %s", functionName, property, prop.EdmType)
+	}
+	return nil
 }
 
 // isLikeMatchFunction reports whether functionName is one of contains, startswith,

--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -293,7 +293,11 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 		// Validate that all values in the IN collection match the property type (OData v4 spec compliance)
 		if entityMetadata != nil {
 			for i, val := range values {
-				if err := validateValueAgainstPropertyType(property, val, entityMetadata); err != nil {
+				var literalType string
+				if lit, ok := collExpr.Values[i].(*LiteralExpr); ok {
+					literalType = lit.Type
+				}
+				if err := validateValueAgainstPropertyType(property, val, literalType, entityMetadata); err != nil {
 					return nil, fmt.Errorf("IN clause value at index %d: %w", i, err)
 				}
 			}
@@ -333,7 +337,11 @@ func convertComparisonExprWithContext(n *ComparisonExpr, ctx *conversionContext)
 	// Check for Int64 overflow
 	// Per OData v4 spec, numeric literals that overflow the target integer type should be rejected
 	if entityMetadata != nil {
-		if err := validateValueAgainstPropertyType(property, value, entityMetadata); err != nil {
+		var literalType string
+		if lit, ok := n.Right.(*LiteralExpr); ok {
+			literalType = lit.Type
+		}
+		if err := validateValueAgainstPropertyType(property, value, literalType, entityMetadata); err != nil {
 			return nil, err
 		}
 	}
@@ -378,15 +386,35 @@ func resolveEnumMemberName(enumLiteral string, property string, entityMetadata *
 	return 0, fmt.Errorf("enum member %q not found for property %q", memberName, property)
 }
 
+// dateTimeLiteralCompatibleEdmTypes maps each OData literal type parsed from a
+// dedicated ABNF production (date, time, datetime, duration, guid - as opposed to
+// the generic "string"/"number" literal types) to the set of EDM primitive types
+// it may be compared against. Unlike the Go-reflect-based checks below, these
+// literal types are unambiguous at parse time, so a mismatch here is a genuine
+// client error per OData Protocol §11.2.5.1.
+var dateTimeLiteralCompatibleEdmTypes = map[string]map[string]bool{
+	"date":     {"Edm.Date": true, "Edm.DateTimeOffset": true},
+	"time":     {"Edm.TimeOfDay": true},
+	"datetime": {"Edm.DateTimeOffset": true},
+	"duration": {"Edm.Duration": true},
+	"guid":     {"Edm.Guid": true},
+}
+
 // validateValueAgainstPropertyType validates that a filter value is appropriate for the target property type.
 // Returns an error if the value would overflow or is incompatible with the property type.
 // Note: If the value is a property name (for property-to-property comparisons), validation is skipped.
-func validateValueAgainstPropertyType(property string, value interface{}, entityMetadata *metadata.EntityMetadata) error {
+func validateValueAgainstPropertyType(property string, value interface{}, literalType string, entityMetadata *metadata.EntityMetadata) error {
 	// Get property metadata
 	prop := entityMetadata.FindProperty(property)
 	if prop == nil {
 		// Property might be a navigation path or computed property - skip validation
 		return nil
+	}
+
+	if compatible, ok := dateTimeLiteralCompatibleEdmTypes[literalType]; ok && prop.EdmType != "" {
+		if !compatible[prop.EdmType] {
+			return fmt.Errorf("type mismatch: %s literal cannot be compared to property '%s' of type %s", literalType, property, prop.EdmType)
+		}
 	}
 
 	// Get the property's Go type (handling pointers)

--- a/internal/query/cast_functions_test.go
+++ b/internal/query/cast_functions_test.go
@@ -466,7 +466,7 @@ func TestCastFunction_WithOtherFunctions(t *testing.T) {
 		},
 		{
 			name:      "cast with year",
-			filter:    "year(Name) eq 2023 and cast(Price, 'Edm.Int32') gt 50",
+			filter:    "year(CreatedAt) eq 2023 and cast(Price, 'Edm.Int32') gt 50",
 			expectErr: false,
 		},
 	}

--- a/internal/query/date_functions_test.go
+++ b/internal/query/date_functions_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -10,11 +11,27 @@ import (
 	"gorm.io/gorm"
 )
 
+// ISO8601Duration is a string alias registered as an OData TypeDefinition with
+// underlying type Edm.Duration, so $filter type-checking recognizes properties
+// backed by ISO-8601 duration strings (e.g. "P1D", "PT2H") as genuinely
+// Edm.Duration rather than Edm.String.
+type ISO8601Duration string
+
+func init() {
+	if err := metadata.RegisterTypeDefinition(reflect.TypeOf(ISO8601Duration("")), metadata.TypeDefinitionInfo{
+		Name:           "ISO8601Duration",
+		UnderlyingType: "Edm.Duration",
+	}); err != nil {
+		panic(err)
+	}
+}
+
 // TestEntity with date field for date function tests
 type TestEntityWithDate struct {
-	ID        int       `json:"ID" odata:"key"`
-	Name      string    `json:"Name"`
-	CreatedAt time.Time `json:"CreatedAt"`
+	ID               int             `json:"ID" odata:"key"`
+	Name             string          `json:"Name"`
+	CreatedAt        time.Time       `json:"CreatedAt"`
+	ShippingDuration ISO8601Duration `json:"ShippingDuration"`
 }
 
 func getTestMetadataWithDate(t *testing.T) *metadata.EntityMetadata {
@@ -53,6 +70,13 @@ func TestDateFunctions_Year(t *testing.T) {
 			filter:    "year(CreatedAt, 2024) eq 2024",
 			expectErr: true,
 		},
+		{
+			// Regression test for issue #800: year() must be rejected against a
+			// genuinely Edm.String property instead of silently matching nothing.
+			name:      "year against Edm.String property is rejected",
+			filter:    "year(Name) eq 2024",
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -86,6 +110,31 @@ func TestDateFunctions_Year(t *testing.T) {
 				t.Error("Expected non-nil FilterExpression")
 			}
 		})
+	}
+}
+
+// TestDateLiteralAgainstStringProperty is a regression test for issue #800: an
+// unquoted date-shaped literal (parsed via the dedicated ABNF date production, as
+// opposed to a quoted string literal) must be rejected when compared to a property
+// genuinely declared Edm.String, instead of silently matching nothing.
+func TestDateLiteralAgainstStringProperty(t *testing.T) {
+	meta := getTestMetadataWithDate(t)
+
+	tokenizer := NewTokenizer("Name eq 2024-01-15")
+	tokens, err := tokenizer.TokenizeAll()
+	if err != nil {
+		t.Fatalf("Tokenization failed: %v", err)
+	}
+
+	parser := NewASTParser(tokens)
+	ast, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Parsing failed: %v", err)
+	}
+	defer ReleaseASTNode(ast)
+
+	if _, err := ASTToFilterExpression(ast, meta); err == nil {
+		t.Error("expected type mismatch error comparing a date literal to an Edm.String property, got nil")
 	}
 }
 
@@ -652,47 +701,47 @@ func TestDateFunctions_SQLGeneration(t *testing.T) {
 		},
 		{
 			name:      "totalseconds SQL",
-			filter:    "totalseconds(CreatedAt) gt 3600",
+			filter:    "totalseconds(ShippingDuration) gt 3600",
 			expectErr: false,
 			// The SQLite expression parses ISO 8601 duration strings into total seconds.
 			// 3-branch CASE: NULL, positive 'P%', negative '-P%'.
-			expectedSQL: "CASE WHEN \"created_at\" IS NULL THEN NULL WHEN \"created_at\" LIKE 'P%' THEN (" +
-				"CAST(CASE WHEN INSTR(\"created_at\",'D')>0 AND (INSTR(\"created_at\",'T')=0 OR INSTR(\"created_at\",'D')<INSTR(\"created_at\",'T'))" +
-				" THEN SUBSTR(\"created_at\",2,INSTR(\"created_at\",'D')-2) ELSE 0 END AS INTEGER)*86400" +
-				"+CAST(CASE WHEN INSTR(\"created_at\",'T')>0 AND INSTR(\"created_at\",'H')>INSTR(\"created_at\",'T')" +
-				" THEN SUBSTR(\"created_at\",INSTR(\"created_at\",'T')+1,INSTR(\"created_at\",'H')-INSTR(\"created_at\",'T')-1) ELSE 0 END AS INTEGER)*3600" +
-				"+CAST(CASE WHEN INSTR(\"created_at\",'T')>0 AND INSTR(SUBSTR(\"created_at\",INSTR(\"created_at\",'T')+1),'M')>0" +
-				" THEN SUBSTR(\"created_at\"," +
-				"CASE WHEN INSTR(\"created_at\",'H')>INSTR(\"created_at\",'T') THEN INSTR(\"created_at\",'H')+1 ELSE INSTR(\"created_at\",'T')+1 END," +
-				"INSTR(\"created_at\",'T')+INSTR(SUBSTR(\"created_at\",INSTR(\"created_at\",'T')+1),'M')-1" +
-				"-CASE WHEN INSTR(\"created_at\",'H')>INSTR(\"created_at\",'T') THEN INSTR(\"created_at\",'H') ELSE INSTR(\"created_at\",'T') END)" +
+			expectedSQL: "CASE WHEN \"shipping_duration\" IS NULL THEN NULL WHEN \"shipping_duration\" LIKE 'P%' THEN (" +
+				"CAST(CASE WHEN INSTR(\"shipping_duration\",'D')>0 AND (INSTR(\"shipping_duration\",'T')=0 OR INSTR(\"shipping_duration\",'D')<INSTR(\"shipping_duration\",'T'))" +
+				" THEN SUBSTR(\"shipping_duration\",2,INSTR(\"shipping_duration\",'D')-2) ELSE 0 END AS INTEGER)*86400" +
+				"+CAST(CASE WHEN INSTR(\"shipping_duration\",'T')>0 AND INSTR(\"shipping_duration\",'H')>INSTR(\"shipping_duration\",'T')" +
+				" THEN SUBSTR(\"shipping_duration\",INSTR(\"shipping_duration\",'T')+1,INSTR(\"shipping_duration\",'H')-INSTR(\"shipping_duration\",'T')-1) ELSE 0 END AS INTEGER)*3600" +
+				"+CAST(CASE WHEN INSTR(\"shipping_duration\",'T')>0 AND INSTR(SUBSTR(\"shipping_duration\",INSTR(\"shipping_duration\",'T')+1),'M')>0" +
+				" THEN SUBSTR(\"shipping_duration\"," +
+				"CASE WHEN INSTR(\"shipping_duration\",'H')>INSTR(\"shipping_duration\",'T') THEN INSTR(\"shipping_duration\",'H')+1 ELSE INSTR(\"shipping_duration\",'T')+1 END," +
+				"INSTR(\"shipping_duration\",'T')+INSTR(SUBSTR(\"shipping_duration\",INSTR(\"shipping_duration\",'T')+1),'M')-1" +
+				"-CASE WHEN INSTR(\"shipping_duration\",'H')>INSTR(\"shipping_duration\",'T') THEN INSTR(\"shipping_duration\",'H') ELSE INSTR(\"shipping_duration\",'T') END)" +
 				" ELSE 0 END AS INTEGER)*60" +
-				"+CAST(CASE WHEN INSTR(\"created_at\",'T')>0 AND INSTR(\"created_at\",'S')>INSTR(\"created_at\",'T')" +
-				" THEN SUBSTR(\"created_at\"," +
-				"CASE WHEN INSTR(SUBSTR(\"created_at\",INSTR(\"created_at\",'T')+1),'M')>0 THEN INSTR(\"created_at\",'T')+INSTR(SUBSTR(\"created_at\",INSTR(\"created_at\",'T')+1),'M')+1" +
-				" WHEN INSTR(\"created_at\",'H')>INSTR(\"created_at\",'T') THEN INSTR(\"created_at\",'H')+1 ELSE INSTR(\"created_at\",'T')+1 END," +
-				"INSTR(\"created_at\",'S')" +
-				"-CASE WHEN INSTR(SUBSTR(\"created_at\",INSTR(\"created_at\",'T')+1),'M')>0 THEN INSTR(\"created_at\",'T')+INSTR(SUBSTR(\"created_at\",INSTR(\"created_at\",'T')+1),'M')" +
-				" WHEN INSTR(\"created_at\",'H')>INSTR(\"created_at\",'T') THEN INSTR(\"created_at\",'H') ELSE INSTR(\"created_at\",'T') END-1)" +
+				"+CAST(CASE WHEN INSTR(\"shipping_duration\",'T')>0 AND INSTR(\"shipping_duration\",'S')>INSTR(\"shipping_duration\",'T')" +
+				" THEN SUBSTR(\"shipping_duration\"," +
+				"CASE WHEN INSTR(SUBSTR(\"shipping_duration\",INSTR(\"shipping_duration\",'T')+1),'M')>0 THEN INSTR(\"shipping_duration\",'T')+INSTR(SUBSTR(\"shipping_duration\",INSTR(\"shipping_duration\",'T')+1),'M')+1" +
+				" WHEN INSTR(\"shipping_duration\",'H')>INSTR(\"shipping_duration\",'T') THEN INSTR(\"shipping_duration\",'H')+1 ELSE INSTR(\"shipping_duration\",'T')+1 END," +
+				"INSTR(\"shipping_duration\",'S')" +
+				"-CASE WHEN INSTR(SUBSTR(\"shipping_duration\",INSTR(\"shipping_duration\",'T')+1),'M')>0 THEN INSTR(\"shipping_duration\",'T')+INSTR(SUBSTR(\"shipping_duration\",INSTR(\"shipping_duration\",'T')+1),'M')" +
+				" WHEN INSTR(\"shipping_duration\",'H')>INSTR(\"shipping_duration\",'T') THEN INSTR(\"shipping_duration\",'H') ELSE INSTR(\"shipping_duration\",'T') END-1)" +
 				" ELSE '0' END AS REAL))" +
-				" WHEN \"created_at\" LIKE '-P%' THEN -1.0*(" +
-				"CAST(CASE WHEN INSTR(SUBSTR(\"created_at\",2),'D')>0 AND (INSTR(SUBSTR(\"created_at\",2),'T')=0 OR INSTR(SUBSTR(\"created_at\",2),'D')<INSTR(SUBSTR(\"created_at\",2),'T'))" +
-				" THEN SUBSTR(SUBSTR(\"created_at\",2),2,INSTR(SUBSTR(\"created_at\",2),'D')-2) ELSE 0 END AS INTEGER)*86400" +
-				"+CAST(CASE WHEN INSTR(SUBSTR(\"created_at\",2),'T')>0 AND INSTR(SUBSTR(\"created_at\",2),'H')>INSTR(SUBSTR(\"created_at\",2),'T')" +
-				" THEN SUBSTR(SUBSTR(\"created_at\",2),INSTR(SUBSTR(\"created_at\",2),'T')+1,INSTR(SUBSTR(\"created_at\",2),'H')-INSTR(SUBSTR(\"created_at\",2),'T')-1) ELSE 0 END AS INTEGER)*3600" +
-				"+CAST(CASE WHEN INSTR(SUBSTR(\"created_at\",2),'T')>0 AND INSTR(SUBSTR(SUBSTR(\"created_at\",2),INSTR(SUBSTR(\"created_at\",2),'T')+1),'M')>0" +
-				" THEN SUBSTR(SUBSTR(\"created_at\",2)," +
-				"CASE WHEN INSTR(SUBSTR(\"created_at\",2),'H')>INSTR(SUBSTR(\"created_at\",2),'T') THEN INSTR(SUBSTR(\"created_at\",2),'H')+1 ELSE INSTR(SUBSTR(\"created_at\",2),'T')+1 END," +
-				"INSTR(SUBSTR(\"created_at\",2),'T')+INSTR(SUBSTR(SUBSTR(\"created_at\",2),INSTR(SUBSTR(\"created_at\",2),'T')+1),'M')-1" +
-				"-CASE WHEN INSTR(SUBSTR(\"created_at\",2),'H')>INSTR(SUBSTR(\"created_at\",2),'T') THEN INSTR(SUBSTR(\"created_at\",2),'H') ELSE INSTR(SUBSTR(\"created_at\",2),'T') END)" +
+				" WHEN \"shipping_duration\" LIKE '-P%' THEN -1.0*(" +
+				"CAST(CASE WHEN INSTR(SUBSTR(\"shipping_duration\",2),'D')>0 AND (INSTR(SUBSTR(\"shipping_duration\",2),'T')=0 OR INSTR(SUBSTR(\"shipping_duration\",2),'D')<INSTR(SUBSTR(\"shipping_duration\",2),'T'))" +
+				" THEN SUBSTR(SUBSTR(\"shipping_duration\",2),2,INSTR(SUBSTR(\"shipping_duration\",2),'D')-2) ELSE 0 END AS INTEGER)*86400" +
+				"+CAST(CASE WHEN INSTR(SUBSTR(\"shipping_duration\",2),'T')>0 AND INSTR(SUBSTR(\"shipping_duration\",2),'H')>INSTR(SUBSTR(\"shipping_duration\",2),'T')" +
+				" THEN SUBSTR(SUBSTR(\"shipping_duration\",2),INSTR(SUBSTR(\"shipping_duration\",2),'T')+1,INSTR(SUBSTR(\"shipping_duration\",2),'H')-INSTR(SUBSTR(\"shipping_duration\",2),'T')-1) ELSE 0 END AS INTEGER)*3600" +
+				"+CAST(CASE WHEN INSTR(SUBSTR(\"shipping_duration\",2),'T')>0 AND INSTR(SUBSTR(SUBSTR(\"shipping_duration\",2),INSTR(SUBSTR(\"shipping_duration\",2),'T')+1),'M')>0" +
+				" THEN SUBSTR(SUBSTR(\"shipping_duration\",2)," +
+				"CASE WHEN INSTR(SUBSTR(\"shipping_duration\",2),'H')>INSTR(SUBSTR(\"shipping_duration\",2),'T') THEN INSTR(SUBSTR(\"shipping_duration\",2),'H')+1 ELSE INSTR(SUBSTR(\"shipping_duration\",2),'T')+1 END," +
+				"INSTR(SUBSTR(\"shipping_duration\",2),'T')+INSTR(SUBSTR(SUBSTR(\"shipping_duration\",2),INSTR(SUBSTR(\"shipping_duration\",2),'T')+1),'M')-1" +
+				"-CASE WHEN INSTR(SUBSTR(\"shipping_duration\",2),'H')>INSTR(SUBSTR(\"shipping_duration\",2),'T') THEN INSTR(SUBSTR(\"shipping_duration\",2),'H') ELSE INSTR(SUBSTR(\"shipping_duration\",2),'T') END)" +
 				" ELSE 0 END AS INTEGER)*60" +
-				"+CAST(CASE WHEN INSTR(SUBSTR(\"created_at\",2),'T')>0 AND INSTR(SUBSTR(\"created_at\",2),'S')>INSTR(SUBSTR(\"created_at\",2),'T')" +
-				" THEN SUBSTR(SUBSTR(\"created_at\",2)," +
-				"CASE WHEN INSTR(SUBSTR(SUBSTR(\"created_at\",2),INSTR(SUBSTR(\"created_at\",2),'T')+1),'M')>0 THEN INSTR(SUBSTR(\"created_at\",2),'T')+INSTR(SUBSTR(SUBSTR(\"created_at\",2),INSTR(SUBSTR(\"created_at\",2),'T')+1),'M')+1" +
-				" WHEN INSTR(SUBSTR(\"created_at\",2),'H')>INSTR(SUBSTR(\"created_at\",2),'T') THEN INSTR(SUBSTR(\"created_at\",2),'H')+1 ELSE INSTR(SUBSTR(\"created_at\",2),'T')+1 END," +
-				"INSTR(SUBSTR(\"created_at\",2),'S')" +
-				"-CASE WHEN INSTR(SUBSTR(SUBSTR(\"created_at\",2),INSTR(SUBSTR(\"created_at\",2),'T')+1),'M')>0 THEN INSTR(SUBSTR(\"created_at\",2),'T')+INSTR(SUBSTR(SUBSTR(\"created_at\",2),INSTR(SUBSTR(\"created_at\",2),'T')+1),'M')" +
-				" WHEN INSTR(SUBSTR(\"created_at\",2),'H')>INSTR(SUBSTR(\"created_at\",2),'T') THEN INSTR(SUBSTR(\"created_at\",2),'H') ELSE INSTR(SUBSTR(\"created_at\",2),'T') END-1)" +
+				"+CAST(CASE WHEN INSTR(SUBSTR(\"shipping_duration\",2),'T')>0 AND INSTR(SUBSTR(\"shipping_duration\",2),'S')>INSTR(SUBSTR(\"shipping_duration\",2),'T')" +
+				" THEN SUBSTR(SUBSTR(\"shipping_duration\",2)," +
+				"CASE WHEN INSTR(SUBSTR(SUBSTR(\"shipping_duration\",2),INSTR(SUBSTR(\"shipping_duration\",2),'T')+1),'M')>0 THEN INSTR(SUBSTR(\"shipping_duration\",2),'T')+INSTR(SUBSTR(SUBSTR(\"shipping_duration\",2),INSTR(SUBSTR(\"shipping_duration\",2),'T')+1),'M')+1" +
+				" WHEN INSTR(SUBSTR(\"shipping_duration\",2),'H')>INSTR(SUBSTR(\"shipping_duration\",2),'T') THEN INSTR(SUBSTR(\"shipping_duration\",2),'H')+1 ELSE INSTR(SUBSTR(\"shipping_duration\",2),'T')+1 END," +
+				"INSTR(SUBSTR(\"shipping_duration\",2),'S')" +
+				"-CASE WHEN INSTR(SUBSTR(SUBSTR(\"shipping_duration\",2),INSTR(SUBSTR(\"shipping_duration\",2),'T')+1),'M')>0 THEN INSTR(SUBSTR(\"shipping_duration\",2),'T')+INSTR(SUBSTR(SUBSTR(\"shipping_duration\",2),INSTR(SUBSTR(\"shipping_duration\",2),'T')+1),'M')" +
+				" WHEN INSTR(SUBSTR(\"shipping_duration\",2),'H')>INSTR(SUBSTR(\"shipping_duration\",2),'T') THEN INSTR(SUBSTR(\"shipping_duration\",2),'H') ELSE INSTR(SUBSTR(\"shipping_duration\",2),'T') END-1)" +
 				" ELSE '0' END AS REAL)) ELSE NULL END > ?",
 			expectedArgsNo: 1,
 		},
@@ -772,10 +821,10 @@ func TestDateFunctions_SQLGenerationSQLServer(t *testing.T) {
 		},
 		{
 			name:   "totalseconds SQL Server",
-			filter: "totalseconds(CreatedAt) gt 3600",
+			filter: "totalseconds(ShippingDuration) gt 3600",
 			// Edm.Duration is an ISO-8601 string; SQL Server parses it with CHARINDEX/SUBSTRING.
 			// 3-branch CASE: NULL, positive 'P%', negative '-P%'.
-			expectedSQL:    "CASE WHEN [created_at] IS NULL THEN NULL WHEN [created_at] LIKE 'P%' THEN (CAST(CASE WHEN CHARINDEX('D',[created_at])>0 AND (CHARINDEX('T',[created_at])=0 OR CHARINDEX('D',[created_at])<CHARINDEX('T',[created_at])) THEN SUBSTRING([created_at],2,CHARINDEX('D',[created_at])-2) ELSE 0 END AS INT)*86400+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,CHARINDEX('H',[created_at])-CHARINDEX('T',[created_at])-1) ELSE 0 END AS INT)*3600+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN SUBSTRING([created_at],CASE WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at])+1 ELSE CHARINDEX('T',[created_at])+1 END,CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))-1-CASE WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at]) ELSE CHARINDEX('T',[created_at]) END) ELSE 0 END AS INT)*60+CAST(CASE WHEN CHARINDEX('T',[created_at])>0 AND CHARINDEX('S',[created_at])>CHARINDEX('T',[created_at]) THEN SUBSTRING([created_at],CASE WHEN CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))+1 WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at])+1 ELSE CHARINDEX('T',[created_at])+1 END,CHARINDEX('S',[created_at])-CASE WHEN CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000))>0 THEN CHARINDEX('T',[created_at])+CHARINDEX('M',SUBSTRING([created_at],CHARINDEX('T',[created_at])+1,8000)) WHEN CHARINDEX('H',[created_at])>CHARINDEX('T',[created_at]) THEN CHARINDEX('H',[created_at]) ELSE CHARINDEX('T',[created_at]) END-1) ELSE '0' END AS FLOAT)) WHEN [created_at] LIKE '-P%' THEN -1.0*(CAST(CASE WHEN CHARINDEX('D',SUBSTRING([created_at],2,8000))>0 AND (CHARINDEX('T',SUBSTRING([created_at],2,8000))=0 OR CHARINDEX('D',SUBSTRING([created_at],2,8000))<CHARINDEX('T',SUBSTRING([created_at],2,8000))) THEN SUBSTRING(SUBSTRING([created_at],2,8000),2,CHARINDEX('D',SUBSTRING([created_at],2,8000))-2) ELSE 0 END AS INT)*86400+CAST(CASE WHEN CHARINDEX('T',SUBSTRING([created_at],2,8000))>0 AND CHARINDEX('H',SUBSTRING([created_at],2,8000))>CHARINDEX('T',SUBSTRING([created_at],2,8000)) THEN SUBSTRING(SUBSTRING([created_at],2,8000),CHARINDEX('T',SUBSTRING([created_at],2,8000))+1,CHARINDEX('H',SUBSTRING([created_at],2,8000))-CHARINDEX('T',SUBSTRING([created_at],2,8000))-1) ELSE 0 END AS INT)*3600+CAST(CASE WHEN CHARINDEX('T',SUBSTRING([created_at],2,8000))>0 AND CHARINDEX('M',SUBSTRING(SUBSTRING([created_at],2,8000),CHARINDEX('T',SUBSTRING([created_at],2,8000))+1,8000))>0 THEN SUBSTRING(SUBSTRING([created_at],2,8000),CASE WHEN CHARINDEX('H',SUBSTRING([created_at],2,8000))>CHARINDEX('T',SUBSTRING([created_at],2,8000)) THEN CHARINDEX('H',SUBSTRING([created_at],2,8000))+1 ELSE CHARINDEX('T',SUBSTRING([created_at],2,8000))+1 END,CHARINDEX('T',SUBSTRING([created_at],2,8000))+CHARINDEX('M',SUBSTRING(SUBSTRING([created_at],2,8000),CHARINDEX('T',SUBSTRING([created_at],2,8000))+1,8000))-1-CASE WHEN CHARINDEX('H',SUBSTRING([created_at],2,8000))>CHARINDEX('T',SUBSTRING([created_at],2,8000)) THEN CHARINDEX('H',SUBSTRING([created_at],2,8000)) ELSE CHARINDEX('T',SUBSTRING([created_at],2,8000)) END) ELSE 0 END AS INT)*60+CAST(CASE WHEN CHARINDEX('T',SUBSTRING([created_at],2,8000))>0 AND CHARINDEX('S',SUBSTRING([created_at],2,8000))>CHARINDEX('T',SUBSTRING([created_at],2,8000)) THEN SUBSTRING(SUBSTRING([created_at],2,8000),CASE WHEN CHARINDEX('M',SUBSTRING(SUBSTRING([created_at],2,8000),CHARINDEX('T',SUBSTRING([created_at],2,8000))+1,8000))>0 THEN CHARINDEX('T',SUBSTRING([created_at],2,8000))+CHARINDEX('M',SUBSTRING(SUBSTRING([created_at],2,8000),CHARINDEX('T',SUBSTRING([created_at],2,8000))+1,8000))+1 WHEN CHARINDEX('H',SUBSTRING([created_at],2,8000))>CHARINDEX('T',SUBSTRING([created_at],2,8000)) THEN CHARINDEX('H',SUBSTRING([created_at],2,8000))+1 ELSE CHARINDEX('T',SUBSTRING([created_at],2,8000))+1 END,CHARINDEX('S',SUBSTRING([created_at],2,8000))-CASE WHEN CHARINDEX('M',SUBSTRING(SUBSTRING([created_at],2,8000),CHARINDEX('T',SUBSTRING([created_at],2,8000))+1,8000))>0 THEN CHARINDEX('T',SUBSTRING([created_at],2,8000))+CHARINDEX('M',SUBSTRING(SUBSTRING([created_at],2,8000),CHARINDEX('T',SUBSTRING([created_at],2,8000))+1,8000)) WHEN CHARINDEX('H',SUBSTRING([created_at],2,8000))>CHARINDEX('T',SUBSTRING([created_at],2,8000)) THEN CHARINDEX('H',SUBSTRING([created_at],2,8000)) ELSE CHARINDEX('T',SUBSTRING([created_at],2,8000)) END-1) ELSE '0' END AS FLOAT)) ELSE NULL END > ?",
+			expectedSQL:    "CASE WHEN [shipping_duration] IS NULL THEN NULL WHEN [shipping_duration] LIKE 'P%' THEN (CAST(CASE WHEN CHARINDEX('D',[shipping_duration])>0 AND (CHARINDEX('T',[shipping_duration])=0 OR CHARINDEX('D',[shipping_duration])<CHARINDEX('T',[shipping_duration])) THEN SUBSTRING([shipping_duration],2,CHARINDEX('D',[shipping_duration])-2) ELSE 0 END AS INT)*86400+CAST(CASE WHEN CHARINDEX('T',[shipping_duration])>0 AND CHARINDEX('H',[shipping_duration])>CHARINDEX('T',[shipping_duration]) THEN SUBSTRING([shipping_duration],CHARINDEX('T',[shipping_duration])+1,CHARINDEX('H',[shipping_duration])-CHARINDEX('T',[shipping_duration])-1) ELSE 0 END AS INT)*3600+CAST(CASE WHEN CHARINDEX('T',[shipping_duration])>0 AND CHARINDEX('M',SUBSTRING([shipping_duration],CHARINDEX('T',[shipping_duration])+1,8000))>0 THEN SUBSTRING([shipping_duration],CASE WHEN CHARINDEX('H',[shipping_duration])>CHARINDEX('T',[shipping_duration]) THEN CHARINDEX('H',[shipping_duration])+1 ELSE CHARINDEX('T',[shipping_duration])+1 END,CHARINDEX('T',[shipping_duration])+CHARINDEX('M',SUBSTRING([shipping_duration],CHARINDEX('T',[shipping_duration])+1,8000))-1-CASE WHEN CHARINDEX('H',[shipping_duration])>CHARINDEX('T',[shipping_duration]) THEN CHARINDEX('H',[shipping_duration]) ELSE CHARINDEX('T',[shipping_duration]) END) ELSE 0 END AS INT)*60+CAST(CASE WHEN CHARINDEX('T',[shipping_duration])>0 AND CHARINDEX('S',[shipping_duration])>CHARINDEX('T',[shipping_duration]) THEN SUBSTRING([shipping_duration],CASE WHEN CHARINDEX('M',SUBSTRING([shipping_duration],CHARINDEX('T',[shipping_duration])+1,8000))>0 THEN CHARINDEX('T',[shipping_duration])+CHARINDEX('M',SUBSTRING([shipping_duration],CHARINDEX('T',[shipping_duration])+1,8000))+1 WHEN CHARINDEX('H',[shipping_duration])>CHARINDEX('T',[shipping_duration]) THEN CHARINDEX('H',[shipping_duration])+1 ELSE CHARINDEX('T',[shipping_duration])+1 END,CHARINDEX('S',[shipping_duration])-CASE WHEN CHARINDEX('M',SUBSTRING([shipping_duration],CHARINDEX('T',[shipping_duration])+1,8000))>0 THEN CHARINDEX('T',[shipping_duration])+CHARINDEX('M',SUBSTRING([shipping_duration],CHARINDEX('T',[shipping_duration])+1,8000)) WHEN CHARINDEX('H',[shipping_duration])>CHARINDEX('T',[shipping_duration]) THEN CHARINDEX('H',[shipping_duration]) ELSE CHARINDEX('T',[shipping_duration]) END-1) ELSE '0' END AS FLOAT)) WHEN [shipping_duration] LIKE '-P%' THEN -1.0*(CAST(CASE WHEN CHARINDEX('D',SUBSTRING([shipping_duration],2,8000))>0 AND (CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))=0 OR CHARINDEX('D',SUBSTRING([shipping_duration],2,8000))<CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))) THEN SUBSTRING(SUBSTRING([shipping_duration],2,8000),2,CHARINDEX('D',SUBSTRING([shipping_duration],2,8000))-2) ELSE 0 END AS INT)*86400+CAST(CASE WHEN CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))>0 AND CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))>CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) THEN SUBSTRING(SUBSTRING([shipping_duration],2,8000),CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1,CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))-CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))-1) ELSE 0 END AS INT)*3600+CAST(CASE WHEN CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))>0 AND CHARINDEX('M',SUBSTRING(SUBSTRING([shipping_duration],2,8000),CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1,8000))>0 THEN SUBSTRING(SUBSTRING([shipping_duration],2,8000),CASE WHEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))>CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) THEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))+1 ELSE CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1 END,CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+CHARINDEX('M',SUBSTRING(SUBSTRING([shipping_duration],2,8000),CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1,8000))-1-CASE WHEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))>CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) THEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000)) ELSE CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) END) ELSE 0 END AS INT)*60+CAST(CASE WHEN CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))>0 AND CHARINDEX('S',SUBSTRING([shipping_duration],2,8000))>CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) THEN SUBSTRING(SUBSTRING([shipping_duration],2,8000),CASE WHEN CHARINDEX('M',SUBSTRING(SUBSTRING([shipping_duration],2,8000),CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1,8000))>0 THEN CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+CHARINDEX('M',SUBSTRING(SUBSTRING([shipping_duration],2,8000),CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1,8000))+1 WHEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))>CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) THEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))+1 ELSE CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1 END,CHARINDEX('S',SUBSTRING([shipping_duration],2,8000))-CASE WHEN CHARINDEX('M',SUBSTRING(SUBSTRING([shipping_duration],2,8000),CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1,8000))>0 THEN CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+CHARINDEX('M',SUBSTRING(SUBSTRING([shipping_duration],2,8000),CHARINDEX('T',SUBSTRING([shipping_duration],2,8000))+1,8000)) WHEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000))>CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) THEN CHARINDEX('H',SUBSTRING([shipping_duration],2,8000)) ELSE CHARINDEX('T',SUBSTRING([shipping_duration],2,8000)) END-1) ELSE '0' END AS FLOAT)) ELSE NULL END > ?",
 			expectedArgsNo: 1,
 		},
 	}
@@ -931,9 +980,9 @@ func TestDateFunctions_TotalOffsetMinutes(t *testing.T) {
 }
 
 func TestDateFunctions_TotalSeconds(t *testing.T) {
-	// Note: totalseconds() per OData spec operates on Edm.Duration values.
-	// The test entity uses a time.Time (datetime) field for parsing validation;
-	// metadata type checking for argument types is not enforced at the query layer.
+	// totalseconds() per OData spec operates on Edm.Duration values, so the test
+	// uses the ShippingDuration field (declared Edm.Duration via a registered
+	// TypeDefinition, see ISO8601Duration above).
 	meta := getTestMetadataWithDate(t)
 
 	tests := []struct {
@@ -943,17 +992,17 @@ func TestDateFunctions_TotalSeconds(t *testing.T) {
 	}{
 		{
 			name:      "totalseconds simple",
-			filter:    "totalseconds(CreatedAt) gt 3600",
+			filter:    "totalseconds(ShippingDuration) gt 3600",
 			expectErr: false,
 		},
 		{
 			name:      "totalseconds eq zero",
-			filter:    "totalseconds(CreatedAt) eq 0",
+			filter:    "totalseconds(ShippingDuration) eq 0",
 			expectErr: false,
 		},
 		{
 			name:      "totalseconds wrong argument count",
-			filter:    "totalseconds(CreatedAt, 2024) gt 0",
+			filter:    "totalseconds(ShippingDuration, 2024) gt 0",
 			expectErr: true,
 		},
 	}
@@ -1091,8 +1140,8 @@ func TestDateFunctions_MinMaxDatetimeSQL(t *testing.T) {
 // duration strings stored as text in SQLite (e.g. "P1D", "PT2H", "P1DT2H30M").
 func TestTotalSecondsISO8601SQLite(t *testing.T) {
 	type DurationRow struct {
-		ID           int    `gorm:"primaryKey"`
-		ShippingTime string `gorm:"column:shipping_time"`
+		ID           int             `gorm:"primaryKey"`
+		ShippingTime ISO8601Duration `gorm:"column:shipping_time"`
 	}
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -1155,8 +1204,8 @@ func TestTotalSecondsISO8601SQLite(t *testing.T) {
 // rather than a raw string comparison (issue #736).
 func TestDurationDirectComparisonSQL(t *testing.T) {
 	type DurationRow struct {
-		ID           int    `gorm:"primaryKey"`
-		ShippingTime string `gorm:"column:shipping_time"`
+		ID           int             `gorm:"primaryKey"`
+		ShippingTime ISO8601Duration `gorm:"column:shipping_time"`
 	}
 
 	meta, err := metadata.AnalyzeEntity(DurationRow{})
@@ -1212,8 +1261,8 @@ func TestDurationDirectComparisonSQL(t *testing.T) {
 // This is the regression test for issue #736.
 func TestDurationDirectComparisonE2E(t *testing.T) {
 	type DurationRow struct {
-		ID           int    `gorm:"primaryKey"`
-		ShippingTime string `gorm:"column:shipping_time"`
+		ID           int             `gorm:"primaryKey"`
+		ShippingTime ISO8601Duration `gorm:"column:shipping_time"`
 	}
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})

--- a/internal/query/isof_functions_test.go
+++ b/internal/query/isof_functions_test.go
@@ -383,7 +383,7 @@ func TestIsOfFunction_WithOtherFunctions(t *testing.T) {
 		},
 		{
 			name:      "isof with year",
-			filter:    "year(Name) eq 2023 and isof(Price, 'Edm.Int32') eq true",
+			filter:    "year(CreatedAt) eq 2023 and isof(Price, 'Edm.Int32') eq true",
 			expectErr: false,
 		},
 		{

--- a/internal/query/math_functions_test.go
+++ b/internal/query/math_functions_test.go
@@ -271,7 +271,7 @@ func TestMathFunctions_Combined(t *testing.T) {
 		},
 		{
 			name:      "nested with date functions",
-			filter:    "round(Price) gt 50 and year(ID) eq 2024",
+			filter:    "round(Price) gt 50 and year(CreatedAt) eq 2024",
 			expectErr: false,
 		},
 		{

--- a/internal/query/parser_test.go
+++ b/internal/query/parser_test.go
@@ -3,16 +3,18 @@ package query
 import (
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/nlstn/go-odata/internal/metadata"
 )
 
 type TestEntity struct {
-	ID          int     `json:"ID" odata:"key"`
-	Name        string  `json:"Name"`
-	Description string  `json:"Description"`
-	Price       float64 `json:"Price"`
-	Category    string  `json:"Category"`
+	ID          int       `json:"ID" odata:"key"`
+	Name        string    `json:"Name"`
+	Description string    `json:"Description"`
+	Price       float64   `json:"Price"`
+	Category    string    `json:"Category"`
+	CreatedAt   time.Time `json:"CreatedAt"`
 }
 
 func getTestMetadata(t *testing.T) *metadata.EntityMetadata {

--- a/test/type_definition_integration_test.go
+++ b/test/type_definition_integration_test.go
@@ -238,3 +238,120 @@ func TestTypeDefinitionQueryWorks(t *testing.T) {
 		t.Errorf("Expected 2 packages, got %d", len(values))
 	}
 }
+
+// ShipDate is a string-backed named type declared as Edm.Date via an explicit
+// UnderlyingType override, since Go has no distinct native type for Edm.Date.
+type ShipDate string
+
+// Shipment is an entity with both a ShipDate (declared Edm.Date) and a genuine
+// Edm.String property (Carrier), used to verify that $filter type-checking
+// distinguishes between the two instead of treating both as interchangeable
+// strings (issue #800).
+type Shipment struct {
+	ID       string   `json:"ID" gorm:"primaryKey" odata:"key"`
+	Carrier  string   `json:"Carrier"`
+	ShipDate ShipDate `json:"ShipDate"`
+}
+
+func init() {
+	if err := odata.RegisterTypeDefinition(ShipDate(""), "ShipDate", odata.TypeDefinitionFacets{UnderlyingType: "Edm.Date"}); err != nil {
+		panic("failed to register ShipDate TypeDefinition: " + err.Error())
+	}
+}
+
+func setupShipmentTestService(t *testing.T) *odata.Service {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	if err := db.AutoMigrate(&Shipment{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
+	shipments := []Shipment{
+		{ID: "ship-1", Carrier: "UPS", ShipDate: "2024-01-15"},
+		{ID: "ship-2", Carrier: "FedEx", ShipDate: "2024-06-01"},
+	}
+	if err := db.Create(&shipments).Error; err != nil {
+		t.Fatalf("Failed to seed shipments: %v", err)
+	}
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error: %v", err)
+	}
+	if err := service.RegisterEntity(&Shipment{}); err != nil {
+		t.Fatalf("Failed to register Shipment entity: %v", err)
+	}
+	return service
+}
+
+// TestTypeDefinitionUnderlyingTypeOverride verifies that a string-backed
+// TypeDefinition with an explicit UnderlyingType override is reported as that
+// type (not Edm.String) in $metadata.
+func TestTypeDefinitionUnderlyingTypeOverride(t *testing.T) {
+	service := setupShipmentTestService(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/$metadata", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, `<TypeDefinition Name="ShipDate" UnderlyingType="Edm.Date"`) {
+		t.Errorf("Expected ShipDate TypeDefinition with UnderlyingType=Edm.Date, got:\n%s", body)
+	}
+	if !strings.Contains(body, `Type="ODataService.ShipDate"`) {
+		t.Errorf("Expected ShipDate property to reference ODataService.ShipDate type, got:\n%s", body)
+	}
+}
+
+// TestTypeDefinitionUnderlyingTypeFilterChecking is a regression test for issue
+// #800: $filter must type-check date functions/literals against the property's
+// declared EDM type, honoring a TypeDefinition's UnderlyingType override, rather
+// than treating every string-backed property as interchangeably Edm.String.
+func TestTypeDefinitionUnderlyingTypeFilterChecking(t *testing.T) {
+	service := setupShipmentTestService(t)
+
+	tests := []struct {
+		name       string
+		filter     string
+		wantStatus int
+	}{
+		{
+			name:       "unquoted date literal against Edm.Date property succeeds",
+			filter:     "ShipDate eq 2024-01-15",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "year() against Edm.Date property succeeds",
+			filter:     "year(ShipDate) eq 2024",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "unquoted date literal against Edm.String property is rejected",
+			filter:     "Carrier eq 2024-01-15",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "year() against Edm.String property is rejected",
+			filter:     "year(Carrier) eq 2024",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/Shipments?$filter="+strings.ReplaceAll(tt.filter, " ", "%20"), nil)
+			w := httptest.NewRecorder()
+			service.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("filter %q: expected status %d, got %d: %s", tt.filter, tt.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/type_definition.go
+++ b/type_definition.go
@@ -16,6 +16,14 @@ type TypeDefinitionFacets struct {
 	Scale int
 	// MaxLength is the maximum length facet, valid for Edm.String and Edm.Binary.
 	MaxLength int
+	// UnderlyingType optionally overrides the EDM primitive type this TypeDefinition
+	// aliases (e.g. "Edm.Date"). When empty, it's inferred from the Go type's kind
+	// (e.g. a string field infers Edm.String). Set this to declare a string-backed
+	// field as Edm.Date, Edm.TimeOfDay, or Edm.Duration, none of which have a
+	// distinct Go representation in this library - without it, $filter cannot
+	// distinguish such a property from a genuine Edm.String and won't type-check
+	// date/time functions or literals applied to it.
+	UnderlyingType string
 }
 
 // RegisterTypeDefinition registers a Go named type as an OData TypeDefinition.
@@ -41,9 +49,10 @@ func RegisterTypeDefinition(goValue interface{}, name string, facets TypeDefinit
 	}
 
 	return metadata.RegisterTypeDefinition(goType, metadata.TypeDefinitionInfo{
-		Name:      name,
-		Precision: facets.Precision,
-		Scale:     facets.Scale,
-		MaxLength: facets.MaxLength,
+		Name:           name,
+		UnderlyingType: facets.UnderlyingType,
+		Precision:      facets.Precision,
+		Scale:          facets.Scale,
+		MaxLength:      facets.MaxLength,
 	})
 }


### PR DESCRIPTION
## Summary

`$filter` never validated that a literal or function argument's type was compatible with a property's *declared* EDM/CSDL type — only its Go `reflect.Kind`. Since a plain Go `string` field is indistinguishable from any other by reflection, `year(Name) eq 2024` and `Name eq 2024-01-15` against a genuinely `Edm.String` property silently evaluated to `200 {"value":[]}` instead of the `400 Bad Request` the OData URL grammar requires.

## Root cause

This library also has no distinct Go type for `Edm.Date`/`Edm.TimeOfDay`/`Edm.Duration` (only `time.Time` maps to `Edm.DateTimeOffset`), so string-backed date/time/duration properties (like the compliance fixture's `ReleaseDate`, `OpenTime`, `ShippingTime`, `ProcessingTime`, `Offset`) were declared `Edm.String` in `$metadata` even though they hold date/time/duration-shaped values — the client has no way to discover this by trusting `$metadata`, and there was no way for `$filter` to distinguish them from a genuine `Edm.String` property like `Name` either.

## Fix

1. **`internal/metadata`**: added `PropertyMetadata.EdmType`, resolved once during entity analysis. It honors a registered `TypeDefinition`'s `UnderlyingType` where present, falling back to the type inferred from the Go field's kind otherwise.
2. **`internal/query`**: `$filter` now validates:
   - date/time-extraction function arguments (`year`, `month`, `day`, `hour`, `minute`, `second`, `date`, `time`, `fractionalseconds`, `totaloffsetminutes`, `totalseconds`) against the argument property's `EdmType`
   - `date`/`time`/`datetime`/`duration`/`guid` literals — parsed via their own dedicated ABNF productions, so unambiguous at parse time — against the compared property's `EdmType`

   Properties without a resolvable `EdmType` (computed aliases, complex types, navigation paths) are left unvalidated, and generic `string`/`number` literals are unaffected — this only closes the gap for the literal types that are unambiguous per the OData grammar.
3. **Public API**: extended `TypeDefinitionFacets` with an optional `UnderlyingType` override, since a string-backed Go field has no other way to declare itself `Edm.Date`/`Edm.TimeOfDay`/`Edm.Duration` instead of defaulting to `Edm.String`.
4. **`cmd/complianceserver`**: `Product.ReleaseDate`/`OpenTime`/`ShippingTime`/`ProcessingTime`/`Offset` now use named types (`ReleaseDateValue`, `TimeOfDayValue`, `DurationValue`) registered via the new override, so `$metadata` honestly reflects what these properties hold and `$filter` validates queries against them correctly.

## Compatibility note

Existing internal tests that applied date/time functions or typed literals to plain, undeclared `string` fields (relying on the previous permissive behavior) were updated to declare a proper `TypeDefinition` for those fields, matching the corrected semantics rather than the old loophole.

Fixes #800

## Test plan

- [x] `go build ./... && go vet ./...` clean (both the main module and `cmd/complianceserver`)
- [x] `go test ./...` passes across the whole repo, including `cmd/complianceserver`
- [x] Added regression tests: `TestDateFunctions_Year/year_against_Edm.String_property_is_rejected`, `TestDateLiteralAgainstStringProperty`, and new end-to-end HTTP tests `TestTypeDefinitionUnderlyingTypeOverride` / `TestTypeDefinitionUnderlyingTypeFilterChecking` in `test/type_definition_integration_test.go`
- [x] Manually verified against `cmd/complianceserver`:
  - `GET /Products?$filter=year(Name) eq 2024` → `400` (was `200 {}`)
  - `GET /Products?$filter=Name eq 2024-01-15` → `400` (was `200 {}`)
  - `GET /Products?$filter=year(ReleaseDate) eq 2024` → `200` with matches (still works, now genuinely valid)
  - `GET /Products?$filter=totalseconds(ShippingTime) gt 3600` → `200` with matches (still works)
  - `$metadata` now shows `<Property Name="ReleaseDate" Type="ComplianceService.ReleaseDateValue" .../>` with a corresponding `<TypeDefinition Name="ReleaseDateValue" UnderlyingType="Edm.Date" />`