### PR TITLE
Reject duplicate Content-ID within a multipart $batch changeset

### DIFF
--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -314,6 +314,11 @@ func (h *BatchHandler) processChangeset(r io.Reader, boundary string, remainingC
 	// refer to the entity created by the request bearing that Content-ID.
 	contentIDLocations := make(map[string]string)
 
+	// seenContentIDs tracks every non-empty Content-ID encountered so far in this changeset.
+	// Per OData v4 §11.7.4, Content-ID values must be unique within a changeset; reusing one
+	// makes $<contentID> URL references (§11.4.9.3) ambiguous, so a duplicate is rejected.
+	seenContentIDs := make(map[string]bool)
+
 	var hasError bool
 	var sizeExceeded bool
 	for {
@@ -336,6 +341,19 @@ func (h *BatchHandler) processChangeset(r io.Reader, boundary string, remainingC
 
 		// Capture Content-ID from MIME part envelope headers (per OData v4 spec, must be echoed in response)
 		contentID := part.Header.Get("Content-ID")
+
+		// Reject a Content-ID reused within the same changeset (OData v4 §11.7.4): two
+		// requests sharing an id would make $<contentID> references (§11.4.9.3) ambiguous.
+		if contentID != "" && seenContentIDs[contentID] {
+			hasError = true
+			errResp := h.createErrorResponse(http.StatusBadRequest, fmt.Sprintf("Duplicate Content-ID: %q", contentID))
+			errResp.ContentID = contentID
+			responses = append(responses, errResp)
+			break
+		}
+		if contentID != "" {
+			seenContentIDs[contentID] = true
+		}
 
 		req, err := h.parseHTTPRequest(part)
 		if err != nil {

--- a/internal/handlers/batch_content_id_test.go
+++ b/internal/handlers/batch_content_id_test.go
@@ -775,3 +775,71 @@ DELETE /$1 HTTP/1.1
 		t.Errorf("expected entity to be deleted, but %d record(s) remain", count)
 	}
 }
+
+// TestBatchChangeset_DuplicateContentID_Rejected verifies that two sub-requests in the same
+// changeset sharing a Content-ID are rejected with a 400-level error rather than both being
+// processed successfully (which would make "$<contentID>" references ambiguous per OData v4
+// §11.4.9.3), and that the changeset is rolled back so neither entity is persisted.
+func TestBatchChangeset_DuplicateContentID_Rejected(t *testing.T) {
+	handler, db := setupContentIDTestHandler(t)
+
+	batchBoundary := "batch_dup"
+	changesetBoundary := "changeset_dup"
+	body := fmt.Sprintf(`--%s
+Content-Type: multipart/mixed; boundary=%s
+
+--%s
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST /ContentIDRefProducts HTTP/1.1
+Content-Type: application/json
+
+{"Name":"Dup A","Price":1.0,"Category":"A"}
+
+--%s
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST /ContentIDRefProducts HTTP/1.1
+Content-Type: application/json
+
+{"Name":"Dup B","Price":1.0,"Category":"A"}
+
+--%s--
+
+--%s--
+`, batchBoundary, changesetBoundary,
+		changesetBoundary, changesetBoundary, changesetBoundary,
+		batchBoundary)
+
+	req := httptest.NewRequest(http.MethodPost, "/$batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", fmt.Sprintf("multipart/mixed; boundary=%s", batchBoundary))
+	w := httptest.NewRecorder()
+
+	handler.HandleBatch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Status = %v, want 200 (batch envelope always 200; failures are per-part). Body: %s", w.Code, w.Body.String())
+	}
+
+	respBody := w.Body.String()
+	if strings.Count(respBody, "HTTP/1.1 201") == 2 {
+		t.Errorf("expected the duplicate Content-ID request not to also succeed with 201; body:\n%s", respBody)
+	}
+	if !strings.Contains(respBody, "HTTP/1.1 400") {
+		t.Errorf("expected a 400 response identifying the duplicate Content-ID; body:\n%s", respBody)
+	}
+	if !strings.Contains(respBody, "Duplicate Content-ID") {
+		t.Errorf("expected the 400 response to identify the duplicate Content-ID; body:\n%s", respBody)
+	}
+
+	// The changeset must have been rolled back entirely - no product should be persisted.
+	var count int64
+	db.Model(&ContentIDRefProduct{}).Count(&count)
+	if count != 0 {
+		t.Errorf("expected 0 products after rejected changeset, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary
- Within a multipart `$batch` changeset, two sub-requests sharing the same `Content-ID` were both processed successfully (each 201 Created), rather than being rejected.
- This made `$<contentID>` cross-referencing (OData v4 §11.4.9.3) ambiguous, since two different entities would share the same alias.
- The JSON batch format already rejects duplicate `id` values with 400; this brings the multipart format in line with that behavior.

## Fix
`processChangeset` now tracks every non-empty `Content-ID` seen so far in the changeset. If a request reuses one, it's rejected with `400 Bad Request` ("Duplicate Content-ID: ..."), `hasError` is set, and the changeset transaction is rolled back — so no entities from the changeset are persisted.

## Test plan
- [x] Added `TestBatchChangeset_DuplicateContentID_Rejected`, reproducing the exact repro from the issue: two `POST /Products` sub-requests both using `Content-ID: 1`. Verifies the duplicate is rejected with 400 and that the changeset is fully rolled back (0 persisted rows).
- [x] `go test ./...` passes.

Fixes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)