### PR TITLE
Declare embedded complex-type properties correctly in $metadata and honor them in $select

### DIFF
--- a/internal/handlers/metadata_shared.go
+++ b/internal/handlers/metadata_shared.go
@@ -113,6 +113,11 @@ func (h *MetadataHandler) propertyEdmType(model metadataModel, prop *metadata.Pr
 	if prop.IsTypeDefinition && prop.TypeDefinitionName != "" {
 		return model.qualifiedTypeName(prop.TypeDefinitionName)
 	}
+	if prop.IsComplexType {
+		if name := complexTypeGoName(prop); name != "" {
+			return model.qualifiedTypeName(name)
+		}
+	}
 	return getEdmType(prop.Type)
 }
 

--- a/internal/query/apply_select.go
+++ b/internal/query/apply_select.go
@@ -48,13 +48,32 @@ func applySelect(db *gorm.DB, selectedProperties []string, expandOptions []Expan
 		columns = append(columns, qualifiedColumn)
 	}
 
+	addComplexTypeColumns := func(complexProp *metadata.PropertyMetadata) {
+		prefix := complexProp.EmbeddedPrefix
+		seen := make(map[string]bool)
+		for _, field := range complexProp.ComplexTypeFields {
+			if field.IsNavigationProp || field.IsComplexType || field.ColumnName == "" {
+				continue
+			}
+			if seen[field.Name] {
+				continue
+			}
+			seen[field.Name] = true
+			addColumn(prefix + field.ColumnName)
+		}
+	}
+
 	for _, propName := range selectedProperties {
 		propName = strings.TrimSpace(propName)
 		for _, prop := range entityMetadata.Properties {
-			if (prop.JsonName == propName || prop.Name == propName) && !prop.IsNavigationProp && !prop.IsComplexType && !prop.IsStream && !prop.IsComputed {
-				// Use GetColumnName for proper column name resolution (handles GORM tags and metadata)
-				columnName := GetColumnName(prop.Name, entityMetadata)
-				addColumn(columnName)
+			if (prop.JsonName == propName || prop.Name == propName) && !prop.IsNavigationProp && !prop.IsStream && !prop.IsComputed {
+				if prop.IsComplexType {
+					addComplexTypeColumns(&prop)
+				} else {
+					// Use GetColumnName for proper column name resolution (handles GORM tags and metadata)
+					columnName := GetColumnName(prop.Name, entityMetadata)
+					addColumn(columnName)
+				}
 				selectedPropMap[prop.Name] = true
 				break
 			}
@@ -152,10 +171,6 @@ func ApplySelect(results interface{}, selectedProperties []string, entityMetadat
 		filteredItem := make(map[string]interface{})
 
 		for _, prop := range entityMetadata.Properties {
-			if prop.IsComplexType {
-				continue
-			}
-
 			isSelected := selectedPropMap[prop.JsonName] || selectedPropMap[prop.Name]
 			isKey := keyPropMap[prop.Name]
 			isExpanded := prop.IsNavigationProp && (expandedPropMap[prop.Name] != nil || expandedPropMap[prop.JsonName] != nil)
@@ -256,10 +271,6 @@ func ApplySelectToEntity(entity interface{}, selectedProperties []string, entity
 	}
 
 	for _, prop := range entityMetadata.Properties {
-		if prop.IsComplexType {
-			continue
-		}
-
 		isSelected := selectedPropMap[prop.JsonName] || selectedPropMap[prop.Name]
 		isKey := keyPropMap[prop.Name]
 		isExpanded := prop.IsNavigationProp && (expandedPropMap[prop.Name] != nil || expandedPropMap[prop.JsonName] != nil)

--- a/test/complex_property_test.go
+++ b/test/complex_property_test.go
@@ -234,3 +234,83 @@ func TestComplexPropertyNull(t *testing.T) {
 		t.Fatalf("expected status 204, got %d", w.Code)
 	}
 }
+
+// TestComplexPropertyMetadataDeclaresComplexType ensures a struct field mapped
+// via gorm's "embedded" tag is declared in $metadata as the actual ComplexType
+// it embeds, not as Edm.String (a client trusting $metadata must be able to
+// deserialize the property correctly).
+func TestComplexPropertyMetadataDeclaresComplexType(t *testing.T) {
+	service, _ := setupComplexPropertyService(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/$metadata", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+
+	if strings.Contains(body, `Name="shippingAddress" Type="Edm.String"`) {
+		t.Fatalf("shippingAddress must not be declared as Edm.String\nBody:\n%s", body)
+	}
+
+	want := `Name="shippingAddress" Type="ODataService.ComplexPropertyAddress"`
+	if !strings.Contains(body, want) {
+		t.Fatalf("expected metadata to contain %q\nBody:\n%s", want, body)
+	}
+}
+
+// TestComplexPropertySelect ensures $select explicitly naming a complex-type
+// property returns it in the response instead of silently dropping it.
+func TestComplexPropertySelect(t *testing.T) {
+	service, db := setupComplexPropertyService(t)
+
+	product := ComplexPropertyProduct{
+		ID:   1,
+		Name: "Widget",
+		ShippingAddress: &ComplexPropertyAddress{
+			Street: "123 Main St",
+			City:   "Metropolis",
+		},
+	}
+	if err := db.Create(&product).Error; err != nil {
+		t.Fatalf("failed to insert product: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ComplexPropertyProducts?$top=1&$select=shippingAddress", nil)
+	w := httptest.NewRecorder()
+
+	service.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Value []map[string]interface{} `json:"value"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(body.Value) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(body.Value))
+	}
+
+	shippingAddress, ok := body.Value[0]["shippingAddress"]
+	if !ok {
+		t.Fatalf("expected shippingAddress to be present in $select result, got %v", body.Value[0])
+	}
+	addr, ok := shippingAddress.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected shippingAddress to be an object, got %T: %v", shippingAddress, shippingAddress)
+	}
+	if addr["street"] != "123 Main St" {
+		t.Fatalf("expected street to be '123 Main St', got %v", addr["street"])
+	}
+	if addr["city"] != "Metropolis" {
+		t.Fatalf("expected city to be 'Metropolis', got %v", addr["city"])
+	}
+}


### PR DESCRIPTION
## Summary
- `Product.ShippingAddress`/`Product.Dimensions`-style properties (Go struct fields mapped via gorm's `embedded` tag) were correctly flagged `IsComplexType` by the metadata analyzer, but two downstream consumers of that flag ignored it:
  - `propertyEdmType` (`internal/handlers/metadata_shared.go`), shared by both the XML and JSON `$metadata` generators, had no branch for complex types and fell through to the `Edm.String` default — contradicting both the actual JSON wire format (a nested object) and the `ComplexType` the schema separately (and correctly) emits for that same struct. Fixed by resolving the qualified complex-type name when `prop.IsComplexType` is set.
  - `$select` projection (`ApplySelect`/`ApplySelectToEntity` in `internal/query/apply_select.go`) unconditionally skipped `IsComplexType` properties, so a property explicitly named in `$select` was dropped from the response entirely instead of being returned. The DB-level column selector (`applySelect`) had the same gap, and needed extra handling since a complex type doesn't map to a single column — it's spread across several prefix-named embedded columns (e.g. `shipping_street`, `shipping_city`).

## Test plan
- [x] Added `TestComplexPropertyMetadataDeclaresComplexType` (`test/complex_property_test.go`) — asserts `$metadata` declares the property as the qualified ComplexType, not `Edm.String`.
- [x] Added `TestComplexPropertySelect` — asserts `$select=shippingAddress` returns the nested object instead of dropping it.
- [x] Verified both new tests fail on the pre-fix code (reproducing the exact issue) and pass after the fix.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` clean.
- [x] `go test ./...` passes (full suite, no regressions).

Fixes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)