### PR TITLE
Avoid wasted allocation normalizing already-canonical query option keys

### DIFF
--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -306,14 +306,14 @@ var validQueryOptions = map[string]bool{
 // per OData v4.01 spec: system query option names are case-insensitive and may be provided without the $ prefix
 // Returns the normalized key if it's a valid OData system query option, otherwise returns the original key
 func normalizeQueryOptionKey(key string) string {
-	// Try with $ prefix
-	withDollar := "$" + strings.ToLower(key)
-	if validQueryOptions[withDollar] {
-		return withDollar
-	}
-
-	// Already has $ prefix, lowercase it and check validity
+	// Fast path: real OData requests almost always send already-lowercase, $-prefixed
+	// keys ($filter, $select, ...). Check validity directly first so that common case
+	// costs zero allocations, instead of always building a "$"+lower(key) candidate
+	// that's only useful for the far rarer no-prefix form.
 	if strings.HasPrefix(key, "$") {
+		if validQueryOptions[key] {
+			return key
+		}
 		lowercase := strings.ToLower(key)
 		if validQueryOptions[lowercase] {
 			return lowercase
@@ -322,10 +322,10 @@ func normalizeQueryOptionKey(key string) string {
 		return key
 	}
 
-	// Check if without modification (lowercase) it's a valid option
-	lowercase := strings.ToLower(key)
-	if validQueryOptions[lowercase] {
-		return lowercase
+	// No $ prefix: OData 4.01 allows system options to be supplied without it.
+	withDollar := "$" + strings.ToLower(key)
+	if validQueryOptions[withDollar] {
+		return withDollar
 	}
 
 	// Not a known OData system query option, return original


### PR DESCRIPTION
## Summary
- `normalizeQueryOptionKey` (called once per query-string parameter on every request, via `NormalizeQueryParams`) unconditionally computed `"$" + strings.ToLower(key)` before ever checking whether `key` was already in its canonical `$`-prefixed lowercase form.
- Real OData requests almost always send already-canonical keys (`$filter`, `$select`, `$orderby`, ...), so this string concatenation allocated on essentially every query parameter for no reason — the candidate it built (e.g. `"$$filter"` for input `"$filter"`) was never valid and immediately discarded.
- Reordered to check the `$`-prefixed fast path first. Verified case-by-case against the original branching (uppercase/no-$ keys, unknown `$` options, etc.) that the returned value is identical in every case — only the allocation is removed.

## Benchmark (`internal/query`, `-benchmem -benchtime=1s`)

| Benchmark | Before | After |
|---|---|---|
| ParseQueryOptions_Simple | 2409 ns/op, 1256 B/op, 25 allocs | 2264 ns/op, 1241 B/op, 23 allocs |
| ParseQueryOptions_Complex | 7731 ns/op, 3905 B/op, 100 allocs | 7385 ns/op, 3856 B/op, 94 allocs |
| ParseQueryOptions_ManyConditions | 7089 ns/op, 3655 B/op, 63 allocs | 6598 ns/op, 3647 B/op, 62 allocs |
| ParseQueryOptions_WithNavigationPaths | 6379 ns/op, 3527 B/op, 75 allocs | 6193 ns/op, 3510 B/op, 73 allocs |
| ParseQueryOptions_ComplexNavigationPaths | 10499 ns/op, 4922 B/op, 113 allocs | 9679 ns/op, 4889 B/op, 110 allocs |

Smaller win than the other two perf PRs in this series (one allocation saved per query parameter key rather than per property reference), but it fires on every single incoming request regardless of query complexity.

## Test plan
- [x] `go test ./...`
- [x] `go test ./... -race`
- [x] Benchmark comparison above

🤖 Generated with [Claude Code](https://claude.com/claude-code)