### PR TITLE
Skip explicit NULLS ordering for non-nullable $orderby columns on Postgres

### DIFF
--- a/internal/query/apply_transform.go
+++ b/internal/query/apply_transform.go
@@ -1200,8 +1200,9 @@ func applyOrderBy(db *gorm.DB, orderBy []OrderByItem, entityMetadata *metadata.E
 		var orderExprs []clause.OrderByColumn
 		for _, item := range orderBy {
 			var columnName string
+			isNavigationPath := entityMetadata != nil && entityMetadata.IsSingleEntityNavigationPath(item.Property)
 			if propertyExists(item.Property, entityMetadata) {
-				if entityMetadata.IsSingleEntityNavigationPath(item.Property) {
+				if isNavigationPath {
 					columnName = getQuotedColumnName(dialect, item.Property, entityMetadata)
 				} else {
 					col := GetColumnName(item.Property, entityMetadata)
@@ -1220,10 +1221,36 @@ func applyOrderBy(db *gorm.DB, orderBy []OrderByItem, entityMetadata *metadata.E
 				columnName = quoteIdent(dialect, sanitizedAlias)
 			}
 
-			// Build the ORDER BY expression with NULL handling
-			direction := " ASC NULLS FIRST"
+			// Build the ORDER BY expression. Per OData v4.0, ascending order sorts NULLs
+			// before non-NULL values and descending order sorts NULLs after non-NULL values;
+			// PostgreSQL's own defaults are the reverse (NULLS LAST for ASC, NULLS FIRST for
+			// DESC), so an explicit NULLS clause is normally required for spec compliance.
+			//
+			// That explicit clause has a real cost: it doesn't match the sort order a plain
+			// b-tree index on the column produces, so PostgreSQL falls back to a sequential
+			// scan plus an explicit sort instead of an index (or index-backward) scan, even
+			// when the column is indexed. When the column is statically known to never be
+			// NULL (non-nullable Go type, or GORM "not null"), the two orderings are
+			// equivalent - there are no NULLs to place - so the clause can be safely omitted,
+			// letting the planner use the index. Navigation paths and unresolved
+			// aliases keep the explicit clause since their nullability isn't known here.
+			needsNullsClause := true
+			if !isNavigationPath && entityMetadata != nil {
+				if prop := entityMetadata.FindProperty(item.Property); prop != nil && prop.Nullable != nil && !*prop.Nullable {
+					needsNullsClause = false
+				}
+			}
+
+			direction := " ASC"
 			if item.Descending {
-				direction = " DESC NULLS LAST"
+				direction = " DESC"
+			}
+			if needsNullsClause {
+				if item.Descending {
+					direction += " NULLS LAST"
+				} else {
+					direction += " NULLS FIRST"
+				}
 			}
 
 			orderExprs = append(orderExprs, clause.OrderByColumn{


### PR DESCRIPTION
## Summary
- Every Postgres `$orderby` unconditionally appends an explicit `NULLS FIRST`/`NULLS LAST` clause (added to keep null-ordering consistent with SQLite/MySQL defaults per OData v4.0).
- That clause doesn't match the sort order a plain b-tree index produces, so PostgreSQL falls back to a sequential scan + explicit sort instead of an index scan, even when the sorted column is indexed.
- Confirmed with `EXPLAIN ANALYZE` on a 10k-row seeded table: `ORDER BY price DESC LIMIT 101` runs as an Index Scan Backward in 0.28ms; the same query with `NULLS LAST` (what go-odata emits today) runs as Seq Scan + Sort in 1.67ms — a 6x gap that widens with table size.
- When the sorted column is statically known to never contain NULL (non-pointer Go type, or GORM `not null`), the two null-orderings are equivalent — there's nothing to place — so the clause is safely omitted in that case, letting the planner use the index. Navigation paths and unresolved aliases (unknown nullability) keep the explicit clause.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/query/... ./test/...`
- [x] Verified via `EXPLAIN ANALYZE` that the generated SQL for `$orderby=Price desc` is now a plain `ORDER BY "price" DESC` and Postgres picks the index scan (confirmed via `log_statement=all`).
- [x] Load-tested against a real Postgres instance (Docker, 10k seeded products): `$orderby=Price desc` at 20 concurrent connections went from 2055 req/s (p50 8.9ms) to 4106 req/s (p50 4.5ms) — now on par with an equivalent `$filter` query instead of trailing behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)