### PR TITLE
Enforce If-None-Match: * precondition on mutating requests

### DIFF
--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -22,6 +22,27 @@ import (
 var errETagMismatch = errors.New("etag mismatch")
 var errAuthorizationDenied = errors.New("authorization denied")
 
+// enforceIfNoneMatch implements the RFC 7232 §3.2 If-None-Match precondition for
+// mutating requests: if the header is "*" or lists the current ETag, the request
+// must fail with 412 rather than be applied. Writes the 412 response itself and
+// returns false when the precondition fails; returns true when the request may proceed.
+func (h *EntityHandler) enforceIfNoneMatch(w http.ResponseWriter, r *http.Request, currentETag string) bool {
+	ifNoneMatch := r.Header.Get(HeaderIfNoneMatch)
+	if ifNoneMatch == "" {
+		return true
+	}
+
+	if etag.NoneMatch(ifNoneMatch, currentETag) {
+		return true
+	}
+
+	if writeErr := response.WriteError(w, r, http.StatusPreconditionFailed, ErrMsgPreconditionFailed,
+		ErrDetailPreconditionFailed); writeErr != nil {
+		h.logger.Error("Error writing error response", "error", writeErr)
+	}
+	return false
+}
+
 // handleDeleteEntity handles DELETE requests for individual entities
 func (h *EntityHandler) handleDeleteEntity(w http.ResponseWriter, r *http.Request, entityKey string) {
 	ctx := r.Context()
@@ -79,6 +100,10 @@ func (h *EntityHandler) handleDeleteEntity(w http.ResponseWriter, r *http.Reques
 					ErrDetailPreconditionFailed); writeErr != nil {
 					h.logger.Error("Error writing error response", "error", writeErr)
 				}
+				return newTransactionHandledError(errETagMismatch)
+			}
+
+			if !h.enforceIfNoneMatch(w, r, currentETag) {
 				return newTransactionHandledError(errETagMismatch)
 			}
 		}
@@ -188,6 +213,10 @@ func (h *EntityHandler) handlePatchEntity(w http.ResponseWriter, r *http.Request
 					ErrDetailPreconditionFailed); writeErr != nil {
 					h.logger.Error("Error writing error response", "error", writeErr)
 				}
+				return newTransactionHandledError(errETagMismatch)
+			}
+
+			if !h.enforceIfNoneMatch(w, r, currentETag) {
 				return newTransactionHandledError(errETagMismatch)
 			}
 		}
@@ -464,6 +493,10 @@ func (h *EntityHandler) handlePutEntity(w http.ResponseWriter, r *http.Request, 
 					ErrDetailPreconditionFailed); writeErr != nil {
 					h.logger.Error("Error writing error response", "error", writeErr)
 				}
+				return newTransactionHandledError(errETagMismatch)
+			}
+
+			if !h.enforceIfNoneMatch(w, r, currentETag) {
 				return newTransactionHandledError(errETagMismatch)
 			}
 		}

--- a/internal/handlers/singleton.go
+++ b/internal/handlers/singleton.go
@@ -133,6 +133,10 @@ func (h *EntityHandler) handlePatchSingleton(w http.ResponseWriter, r *http.Requ
 			}
 			return
 		}
+
+		if !h.enforceIfNoneMatch(w, r, currentETag) {
+			return
+		}
 	}
 
 	// Parse the update data from request body
@@ -205,6 +209,10 @@ func (h *EntityHandler) handlePutSingleton(w http.ResponseWriter, r *http.Reques
 				ErrDetailPreconditionFailed); writeErr != nil {
 				h.logger.Error("Error writing error response", "error", writeErr)
 			}
+			return
+		}
+
+		if !h.enforceIfNoneMatch(w, r, currentETag) {
 			return
 		}
 	}

--- a/test/etag_test.go
+++ b/test/etag_test.go
@@ -278,6 +278,46 @@ func TestPatchEntity_WithWildcardIfMatch(t *testing.T) {
 	}
 }
 
+// Test PATCH with If-None-Match: * against an existing entity (RFC 7232 §3.2:
+// must fail with 412 and leave the entity unmodified)
+func TestPatchEntity_WithWildcardIfNoneMatch(t *testing.T) {
+	service, db := setupETagTestService(t)
+
+	// Create a test product
+	product := ETagProduct{
+		ID:          1,
+		Name:        "Laptop",
+		Price:       999.99,
+		Version:     1,
+		LastUpdated: time.Now(),
+	}
+	db.Create(&product)
+
+	update := map[string]interface{}{
+		"price": 899.99,
+	}
+	body, _ := json.Marshal(update)
+
+	req := httptest.NewRequest(http.MethodPatch, "/ETagProducts(1)", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("If-None-Match", "*")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusPreconditionFailed)
+	}
+
+	var reloaded ETagProduct
+	if err := db.First(&reloaded, 1).Error; err != nil {
+		t.Fatalf("failed to reload product: %v", err)
+	}
+	if reloaded.Price != 999.99 {
+		t.Errorf("Price = %v, want unchanged 999.99 (update should have been rejected)", reloaded.Price)
+	}
+}
+
 // Test PUT with matching If-Match header
 func TestPutEntity_WithMatchingETag(t *testing.T) {
 	service, db := setupETagTestService(t)
@@ -352,6 +392,48 @@ func TestPutEntity_WithNonMatchingETag(t *testing.T) {
 	}
 }
 
+// Test PUT with If-None-Match: * against an existing entity (RFC 7232 §3.2:
+// must fail with 412 and leave the entity unmodified)
+func TestPutEntity_WithWildcardIfNoneMatch(t *testing.T) {
+	service, db := setupETagTestService(t)
+
+	// Create a test product
+	product := ETagProduct{
+		ID:          1,
+		Name:        "Laptop",
+		Price:       999.99,
+		Version:     1,
+		LastUpdated: time.Now(),
+	}
+	db.Create(&product)
+
+	replacement := map[string]interface{}{
+		"name":    "Gaming Laptop",
+		"price":   1299.99,
+		"version": 1,
+	}
+	body, _ := json.Marshal(replacement)
+
+	req := httptest.NewRequest(http.MethodPut, "/ETagProducts(1)", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("If-None-Match", "*")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusPreconditionFailed)
+	}
+
+	var reloaded ETagProduct
+	if err := db.First(&reloaded, 1).Error; err != nil {
+		t.Fatalf("failed to reload product: %v", err)
+	}
+	if reloaded.Name != "Laptop" {
+		t.Errorf("Name = %v, want unchanged %q (update should have been rejected)", reloaded.Name, "Laptop")
+	}
+}
+
 // Test DELETE with matching If-Match header
 func TestDeleteEntity_WithMatchingETag(t *testing.T) {
 	service, db := setupETagTestService(t)
@@ -407,6 +489,37 @@ func TestDeleteEntity_WithNonMatchingETag(t *testing.T) {
 
 	if w.Code != http.StatusPreconditionFailed {
 		t.Errorf("Status = %v, want %v", w.Code, http.StatusPreconditionFailed)
+	}
+}
+
+// Test DELETE with If-None-Match: * against an existing entity (RFC 7232 §3.2:
+// must fail with 412 and leave the entity in place)
+func TestDeleteEntity_WithWildcardIfNoneMatch(t *testing.T) {
+	service, db := setupETagTestService(t)
+
+	// Create a test product
+	product := ETagProduct{
+		ID:          1,
+		Name:        "Laptop",
+		Price:       999.99,
+		Version:     1,
+		LastUpdated: time.Now(),
+	}
+	db.Create(&product)
+
+	req := httptest.NewRequest(http.MethodDelete, "/ETagProducts(1)", nil)
+	req.Header.Set("If-None-Match", "*")
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusPreconditionFailed)
+	}
+
+	var reloaded ETagProduct
+	if err := db.First(&reloaded, 1).Error; err != nil {
+		t.Errorf("expected entity to still exist after rejected delete, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Per RFC 7232 §3.2, `If-None-Match: *` on a request targeting an existing resource must fail with 412 Precondition Failed for any method other than GET/HEAD (the standard "create-if-not-exists" guard).
- PATCH, PUT, and DELETE handlers (both regular entities and singletons) never read `If-None-Match` at all — only `If-Match` was checked — so the wildcard guard was silently ignored and updates/deletes against existing entities succeeded.
- `etag.NoneMatch` in `internal/etag/etag.go` already implements the correct wildcard semantics; it just wasn't being invoked from any mutating code path. Added `enforceIfNoneMatch` in `internal/handlers/entity_write.go` and wired it into the existing conditional-request checks in `entity_write.go` (DELETE/PATCH/PUT) and `singleton.go` (PATCH/PUT).

## Test plan
- [x] Added regression tests: `TestPatchEntity_WithWildcardIfNoneMatch`, `TestPutEntity_WithWildcardIfNoneMatch`, `TestDeleteEntity_WithWildcardIfNoneMatch` in `test/etag_test.go`, each asserting a 412 response and that the entity is left unmodified.
- [x] `go build ./...` and `go vet ./...` pass.
- [x] `go test ./...` passes (full suite).

Fixes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)