### PR TITLE
Fix $filter dropping parenthesized left operand in nested arithmetic

### DIFF
--- a/internal/query/apply_filter_test.go
+++ b/internal/query/apply_filter_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/nlstn/go-odata/internal/metadata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 type navigationFilterAuthor struct {
@@ -130,6 +132,52 @@ func TestNavigationFilterUsesMultiHopNavigationPath(t *testing.T) {
 
 	if len(args) != 1 || args[0] != "Acme" {
 		t.Fatalf("expected args [Acme], got %#v", args)
+	}
+}
+
+// TestFilterNestedArithmeticGroupedOnLeft is a regression test for a bug where
+// "(Price div 3) mul 3 eq 15.5" silently dropped the parenthesized "Price div 3"
+// sub-expression: the outer "mul" node's Left operand was a *GroupExpr, which
+// convertBinaryArithmeticExprWithContext didn't unwrap, so it fell into the
+// "no property" placeholder branch and the filter degenerated into comparing the
+// bare literal 3 against 15.5 (i.e., it matched no rows regardless of Price).
+func TestFilterNestedArithmeticGroupedOnLeft(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&TestEntity{}); err != nil {
+		t.Fatalf("Failed to migrate: %v", err)
+	}
+
+	rows := []TestEntity{
+		{ID: 1, Name: "Coffee Mug", Price: 15.5}, // (15.5 div 3) mul 3 == 15.5
+		{ID: 2, Name: "Notebook", Price: 10.0},   // (10 div 3) mul 3 == 9.0 != 10.0
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("Failed to seed rows: %v", err)
+	}
+
+	meta := getTestMetadata(t)
+
+	filterExpr, err := parseFilter("(Price div 3) mul 3 eq 15.5", meta, nil, 0)
+	if err != nil {
+		t.Fatalf("Failed to parse filter: %v", err)
+	}
+
+	if filterExpr.Left == nil || filterExpr.Left.Left == nil {
+		t.Fatalf("expected nested arithmetic expression to be preserved, got %+v", filterExpr.Left)
+	}
+
+	var matched []TestEntity
+	query := applyFilter(db.Model(&TestEntity{}), filterExpr, meta)
+	if err := query.Find(&matched).Error; err != nil {
+		t.Fatalf("Failed to execute query: %v", err)
+	}
+
+	if len(matched) != 1 || matched[0].ID != 1 {
+		t.Fatalf("expected exactly [Coffee Mug] (ID 1) to match, got %+v", matched)
 	}
 }
 

--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -536,17 +536,28 @@ func convertBinaryArithmeticExprWithContext(binExpr *BinaryExpr, ctx *conversion
 		return nil, fmt.Errorf("unsupported arithmetic operator: %s", binExpr.Operator)
 	}
 
+	// Unwrap a parenthesized sub-expression on either side, e.g. "(Price div 3) mul 3",
+	// so nested arithmetic isn't silently dropped just because it was grouped.
+	leftNode := binExpr.Left
+	if leftGroup, ok := leftNode.(*GroupExpr); ok {
+		leftNode = leftGroup.Expr
+	}
+	rightNode := binExpr.Right
+	if rightGroup, ok := rightNode.(*GroupExpr); ok {
+		rightNode = rightGroup.Expr
+	}
+
 	// Extract property from left side
 	var property string
 	var leftExpr *FilterExpression
-	if leftIdent, ok := binExpr.Left.(*IdentifierExpr); ok {
+	if leftIdent, ok := leftNode.(*IdentifierExpr); ok {
 		property = leftIdent.Name
 		// Validate property exists (either in entity metadata or as a computed alias)
 		hasComputedAlias := ctx != nil && ctx.hasComputedAlias(property)
 		if ctx != nil && !propertyAllowedInFilter(ctx, property) && !hasComputedAlias {
 			return nil, fmt.Errorf("property '%s' does not exist", property)
 		}
-	} else if leftBinExpr, ok := binExpr.Left.(*BinaryExpr); ok {
+	} else if leftBinExpr, ok := leftNode.(*BinaryExpr); ok {
 		// Nested arithmetic expression - recursively convert it
 		leftFilterExpr, err := convertBinaryArithmeticExprWithContext(leftBinExpr, ctx)
 		if err != nil {
@@ -562,11 +573,11 @@ func convertBinaryArithmeticExprWithContext(binExpr *BinaryExpr, ctx *conversion
 	// Extract value from right side
 	var value interface{}
 	var rightExpr *FilterExpression
-	if rightLit, ok := binExpr.Right.(*LiteralExpr); ok {
+	if rightLit, ok := rightNode.(*LiteralExpr); ok {
 		value = rightLit.Value
-	} else if rightIdent, ok := binExpr.Right.(*IdentifierExpr); ok {
+	} else if rightIdent, ok := rightNode.(*IdentifierExpr); ok {
 		value = rightIdent.Name
-	} else if rightBinExpr, ok := binExpr.Right.(*BinaryExpr); ok {
+	} else if rightBinExpr, ok := rightNode.(*BinaryExpr); ok {
 		// Nested arithmetic expression on right side - recursively convert it
 		// This handles cases like "Price add (10 mul 2)"
 		rightFilterExpr, err := convertBinaryArithmeticExprWithContext(rightBinExpr, ctx)


### PR DESCRIPTION
## Summary
`$filter=(Price div 3) mul 3 eq 15.5` returned an empty result set even for products where the computed value provably equals the literal, while `$apply=compute((Price div 3) mul 3 as Recomputed)` correctly computed the value.

## Root cause
When converting the parsed AST into a `FilterExpression`, `convertBinaryArithmeticExprWithContext` (in `internal/query/ast_parser_validation.go`) only recognized a nested arithmetic sub-expression on the left side if it was a bare `*BinaryExpr`. For `(Price div 3) mul 3`, the left operand of the outer `mul` node is a `*GroupExpr` wrapping the `Price div 3` binary expression (from the parenthesization), which fell through to a "no property" placeholder branch — silently discarding the entire `Price div 3` sub-expression.

The resulting malformed `FilterExpression` (`{Operator: mul, Value: 3, Left: nil, Right: nil}`) then happened to structurally match the "bare literal" case in `buildComputeExpressionSQLWithArgs`, so the generated SQL compared the literal `3` against `15.5` — always false, regardless of `Price`.

## Fix
Unwrap a `*GroupExpr` on either side of the arithmetic `BinaryExpr` before matching, the same way the top-level comparison conversion already unwraps a grouped left-hand side (`convertComparisonExprWithContext`'s existing `GroupExpr` handling).

## Test plan
- [x] Added `TestFilterNestedArithmeticGroupedOnLeft` in `internal/query/apply_filter_test.go`: seeds an in-memory SQLite DB with a "Coffee Mug" (Price=15.5, satisfies the expression) and a "Notebook" (Price=10.0, doesn't), runs `applyFilter` with `(Price div 3) mul 3 eq 15.5`, and asserts only Coffee Mug matches. Also asserts the parsed filter tree keeps the nested `Left.Left` expression instead of discarding it.
- [x] `go test ./...` passes.

Fixes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)