### PR TITLE
Avoid boxing allocation when hashing time.Time ETag fields

### DIFF
--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -15,6 +15,9 @@ import (
 // hexTable for fast hex encoding without allocation
 const hexTable = "0123456789abcdef"
 
+// timeType caches the reflect.Type for time.Time to avoid recomputing it on every call.
+var timeType = reflect.TypeOf(time.Time{})
+
 // globalFieldIndexCache uses sync.Map for lock-free reads under high concurrency
 // Keys are reflect.Type, values are map[string]int (field name to index)
 var globalFieldIndexCache sync.Map
@@ -119,8 +122,16 @@ func Generate(entity interface{}, meta *metadata.EntityMetadata) string {
 		etagSource = strconv.FormatUint(fieldValue.Uint(), 10)
 	case reflect.Struct:
 		// Handle time.Time specially
-		if t, ok := fieldValue.Interface().(time.Time); ok {
-			etagSource = strconv.FormatInt(t.Unix(), 10)
+		if fieldValue.Type() == timeType {
+			// Boxing a 24-byte time.Time value into an interface{} via fieldValue.Interface()
+			// heap-allocates. Take its address instead (fields of a dereferenced pointer are
+			// addressable) and box the pointer, which fits directly in the interface with no
+			// extra allocation.
+			if fieldValue.CanAddr() {
+				etagSource = strconv.FormatInt(fieldValue.Addr().Interface().(*time.Time).Unix(), 10)
+			} else {
+				etagSource = strconv.FormatInt(fieldValue.Interface().(time.Time).Unix(), 10)
+			}
 		} else {
 			etagSource = fmt.Sprintf("%v", fieldValue.Interface())
 		}

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -128,9 +128,11 @@ func Generate(entity interface{}, meta *metadata.EntityMetadata) string {
 			// addressable) and box the pointer, which fits directly in the interface with no
 			// extra allocation.
 			if fieldValue.CanAddr() {
-				etagSource = strconv.FormatInt(fieldValue.Addr().Interface().(*time.Time).Unix(), 10)
+				t := fieldValue.Addr().Interface().(*time.Time) //nolint:errcheck // type guaranteed by the timeType check above
+				etagSource = strconv.FormatInt(t.Unix(), 10)
 			} else {
-				etagSource = strconv.FormatInt(fieldValue.Interface().(time.Time).Unix(), 10)
+				t := fieldValue.Interface().(time.Time) //nolint:errcheck // type guaranteed by the timeType check above
+				etagSource = strconv.FormatInt(t.Unix(), 10)
 			}
 		} else {
 			etagSource = fmt.Sprintf("%v", fieldValue.Interface())


### PR DESCRIPTION
## Summary
- `etag.Generate` computed ETags for `time.Time` fields via `fieldValue.Interface().(time.Time)`. Boxing a 24-byte struct into an `interface{}` always heap-allocates a copy to hold the value.
- Since `Generate` is called with a dereferenced pointer's field (addressable in practice), take the field's address and box the `*time.Time` pointer instead — a pointer fits directly in the interface's data word with no extra allocation. Falls back to the original value-boxing path if the field isn't addressable (defensive, e.g. if an entity is ever passed by value).
- Cached `reflect.TypeOf(time.Time{})` in a package var instead of recomputing it via a type assertion each call.

## Benchmark (`internal/etag`, `-benchmem -benchtime=1s`)

| Benchmark | Before | After |
|---|---|---|
| ETagGenerate_TimeField | 118.8 ns/op, 64 B/op, 3 allocs/op | 95.22 ns/op, 40 B/op, 2 allocs/op |

~20% faster and one fewer allocation for every ETag generated on a `time.Time`-typed field (a common case — most entities use an `UpdatedAt`/timestamp field for optimistic concurrency).

## Test plan
- [x] `go test ./internal/etag/...` (all existing unit tests pass, including map/struct consistency tests)
- [x] `go test ./... -race`
- [x] Benchmark comparison above

🤖 Generated with [Claude Code](https://claude.com/claude-code)