### PR TITLE
Ensure required status checks always run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'cmd/complianceserver/**'
       - '.github/workflows/ci.yml'
       - '.golangci.yml'
   pull_request:
@@ -15,6 +16,7 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+      - 'cmd/complianceserver/**'
       - '.github/workflows/ci.yml'
       - '.golangci.yml'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,12 @@ on:
       - 'cmd/complianceserver/**'
       - '.github/workflows/ci.yml'
       - '.golangci.yml'
+  # No paths filter here: Build/Test/Lint are required status checks on every PR
+  # to main (see the repo's branch ruleset), so they must run regardless of which
+  # files changed - a path filter here can leave a PR permanently unable to merge
+  # if it happens not to touch a matched path.
   pull_request:
     branches: [ main ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'cmd/complianceserver/**'
-      - '.github/workflows/ci.yml'
-      - '.golangci.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/mariadb-compliance.yml
+++ b/.github/workflows/mariadb-compliance.yml
@@ -9,14 +9,12 @@ on:
       - 'go.sum'
       - 'cmd/complianceserver/**'
       - '.github/workflows/mariadb-compliance.yml'
+  # No paths filter here: this is a required status check on every PR to main
+  # (see the repo's branch ruleset), so it must run regardless of which files
+  # changed - a path filter here can leave a PR permanently unable to merge if
+  # it happens not to touch a matched path.
   pull_request:
     branches: [ main ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'cmd/complianceserver/**'
-      - '.github/workflows/mariadb-compliance.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/mssql-compliance.yml
+++ b/.github/workflows/mssql-compliance.yml
@@ -9,14 +9,12 @@ on:
       - 'go.sum'
       - 'cmd/complianceserver/**'
       - '.github/workflows/mssql-compliance.yml'
+  # No paths filter here: this is a required status check on every PR to main
+  # (see the repo's branch ruleset), so it must run regardless of which files
+  # changed - a path filter here can leave a PR permanently unable to merge if
+  # it happens not to touch a matched path.
   pull_request:
     branches: [ main ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'cmd/complianceserver/**'
-      - '.github/workflows/mssql-compliance.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/mysql-compliance.yml
+++ b/.github/workflows/mysql-compliance.yml
@@ -9,14 +9,12 @@ on:
       - 'go.sum'
       - 'cmd/complianceserver/**'
       - '.github/workflows/mysql-compliance.yml'
+  # No paths filter here: this is a required status check on every PR to main
+  # (see the repo's branch ruleset), so it must run regardless of which files
+  # changed - a path filter here can leave a PR permanently unable to merge if
+  # it happens not to touch a matched path.
   pull_request:
     branches: [ main ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'cmd/complianceserver/**'
-      - '.github/workflows/mysql-compliance.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/postgres-compliance.yml
+++ b/.github/workflows/postgres-compliance.yml
@@ -9,14 +9,12 @@ on:
       - 'go.sum'
       - 'cmd/complianceserver/**'
       - '.github/workflows/postgres-compliance.yml'
+  # No paths filter here: this is a required status check on every PR to main
+  # (see the repo's branch ruleset), so it must run regardless of which files
+  # changed - a path filter here can leave a PR permanently unable to merge if
+  # it happens not to touch a matched path.
   pull_request:
     branches: [ main ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'cmd/complianceserver/**'
-      - '.github/workflows/postgres-compliance.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/sqlite-compliance.yml
+++ b/.github/workflows/sqlite-compliance.yml
@@ -9,14 +9,12 @@ on:
       - 'go.sum'
       - 'cmd/complianceserver/**'
       - '.github/workflows/sqlite-compliance.yml'
+  # No paths filter here: this is a required status check on every PR to main
+  # (see the repo's branch ruleset), so it must run regardless of which files
+  # changed - a path filter here can leave a PR permanently unable to merge if
+  # it happens not to touch a matched path.
   pull_request:
     branches: [ main ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'cmd/complianceserver/**'
-      - '.github/workflows/sqlite-compliance.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
The branch ruleset requires `Build`, `Test`, `Lint` (from `ci.yml`) and the 5 DB compliance-test workflows as status checks before merge. Each of those 6 workflows has its own `pull_request` `paths:` filter, so a PR that doesn't touch a matched path never triggers that workflow - and a required check that never reports leaves the PR permanently `BLOCKED`, no matter how long you wait.

This surfaced twice while investigating [#804](https://github.com/NLstn/go-odata/pull/804) (dependabot bumping a dependency in `cmd/complianceserver`, which has no `.go` changes at the root and wasn't matched by `ci.yml`'s filter):
- My first commit on this branch added `cmd/complianceserver/**` to `ci.yml`'s paths - which fixed `ci.yml` specifically, but the fix itself only touched `.github/workflows/ci.yml`, so it didn't match any of the 5 compliance workflows' own filters and got blocked the same way.
- The second commit removes the root cause: required checks can't have a `pull_request` path filter at all, since "run only sometimes" is incompatible with "required on every PR." Dropped the `paths:` filter from the `pull_request` trigger on all 6 required workflows (`ci.yml` + the 5 `*-compliance.yml` files). `push` triggers keep their filters - those only affect post-merge runs on `main`, not merge gating, so no need to widen them.

## Trade-off
Every PR to `main` will now always run all 6 required workflows (Build/Test/Lint + 5 DB compliance suites), even for changes that don't touch Go code (e.g. docs-only). These jobs are fast (~1-2 min each), so this seemed like the right trade for actually being mergeable, but flagging it explicitly in case a narrower approach (e.g. a required "skip" job that path-matches and always succeeds) is preferred instead.

## Test plan
- [x] Validated YAML syntax for all 6 modified files
- [x] No code changes - workflow trigger config only
- [ ] After merge, verify #804 picks up all 8 required checks and unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)