### PR TITLE
Index uncached feature flag queries

### DIFF
--- a/cmd/perfserver/entities/feature_flag.go
+++ b/cmd/perfserver/entities/feature_flag.go
@@ -22,9 +22,9 @@ type UncachedFeatureFlag struct {
 	ID                uint      `json:"ID" gorm:"primaryKey" odata:"key"`
 	Key               string    `json:"Key" gorm:"not null;uniqueIndex:idx_uncached_feature_flags_key" odata:"required,maxlength=200"`
 	Description       string    `json:"Description" odata:"maxlength=500"`
-	Environment       string    `json:"Environment" gorm:"not null" odata:"required,maxlength=20"`
-	Enabled           bool      `json:"Enabled" gorm:"not null"`
-	RolloutPercentage int       `json:"RolloutPercentage" gorm:"not null" odata:"required"`
+	Environment       string    `json:"Environment" gorm:"not null;index:idx_uncached_feature_flags_env_enabled_rollout,priority:1" odata:"required,maxlength=20"`
+	Enabled           bool      `json:"Enabled" gorm:"not null;index:idx_uncached_feature_flags_env_enabled_rollout,priority:2"`
+	RolloutPercentage int       `json:"RolloutPercentage" gorm:"not null;index:idx_uncached_feature_flags_env_enabled_rollout,priority:3,sort:desc" odata:"required"`
 	Owner             string    `json:"Owner" odata:"maxlength=120"`
 	UpdatedAt         time.Time `json:"UpdatedAt"`
 }


### PR DESCRIPTION
## Summary

Adds the same composite `(environment, enabled, rollout_percentage DESC)` index to uncached feature flags that cached feature flags already use.

This makes the cache benchmark compare cache behavior rather than an indexed table against an unindexed PostgreSQL table.

## Performance

PostgreSQL 17, 50,000 feature flags, filtered and ordered top-201 query:

| Schema | Plan | Execution time |
| --- | --- | ---: |
| Previous uncached table | Sequential scan of 50,000 rows plus top-N sort | 9.371 ms |
| This change | Composite index scan | 0.461 ms |

That is approximately a 20x database execution-time improvement. A single-client HTTP run reached 1,391 RPS.

## Validation

- `go test -mod=mod ./...` in `cmd/perfserver`
- `go build -mod=mod ./...` in `cmd/perfserver`
- PostgreSQL `EXPLAIN (ANALYZE, BUFFERS)` and HTTP smoke benchmark
- `go vet ./...`
- `go build ./...`
- `go test ./...`
