### PR TITLE
Add perfserver memory profiles

### DIFF
--- a/cmd/perfserver/PERFORMANCE_ANALYSIS.md
+++ b/cmd/perfserver/PERFORMANCE_ANALYSIS.md
@@ -33,10 +33,10 @@ This provides:
 ### Load Test with CPU Profiling
 
 ```bash
-./run_load_tests.sh --wrk -d 30s --cpu-profile
+./run_load_tests.sh -d 30s --cpu-profile --memory-profile
 ```
 
-This generates `load-test-results/cpu.prof` showing:
+This generates `load-test-results/cpu.prof`, `heap.prof`, and `alloc.prof` showing:
 - Where CPU time is spent
 - Hot functions and call paths
 - Memory allocation patterns
@@ -61,7 +61,7 @@ This generates `load-test-results/sql-trace.txt` showing:
 ### Full Profiling (CPU + SQL)
 
 ```bash
-./run_load_tests.sh --wrk -d 30s --cpu-profile --sql-trace
+./run_load_tests.sh -d 30s --cpu-profile --memory-profile --sql-trace
 ```
 
 **Use when:** You want comprehensive performance insights.

--- a/cmd/perfserver/README.md
+++ b/cmd/perfserver/README.md
@@ -6,6 +6,7 @@ This is the performance testing server for the go-odata library. It provides ext
 
 - **Extensive Data Seeding**: Generates 10,000 products, 100 categories, and 30,000 product descriptions by default
 - **CPU Profiling**: Built-in CPU profiling support for performance analysis
+- **Memory Profiling**: Heap and cumulative allocation profiles captured on shutdown
 - **SQL Query Tracing**: Detailed SQL query tracking with optimization recommendations
 - **Database Support**: Works with both SQLite and PostgreSQL
 
@@ -55,7 +56,18 @@ This will:
 
 ### Combined Profiling
 ```bash
-go run . -cpuprofile cpu.prof -trace-sql -trace-sql-file sql-trace.txt
+go run . -cpuprofile cpu.prof -heapprofile heap.prof -allocprofile alloc.prof -trace-sql -trace-sql-file sql-trace.txt
+```
+
+### Memory Profiling
+```bash
+go run . -heapprofile heap.prof -allocprofile alloc.prof
+```
+
+Stop the server gracefully to write the profiles. Inspect retained heap and cumulative allocation pressure with:
+```bash
+go tool pprof -top -sample_index=inuse_space heap.prof
+go tool pprof -top -sample_index=alloc_space alloc.prof
 ```
 
 ## Seeding Options
@@ -131,6 +143,9 @@ Use the included load testing script to run comprehensive performance tests:
 
 # With CPU profiling
 ./run_load_tests.sh --cpu-profile
+
+# With heap and allocation profiling
+./run_load_tests.sh --memory-profile
 
 # With SQL tracing
 ./run_load_tests.sh --sql-trace
@@ -222,4 +237,3 @@ For detailed instructions on analyzing performance bottlenecks, see:
 - SQL query optimization
 - Common bottlenecks and solutions
 - Performance testing best practices
-

--- a/cmd/perfserver/main.go
+++ b/cmd/perfserver/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"runtime/pprof"
 	"syscall"
 	"time"
@@ -27,6 +28,8 @@ func main() {
 	dbDSN := flag.String("dsn", "", "Database DSN (connection string). For postgres, use postgresql://... format. For sqlite, use file path")
 	port := flag.String("port", "9091", "Port to listen on")
 	cpuProfile := flag.String("cpuprofile", "", "Write CPU profile to file")
+	heapProfile := flag.String("heapprofile", "", "Write live heap profile on shutdown")
+	allocProfile := flag.String("allocprofile", "", "Write cumulative allocation profile on shutdown")
 	traceSQL := flag.Bool("trace-sql", false, "Enable SQL query tracing and optimization analysis")
 	traceSQLFile := flag.String("trace-sql-file", "", "Write SQL trace analysis to file (requires --trace-sql)")
 	extensive := flag.Bool("extensive", true, "Use extensive seeding with large datasets for performance testing")
@@ -74,6 +77,10 @@ func main() {
 				log.Printf("Error closing CPU profile file: %v", err)
 			}
 			fmt.Println("✅ CPU profile written to:", *cpuProfile)
+		}
+
+		if err := writeMemoryProfiles(*heapProfile, *allocProfile); err != nil {
+			log.Printf("Error writing memory profile: %v", err)
 		}
 
 		// Print SQL trace summary if enabled
@@ -254,6 +261,17 @@ func main() {
 		fmt.Println()
 	}
 
+	if *heapProfile != "" || *allocProfile != "" {
+		fmt.Println("🧠 Memory Profiling: ENABLED")
+		if *heapProfile != "" {
+			fmt.Printf("  Live heap profile: %s\n", *heapProfile)
+		}
+		if *allocProfile != "" {
+			fmt.Printf("  Cumulative allocation profile: %s\n", *allocProfile)
+		}
+		fmt.Println()
+	}
+
 	if *extensive {
 		fmt.Println("📈 Extensive seeding mode: ENABLED")
 		fmt.Println("  10,000 products, 100 categories, 30,000 descriptions")
@@ -284,4 +302,41 @@ func main() {
 			}
 		}
 	}
+}
+
+func writeMemoryProfiles(heapProfile, allocProfile string) error {
+	if heapProfile == "" && allocProfile == "" {
+		return nil
+	}
+
+	if heapProfile != "" {
+		runtime.GC()
+		if err := writeProfile(heapProfile, pprof.Lookup("heap")); err != nil {
+			return err
+		}
+		fmt.Println("✅ Heap profile written to:", heapProfile)
+	}
+
+	if allocProfile != "" {
+		if err := writeProfile(allocProfile, pprof.Lookup("allocs")); err != nil {
+			return err
+		}
+		fmt.Println("✅ Allocation profile written to:", allocProfile)
+	}
+
+	return nil
+}
+
+func writeProfile(path string, profile *pprof.Profile) error {
+	if profile == nil {
+		return fmt.Errorf("profile is unavailable")
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return profile.WriteTo(f, 0)
 }

--- a/cmd/perfserver/run_load_tests.sh
+++ b/cmd/perfserver/run_load_tests.sh
@@ -24,6 +24,7 @@ DB_TYPE="sqlite"           # sqlite | postgres
 DB_DSN=""                  # Optional; for postgres defaults if empty
 EXTERNAL_SERVER=0          # Don't start/stop server automatically
 ENABLE_CPU_PROFILE=0       # Enable CPU profiling
+ENABLE_MEMORY_PROFILE=0    # Enable heap and allocation profiling
 ENABLE_SQL_TRACE=0         # Enable SQL query tracing
 FEATURE_FLAG_SPEEDUP_THRESHOLD="1.50"  # Cached must be at least this many times faster
 
@@ -95,6 +96,18 @@ cleanup() {
             else
                 echo -e "${YELLOW}⚠ CPU profile file not found at /tmp/perfserver-cpu.prof${NC}"
             fi
+        fi
+
+        if [ $ENABLE_MEMORY_PROFILE -eq 1 ]; then
+            for profile_name in heap alloc; do
+                profile_path="/tmp/perfserver-${profile_name}.prof"
+                if [ -s "$profile_path" ]; then
+                    cp "$profile_path" "$OUTPUT_DIR/${profile_name}.prof"
+                    echo -e "${GREEN}✓ ${profile_name} profile saved to: $OUTPUT_DIR/${profile_name}.prof${NC}"
+                else
+                    echo -e "${YELLOW}⚠ ${profile_name} profile file not found or empty at $profile_path${NC}"
+                fi
+            done
         fi
         
         if [ $ENABLE_SQL_TRACE -eq 1 ]; then
@@ -286,6 +299,12 @@ start_server() {
         echo "📊 CPU profiling: ENABLED"
     fi
 
+    if [ $ENABLE_MEMORY_PROFILE -eq 1 ]; then
+        SERVER_ARGS+=( -heapprofile /tmp/perfserver-heap.prof )
+        SERVER_ARGS+=( -allocprofile /tmp/perfserver-alloc.prof )
+        echo "🧠 Memory profiling: ENABLED"
+    fi
+
     if [ $ENABLE_SQL_TRACE -eq 1 ]; then
         SERVER_ARGS+=( -trace-sql -trace-sql-file /tmp/perfserver-sql-trace.txt )
         echo "🔍 SQL tracing: ENABLED"
@@ -473,6 +492,7 @@ OPTIONS:
     --dsn DSN              Database DSN/connection string (required for postgres)
     --external-server      Use an external server (don't start/stop the perfserver)
     --cpu-profile          Enable CPU profiling (saves to OUTPUT_DIR/cpu.prof)
+    --memory-profile       Enable heap and allocation profiles (saves to OUTPUT_DIR/heap.prof and alloc.prof)
     --sql-trace            Enable SQL query tracing (saves to OUTPUT_DIR/sql-trace.txt)
     --feature-flag-threshold NUM
                            Minimum cached/uncached speedup ratio for validation (default: 1.50)
@@ -490,8 +510,8 @@ EXAMPLES:
     # Run with custom parameters
     $0 -d 60s -t 12 -C 200
     
-    # Enable CPU profiling and SQL tracing
-    $0 --cpu-profile --sql-trace
+    # Enable CPU, memory, and SQL profiling
+    $0 --cpu-profile --memory-profile --sql-trace
 
     # Custom server URL and output directory (external server)
     $0 --external-server -u http://localhost:8080 -o ./my-results
@@ -555,6 +575,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --cpu-profile)
             ENABLE_CPU_PROFILE=1
+            shift
+            ;;
+        --memory-profile)
+            ENABLE_MEMORY_PROFILE=1
             shift
             ;;
         --sql-trace)


### PR DESCRIPTION
## Summary

Adds supported heap and cumulative allocation profiling to the performance server and load-test script.

The server writes profiles on graceful shutdown. The load-test script copies them into the result directory, and the documentation now includes the commands needed to inspect retained heap and allocation pressure.

## Performance impact

This is observability work, not a throughput optimization. It closes the prior measurement gap: CPU and SQL tracing were supported, while memory allocation profiling was documented but could not be generated by the harness.

A local smoke test produced non-empty profile artifacts on graceful shutdown:

- heap profile: 2.6 KB
- allocation profile: 3.2 KB

## Validation

- `bash -n cmd/perfserver/run_load_tests.sh`
- `go test -mod=mod ./...` in `cmd/perfserver`
- `go build -mod=mod ./...` in `cmd/perfserver`
- local graceful-shutdown profile smoke test
- `go vet ./...`
- `go build ./...`
- `go test ./...`
