### PR TITLE
Cache metadata XML response bytes

### DIFF
--- a/internal/handlers/metadata_handler.go
+++ b/internal/handlers/metadata_handler.go
@@ -50,7 +50,7 @@ type MetadataHandler struct {
 	actions   map[string][]*actions.ActionDefinition
 	functions map[string][]*actions.FunctionDefinition
 	// Lock-free cached metadata documents by version (key: version string)
-	cachedXML            sync.Map     // map[string]string
+	cachedXML            sync.Map     // map[string][]byte
 	cachedJSON           sync.Map     // map[string][]byte
 	cacheSizeXML         atomic.Int64 // Tracks XML cache entries for eviction
 	cacheSizeJSON        atomic.Int64 // Tracks JSON cache entries for eviction

--- a/internal/handlers/metadata_handler_test.go
+++ b/internal/handlers/metadata_handler_test.go
@@ -368,4 +368,11 @@ func TestMetadataHandler_Caching(t *testing.T) {
 			t.Errorf("Request %d: Status = %v, want %v", i, w.Code, http.StatusOK)
 		}
 	}
+
+	handler.cachedXML.Range(func(_, value any) bool {
+		if _, ok := value.([]byte); !ok {
+			t.Errorf("XML cache value has type %T, want []byte", value)
+		}
+		return true
+	})
 }

--- a/internal/handlers/metadata_xml.go
+++ b/internal/handlers/metadata_xml.go
@@ -20,7 +20,7 @@ func (h *MetadataHandler) handleMetadataXML(w http.ResponseWriter, r *http.Reque
 
 	// Lock-free cache lookup (fast path - common case)
 	if cached, ok := h.cachedXML.Load(versionKey); ok {
-		cachedStr, ok := cached.(string)
+		cachedBytes, ok := cached.([]byte)
 		if !ok {
 			// Cache corruption - rebuild
 			h.cachedXML.Delete(versionKey)
@@ -30,13 +30,13 @@ func (h *MetadataHandler) handleMetadataXML(w http.ResponseWriter, r *http.Reque
 			w.Header().Set("Content-Type", "application/xml")
 
 			if r.Method == http.MethodHead {
-				w.Header().Set("Content-Length", fmt.Sprintf("%d", len(cachedStr)))
+				w.Header().Set("Content-Length", fmt.Sprintf("%d", len(cachedBytes)))
 				w.WriteHeader(http.StatusOK)
 				return
 			}
 
 			w.WriteHeader(http.StatusOK)
-			if _, err := w.Write([]byte(cachedStr)); err != nil {
+			if _, err := w.Write(cachedBytes); err != nil {
 				h.logger.Error("Error writing metadata response", "error", err)
 			}
 			return
@@ -45,7 +45,7 @@ func (h *MetadataHandler) handleMetadataXML(w http.ResponseWriter, r *http.Reque
 
 	// Cache miss - build metadata (slow path)
 	model := h.newMetadataModel()
-	cached := h.buildMetadataDocument(model, ver)
+	cached := []byte(h.buildMetadataDocument(model, ver))
 
 	// Store in cache using LoadOrStore for thread safety
 	// (another goroutine might have built it while we were building)
@@ -59,7 +59,7 @@ func (h *MetadataHandler) handleMetadataXML(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Use the actual cached value (ours or the one that was stored by another goroutine)
-	cachedStr, ok := actual.(string)
+	cachedBytes, ok := actual.([]byte)
 	if !ok {
 		// Should never happen, but handle gracefully
 		h.logger.Error("Invalid cache entry type", "version", versionKey)
@@ -69,13 +69,13 @@ func (h *MetadataHandler) handleMetadataXML(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Type", "application/xml")
 
 	if r.Method == http.MethodHead {
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(cachedStr)))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(cachedBytes)))
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(cachedStr)); err != nil {
+	if _, err := w.Write(cachedBytes); err != nil {
 		h.logger.Error("Error writing metadata response", "error", err)
 	}
 }


### PR DESCRIPTION
## Summary

Cache XML metadata as response-ready `[]byte` rather than a string. Cache hits now write the cached buffer directly instead of allocating a fresh byte slice for every response.

## Performance

`BenchmarkMetadataXML` (five runs, Apple M5):

| Revision | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Before | ~1,300 | ~7,925 | 25 |
| After | ~1,200 | ~7,220 | 24 |

That is about 7% lower cache-hit latency, 9% fewer allocated bytes, and one fewer allocation per request in the benchmark fixture. The PostgreSQL load trace attributed 3.17 GB of cumulative allocations to the metadata handler, chiefly from converting cached XML strings to byte slices.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
