### PR TITLE
Avoid copying the response buffer before writing it to the client

### DIFF
--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -168,31 +168,34 @@ func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.R
 	envelope.Set("value", transformedData)
 
 	if r.Method == http.MethodHead {
-		jsonBytes, err := json.Marshal(envelope)
+		buf, err := envelope.marshalToPooledBuffer()
 		envelope.Release()
 		if err != nil {
 			releaseOrderedMaps(transformedData)
 			return WriteError(w, r, http.StatusInternalServerError, "Internal Server Error", "Failed to serialize response to JSON.")
 		}
 		w.Header().Set("Content-Type", fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(jsonBytes)))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
 		w.WriteHeader(http.StatusOK)
+		releasePooledBuffer(buf)
 		releaseOrderedMaps(transformedData)
 		return nil
 	}
 
-	// Marshal to bytes first so we can set Content-Length and avoid the outer appendCompact
-	// re-scan that json.Encoder.Encode performs after calling MarshalJSON.
-	responseBytes, marshalErr := envelope.MarshalJSON()
+	// Marshal into a pooled buffer and write its bytes directly, avoiding the copy-out
+	// allocation that envelope.MarshalJSON() would otherwise need to satisfy the
+	// json.Marshaler contract of returning an owned []byte.
+	buf, marshalErr := envelope.marshalToPooledBuffer()
 	envelope.Release()
 	releaseOrderedMaps(transformedData)
 	if marshalErr != nil {
 		return marshalErr
 	}
 	w.Header().Set("Content-Type", fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(responseBytes)))
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
 	w.WriteHeader(http.StatusOK)
-	_, err := w.Write(responseBytes)
+	_, err := w.Write(buf.Bytes())
+	releasePooledBuffer(buf)
 	return err
 }
 

--- a/internal/response/navigation_links.go
+++ b/internal/response/navigation_links.go
@@ -352,24 +352,29 @@ func WriteODataEntityFromNavigationPath(w http.ResponseWriter, r *http.Request, 
 	w.Header().Set("Content-Type", fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel))
 
 	if r.Method == http.MethodHead {
-		jsonBytes, err := entityMap.MarshalJSON()
+		buf, err := entityMap.marshalToPooledBuffer()
 		entityMap.Release()
 		if err != nil {
 			return err
 		}
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(jsonBytes)))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
 		w.WriteHeader(http.StatusOK)
+		releasePooledBuffer(buf)
 		return nil
 	}
 
-	responseBytes, err := entityMap.MarshalJSON()
+	// Marshal into a pooled buffer and write its bytes directly, avoiding the copy-out
+	// allocation that entityMap.MarshalJSON() would otherwise need to satisfy the
+	// json.Marshaler contract of returning an owned []byte.
+	buf, err := entityMap.marshalToPooledBuffer()
 	entityMap.Release()
 	if err != nil {
 		return err
 	}
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(responseBytes)))
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
 	w.WriteHeader(http.StatusOK)
-	_, writeErr := w.Write(responseBytes)
+	_, writeErr := w.Write(buf.Bytes())
+	releasePooledBuffer(buf)
 	return writeErr
 }
 

--- a/internal/response/ordered_map.go
+++ b/internal/response/ordered_map.go
@@ -151,29 +151,49 @@ func (om *OrderedMap) ToMap() map[string]interface{} {
 
 // MarshalJSON implements json.Marshaler to maintain field order.
 func (om *OrderedMap) MarshalJSON() ([]byte, error) {
-	if len(om.keys) == 0 {
-		return []byte("{}"), nil
-	}
-
-	buf := bufferPool.Get().(*bytes.Buffer) //nolint:errcheck // sync.Pool.Get() doesn't return error
-	buf.Reset()
-	defer func() {
-		// Pool buffers up to 512KB. With marshalTo writing the full collection
-		// JSON into one buffer, responses for top=100-500 can reach 100-500KB.
-		if buf.Cap() < 512*1024 {
-			bufferPool.Put(buf)
-		}
-	}()
-
-	buf.Grow(len(om.keys) * 100)
-
-	if err := om.marshalTo(buf); err != nil {
+	buf, err := om.marshalToPooledBuffer()
+	if err != nil {
 		return nil, err
 	}
+	defer releasePooledBuffer(buf)
 
 	result := make([]byte, buf.Len())
 	copy(result, buf.Bytes())
 	return result, nil
+}
+
+// marshalToPooledBuffer serializes the ordered map into a buffer obtained from bufferPool.
+// Callers that only need to write the bytes out (e.g. to an http.ResponseWriter) can use
+// buf.Bytes() directly and avoid the copy-out allocation that MarshalJSON performs solely
+// to satisfy the json.Marshaler interface contract of returning an owned []byte. The
+// returned buffer must be released via releasePooledBuffer once its bytes are no longer
+// needed.
+func (om *OrderedMap) marshalToPooledBuffer() (*bytes.Buffer, error) {
+	buf := bufferPool.Get().(*bytes.Buffer) //nolint:errcheck // sync.Pool.Get() doesn't return error
+	buf.Reset()
+
+	if len(om.keys) == 0 {
+		buf.WriteString("{}")
+		return buf, nil
+	}
+
+	buf.Grow(len(om.keys) * 100)
+
+	if err := om.marshalTo(buf); err != nil {
+		releasePooledBuffer(buf)
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+// releasePooledBuffer returns buf to bufferPool. Buffers that grew past 512KB are dropped
+// instead of pooled, matching the size cap marshalToPooledBuffer's callers rely on to avoid
+// bloating the pool with oversized buffers from unusually large responses.
+func releasePooledBuffer(buf *bytes.Buffer) {
+	if buf.Cap() < 512*1024 {
+		bufferPool.Put(buf)
+	}
 }
 
 // marshalTo writes the JSON representation directly to buf.


### PR DESCRIPTION
## Summary
- `OrderedMap.MarshalJSON()` serialized into a pooled `bytes.Buffer`, then allocated a brand-new `[]byte` and copied the buffer into it purely to satisfy the `json.Marshaler` contract (return an owned slice).
- The only callers on the hot path (collection and single-entity JSON responses) immediately wrote those bytes to the `http.ResponseWriter` and discarded them, so that copy bought nothing.
- An allocation profile taken under concurrent load (Postgres backend, `$top=100`) showed this copy-out step alone accounted for ~18% of all bytes allocated (1.37GB of 7.45GB in a 10s window).
- Adds `marshalToPooledBuffer()`/`releasePooledBuffer()` so callers can write `buf.Bytes()` straight to the `ResponseWriter` and release the buffer afterward, instead of going through the copying `MarshalJSON()`. Applied to the collection envelope writer and the single-entity writer (including their HEAD-request variants). `MarshalJSON()` itself becomes a thin wrapper around the same helper for any caller that still needs the `json.Marshaler` contract.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/response/... ./test/...`
- [x] Re-profiled allocations after the change — the `OrderedMap.MarshalJSON` copy-out no longer appears in the top allocators under the same load.
- [x] Load-tested against Postgres (10k seeded products): combined with the sibling PRs in this stack, throughput on `$top=100` went from 2979 to 4214 req/s at 20 concurrent connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)