### PR TITLE
Fast-scan expanded entity reads

### DIFF
--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -142,7 +142,10 @@ func (h *EntityHandler) fetchEntityByKey(ctx context.Context, entityKey string, 
 	if len(scopes) > 0 {
 		db = db.Scopes(scopes...)
 	}
-	baseDB := db
+	// Keep a pristine session for the post-read expand queries. GORM mutates the
+	// statement used by First (including its key predicate), so sharing it would
+	// incorrectly apply the parent key filter to child lookups.
+	baseDB := db.Session(&gorm.Session{NewDB: true})
 	if usingCache {
 		// Expand queries may require related tables that are not present in the cache DB.
 		// Run per-parent expand lookups against the primary database.

--- a/internal/handlers/expand_benchmark_test.go
+++ b/internal/handlers/expand_benchmark_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type expandBenchmarkCategory struct {
+	ID   uint `gorm:"primaryKey" odata:"key"`
+	Name string
+}
+
+type expandBenchmarkProduct struct {
+	ID         uint `gorm:"primaryKey" odata:"key"`
+	Name       string
+	CategoryID uint
+	Category   *expandBenchmarkCategory `gorm:"foreignKey:CategoryID;references:ID"`
+}
+
+func BenchmarkCollectionExpandBelongsTo(b *testing.B) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := db.AutoMigrate(&expandBenchmarkCategory{}, &expandBenchmarkProduct{}); err != nil {
+		b.Fatal(err)
+	}
+	categories := make([]expandBenchmarkCategory, 10)
+	for i := range categories {
+		categories[i] = expandBenchmarkCategory{ID: uint(i + 1), Name: "category"}
+	}
+	products := make([]expandBenchmarkProduct, 50)
+	for i := range products {
+		products[i] = expandBenchmarkProduct{ID: uint(i + 1), Name: "product", CategoryID: uint(i%len(categories) + 1)}
+	}
+	if err := db.Create(&categories).Error; err != nil {
+		b.Fatal(err)
+	}
+	if err := db.Create(&products).Error; err != nil {
+		b.Fatal(err)
+	}
+
+	productMeta, err := metadata.AnalyzeEntity(expandBenchmarkProduct{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	categoryMeta, err := metadata.AnalyzeEntity(expandBenchmarkCategory{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	handler := NewEntityHandler(db, productMeta, nil)
+	handler.SetEntitiesMetadata(map[string]*metadata.EntityMetadata{
+		productMeta.EntitySetName:  productMeta,
+		categoryMeta.EntitySetName: categoryMeta,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/ExpandBenchmarkProducts?$top=50&$expand=Category", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		handler.HandleCollection(w, req)
+		if w.Code != http.StatusOK {
+			b.Fatalf("status = %d: %s", w.Code, w.Body.String())
+		}
+	}
+}

--- a/internal/query/apply_expand.go
+++ b/internal/query/apply_expand.go
@@ -8,7 +8,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// applyExpand applies expand (preload) options to the GORM query
+// applyExpand applies expand options to the GORM query.
+//
+// Navigation values are populated after the parent query by
+// ApplyPerParentExpand. Keeping preloads off the parent query lets it use the
+// fast scanner and avoids GORM's preload callback path.
 func applyExpand(db *gorm.DB, expand []ExpandOption, entityMetadata *metadata.EntityMetadata) *gorm.DB {
 	if len(expand) == 0 {
 		return db
@@ -20,7 +24,7 @@ func applyExpand(db *gorm.DB, expand []ExpandOption, entityMetadata *metadata.En
 			continue
 		}
 
-		if needsPerParentExpand(expandOpt, navProp) {
+		if needsPerParentExpand(navProp) {
 			continue
 		}
 
@@ -43,11 +47,8 @@ func applyExpand(db *gorm.DB, expand []ExpandOption, entityMetadata *metadata.En
 	return db
 }
 
-func needsPerParentExpand(expandOpt ExpandOption, navProp *metadata.PropertyMetadata) bool {
-	if navProp == nil || !navProp.IsNavigationProp || !navProp.NavigationIsArray {
-		return false
-	}
-	return expandOpt.Top != nil || expandOpt.Skip != nil
+func needsPerParentExpand(navProp *metadata.PropertyMetadata) bool {
+	return navProp != nil && navProp.IsNavigationProp
 }
 
 // needsPreloadCallback checks if an expand option requires a preload callback

--- a/internal/query/apply_expand_test.go
+++ b/internal/query/apply_expand_test.go
@@ -48,60 +48,52 @@ func TestNeedsPerParentExpand(t *testing.T) {
 	meta := getExpandTestMetadata(t)
 
 	t.Run("nil nav prop returns false", func(t *testing.T) {
-		expandOpt := ExpandOption{}
-		result := needsPerParentExpand(expandOpt, nil)
+		result := needsPerParentExpand(nil)
 		if result {
 			t.Error("expected false for nil nav prop")
 		}
 	})
 
 	t.Run("non-navigation prop returns false", func(t *testing.T) {
-		expandOpt := ExpandOption{}
 		navProp := &metadata.PropertyMetadata{
 			Name:             "Name",
 			IsNavigationProp: false,
 		}
-		result := needsPerParentExpand(expandOpt, navProp)
+		result := needsPerParentExpand(navProp)
 		if result {
 			t.Error("expected false for non-navigation prop")
 		}
 	})
 
-	t.Run("single entity navigation returns false", func(t *testing.T) {
-		expandOpt := ExpandOption{}
+	t.Run("single entity navigation returns true", func(t *testing.T) {
 		navProp := meta.FindNavigationProperty("category")
-		result := needsPerParentExpand(expandOpt, navProp)
-		if result {
-			t.Error("expected false for single entity navigation")
+		result := needsPerParentExpand(navProp)
+		if !result {
+			t.Error("expected true for single entity navigation")
 		}
 	})
 
 	t.Run("array navigation with top returns true", func(t *testing.T) {
-		top := 5
-		expandOpt := ExpandOption{Top: &top}
 		navProp := meta.FindNavigationProperty("tags")
-		result := needsPerParentExpand(expandOpt, navProp)
+		result := needsPerParentExpand(navProp)
 		if !result {
 			t.Error("expected true for array navigation with top")
 		}
 	})
 
 	t.Run("array navigation with skip returns true", func(t *testing.T) {
-		skip := 5
-		expandOpt := ExpandOption{Skip: &skip}
 		navProp := meta.FindNavigationProperty("tags")
-		result := needsPerParentExpand(expandOpt, navProp)
+		result := needsPerParentExpand(navProp)
 		if !result {
 			t.Error("expected true for array navigation with skip")
 		}
 	})
 
-	t.Run("array navigation without top/skip returns false", func(t *testing.T) {
-		expandOpt := ExpandOption{}
+	t.Run("array navigation without top/skip returns true", func(t *testing.T) {
 		navProp := meta.FindNavigationProperty("tags")
-		result := needsPerParentExpand(expandOpt, navProp)
-		if result {
-			t.Error("expected false for array navigation without top/skip")
+		result := needsPerParentExpand(navProp)
+		if !result {
+			t.Error("expected true for array navigation without top/skip")
 		}
 	})
 }

--- a/internal/query/expand_per_parent.go
+++ b/internal/query/expand_per_parent.go
@@ -5,10 +5,12 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/nlstn/go-odata/internal/fastscan"
 	"github.com/nlstn/go-odata/internal/metadata"
 	"gorm.io/gorm"
+	gormschema "gorm.io/gorm/schema"
 )
 
 // ApplyPerParentExpand applies $expand options with $top/$skip for collection navigation properties per parent.
@@ -24,11 +26,17 @@ func ApplyPerParentExpand(db *gorm.DB, results interface{}, expandOptions []Expa
 
 	for _, expandOpt := range expandOptions {
 		navProp := findNavigationProperty(expandOpt.NavigationProperty, entityMetadata)
-		if !needsPerParentExpand(expandOpt, navProp) {
+		if navProp != nil && navProp.IsManyToMany {
+			if err := loadManyToManyExpand(db, parentValues, navProp, expandOpt, entityMetadata); err != nil {
+				return err
+			}
+			continue
+		}
+		if !needsPerParentExpand(navProp) {
 			// Even if this expand doesn't need per-parent processing itself, recurse into
 			// already-loaded children when the nested expands need per-parent processing.
 			if len(expandOpt.Expand) > 0 && navProp != nil && navProp.IsNavigationProp {
-				targetMetadata, err := entityMetadata.ResolveNavigationTarget(expandOpt.NavigationProperty)
+				targetMetadata, err := resolveExpandTarget(entityMetadata, navProp, expandOpt.NavigationProperty)
 				if err == nil {
 					if err := applyNestedPerParentExpand(db, parentValues, navProp, expandOpt.Expand, targetMetadata); err != nil {
 						return err
@@ -38,7 +46,7 @@ func ApplyPerParentExpand(db *gorm.DB, results interface{}, expandOptions []Expa
 			continue
 		}
 
-		targetMetadata, err := entityMetadata.ResolveNavigationTarget(expandOpt.NavigationProperty)
+		targetMetadata, err := resolveExpandTarget(entityMetadata, navProp, expandOpt.NavigationProperty)
 		if err != nil {
 			continue
 		}
@@ -90,6 +98,68 @@ func ApplyPerParentExpand(db *gorm.DB, results interface{}, expandOptions []Expa
 	}
 
 	return nil
+}
+
+// loadManyToManyExpand keeps the parent collection on the fast-scan path while
+// delegating the join-table-specific lookup to GORM. GORM's relationship parser
+// is authoritative for custom and self-referential join columns. This fallback
+// is deliberately isolated to the association lookup; direct relationships use
+// the batched fast-scan-friendly loader above.
+func loadManyToManyExpand(db *gorm.DB, parentValues []reflect.Value, navProp *metadata.PropertyMetadata, expandOpt ExpandOption, entityMetadata *metadata.EntityMetadata) error {
+	targetMetadata, err := resolveExpandTarget(entityMetadata, navProp, expandOpt.NavigationProperty)
+	if err != nil {
+		return err
+	}
+	for _, parentValue := range parentValues {
+		parent := dereferenceValue(parentValue)
+		if !parent.IsValid() || parent.Kind() != reflect.Struct || !parent.CanAddr() {
+			continue
+		}
+		parentPtr := parent.Addr().Interface()
+		preloadDB := db.Session(&gorm.Session{NewDB: true}).Preload(navProp.Name, func(childDB *gorm.DB) *gorm.DB {
+			return applyExpandCallback(childDB, stripNestedExpand(expandOpt), targetMetadata)
+		})
+		if err := preloadDB.First(parentPtr).Error; err != nil {
+			return err
+		}
+		if len(expandOpt.Expand) > 0 {
+			if err := applyNestedPerParentExpand(db, []reflect.Value{parentPtrValue(parentPtr)}, navProp, expandOpt.Expand, targetMetadata); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func parentPtrValue(parent interface{}) reflect.Value {
+	return reflect.ValueOf(parent)
+}
+
+func stripNestedExpand(expandOpt ExpandOption) ExpandOption {
+	expandOpt.Expand = nil
+	return expandOpt
+}
+
+// resolveExpandTarget normally uses the service metadata registry. Entity
+// handlers may be used standalone, however, in which case the registry only
+// contains the root type. The navigation field still gives us enough type
+// information to load a direct relationship, so use it as a safe fallback.
+func resolveExpandTarget(entityMetadata *metadata.EntityMetadata, navProp *metadata.PropertyMetadata, navigationProperty string) (*metadata.EntityMetadata, error) {
+	targetMetadata, err := entityMetadata.ResolveNavigationTarget(navigationProperty)
+	if err == nil {
+		return targetMetadata, nil
+	}
+	if navProp == nil {
+		return nil, err
+	}
+	targetType := navProp.Type
+	for targetType.Kind() == reflect.Ptr || targetType.Kind() == reflect.Slice || targetType.Kind() == reflect.Array {
+		targetType = targetType.Elem()
+	}
+	if targetType.Kind() != reflect.Struct {
+		return nil, err
+	}
+	return metadata.AnalyzeEntity(reflect.New(targetType).Interface())
 }
 
 func collectParentValues(results interface{}) ([]reflect.Value, error) {
@@ -157,7 +227,55 @@ func resolveParentReferenceProperty(navProp *metadata.PropertyMetadata, entityMe
 		return expandCompositeConstraints(navProp.ReferentialConstraints, entityMetadata, targetMetadata)
 	}
 
+	// GORM's relationship schema is the source of truth for relationship
+	// direction when tags do not describe enough information. Most navigation
+	// fields expose foreignKey/references, however, and resolving those against
+	// our already-built metadata avoids reparsing GORM schema on every request.
+	if constraints := gormRelationshipConstraints(navProp, entityMetadata); len(constraints) > 0 {
+		return constraints
+	}
+
 	return fallbackReferenceConstraints(navProp, entityMetadata, targetMetadata)
+}
+
+func gormRelationshipConstraints(navProp *metadata.PropertyMetadata, entityMetadata *metadata.EntityMetadata) []parentReferenceConstraint {
+	ownerType := entityMetadata.EntityType
+	for ownerType.Kind() == reflect.Ptr {
+		ownerType = ownerType.Elem()
+	}
+	if ownerType.Kind() != reflect.Struct || navProp.IsManyToMany {
+		return nil
+	}
+
+	sch, err := gormschema.Parse(reflect.New(ownerType).Interface(), &sync.Map{}, gormschema.NamingStrategy{})
+	if err != nil || sch == nil {
+		return nil
+	}
+	rel := sch.Relationships.Relations[navProp.FieldName]
+	if rel == nil {
+		return nil
+	}
+
+	constraints := make([]parentReferenceConstraint, 0, len(rel.References))
+	for _, ref := range rel.References {
+		if ref == nil || ref.PrimaryKey == nil || ref.ForeignKey == nil {
+			continue
+		}
+		constraint := parentReferenceConstraint{}
+		if ref.OwnPrimaryKey {
+			// has-one / has-many: target.ForeignKey = parent.PrimaryKey
+			constraint.dependentProperty = ref.ForeignKey.Name
+			constraint.dependentColumn = ref.ForeignKey.DBName
+			constraint.principalProperty = ref.PrimaryKey.Name
+		} else {
+			// belongs-to: target.PrimaryKey = parent.ForeignKey
+			constraint.dependentProperty = ref.PrimaryKey.Name
+			constraint.dependentColumn = ref.PrimaryKey.DBName
+			constraint.principalProperty = ref.ForeignKey.Name
+		}
+		constraints = append(constraints, constraint)
+	}
+	return constraints
 }
 
 func expandCompositeConstraints(constraints map[string]string, entityMetadata *metadata.EntityMetadata, targetMetadata *metadata.EntityMetadata) []parentReferenceConstraint {
@@ -176,6 +294,14 @@ func expandCompositeConstraints(constraints map[string]string, entityMetadata *m
 		for i := 0; i < count; i++ {
 			dependent := resolvePropertyName(dependents[i], targetMetadata)
 			principal := resolvePropertyName(principals[i], entityMetadata)
+			if targetMetadata.FindProperty(dependent) == nil &&
+				entityMetadata.FindProperty(dependents[i]) != nil &&
+				targetMetadata.FindProperty(principals[i]) != nil {
+				// belongs-to: the tag's foreign key is on the parent and the
+				// referenced key is on the target.
+				dependent = resolvePropertyName(principals[i], targetMetadata)
+				principal = resolvePropertyName(dependents[i], entityMetadata)
+			}
 			resolved = append(resolved, parentReferenceConstraint{
 				dependentProperty: dependent,
 				dependentColumn:   GetColumnName(dependent, targetMetadata),
@@ -446,7 +572,7 @@ func buildCompositeKey(values []interface{}) string {
 	var builder strings.Builder
 	for _, value := range values {
 		normalized := normalizeKeyValue(value)
-		builder.WriteString(fmt.Sprintf("%T:%v|", normalized, normalized))
+		_, _ = fmt.Fprintf(&builder, "%T:%v|", normalized, normalized)
 	}
 	return builder.String()
 }
@@ -579,17 +705,34 @@ func setNavigationValue(parentStruct reflect.Value, navProp *metadata.PropertyMe
 		return nil
 	}
 
-	if field.Kind() != reflect.Slice {
+	if field.Kind() == reflect.Slice {
+		if value.Type().AssignableTo(field.Type()) {
+			field.Set(value)
+			return nil
+		}
+		if value.Type().ConvertibleTo(field.Type()) {
+			field.Set(value.Convert(field.Type()))
+		}
 		return nil
 	}
 
-	if value.Type().AssignableTo(field.Type()) {
-		field.Set(value)
+	// A single-valued relationship uses the first matching target row. The
+	// zero value (or nil pointer) faithfully represents a missing relationship.
+	if value.Len() == 0 {
+		field.Set(reflect.Zero(field.Type()))
 		return nil
 	}
-	if value.Type().ConvertibleTo(field.Type()) {
-		field.Set(value.Convert(field.Type()))
+	child := value.Index(0)
+	if child.Type().AssignableTo(field.Type()) {
+		field.Set(child)
 		return nil
+	}
+	if field.Kind() == reflect.Ptr && child.Type().AssignableTo(field.Type().Elem()) && child.CanAddr() {
+		field.Set(child.Addr())
+		return nil
+	}
+	if child.Type().ConvertibleTo(field.Type()) {
+		field.Set(child.Convert(field.Type()))
 	}
 
 	return nil

--- a/internal/query/expand_per_parent_test.go
+++ b/internal/query/expand_per_parent_test.go
@@ -1,0 +1,115 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type perParentAuthor struct {
+	ID    uint            `gorm:"primaryKey" odata:"key"`
+	Books []perParentBook `gorm:"foreignKey:AuthorID"`
+}
+
+type perParentBook struct {
+	ID       uint `gorm:"primaryKey" odata:"key"`
+	AuthorID uint
+	Author   *perParentAuthor `gorm:"foreignKey:AuthorID"`
+}
+
+type perParentTag struct {
+	ID uint `gorm:"primaryKey" odata:"key"`
+}
+
+type perParentProduct struct {
+	ID   uint           `gorm:"primaryKey" odata:"key"`
+	Tags []perParentTag `gorm:"many2many:per_parent_product_tags"`
+}
+
+func TestApplyPerParentExpandLoadsDirectRelationships(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&perParentAuthor{}, &perParentBook{}); err != nil {
+		t.Fatal(err)
+	}
+	db.Create(&perParentAuthor{ID: 1})
+	db.Create(&[]perParentBook{{ID: 1, AuthorID: 1}, {ID: 2, AuthorID: 1}})
+
+	authorMeta, err := metadata.AnalyzeEntity(perParentAuthor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bookMeta, err := metadata.AnalyzeEntity(perParentBook{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := map[string]*metadata.EntityMetadata{
+		authorMeta.EntitySetName: authorMeta,
+		bookMeta.EntitySetName:   bookMeta,
+	}
+	authorMeta.SetEntitiesRegistry(registry)
+	bookMeta.SetEntitiesRegistry(registry)
+
+	var authors []perParentAuthor
+	db.Find(&authors)
+	if err := ApplyPerParentExpand(db, &authors, []ExpandOption{{NavigationProperty: "Books"}}, authorMeta); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(authors[0].Books); got != 2 {
+		t.Fatalf("Books length = %d, want 2", got)
+	}
+
+	var books []perParentBook
+	db.Find(&books)
+	if err := ApplyPerParentExpand(db, &books, []ExpandOption{{NavigationProperty: "Author"}}, bookMeta); err != nil {
+		t.Fatal(err)
+	}
+	if books[0].Author == nil || books[0].Author.ID != 1 {
+		t.Fatalf("Author = %#v, want author 1", books[0].Author)
+	}
+}
+
+func TestApplyPerParentExpandLoadsManyToManyRelationships(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&perParentProduct{}, &perParentTag{}); err != nil {
+		t.Fatal(err)
+	}
+	product := perParentProduct{ID: 1}
+	tags := []perParentTag{{ID: 1}, {ID: 2}}
+	db.Create(&product)
+	db.Create(&tags)
+	if err := db.Model(&product).Association("Tags").Append(&tags); err != nil {
+		t.Fatal(err)
+	}
+
+	productMeta, err := metadata.AnalyzeEntity(perParentProduct{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tagMeta, err := metadata.AnalyzeEntity(perParentTag{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := map[string]*metadata.EntityMetadata{
+		productMeta.EntitySetName: productMeta,
+		tagMeta.EntitySetName:     tagMeta,
+	}
+	productMeta.SetEntitiesRegistry(registry)
+	tagMeta.SetEntitiesRegistry(registry)
+
+	var products []perParentProduct
+	db.Find(&products)
+	if err := ApplyPerParentExpand(db, &products, []ExpandOption{{NavigationProperty: "Tags"}}, productMeta); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(products[0].Tags); got != 2 {
+		t.Fatalf("Tags length = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #835.

- Moves direct navigation-property expands off GORM `Preload` and into the existing batched per-parent loader, so the parent and child collection queries can use `fastscan.Find`.
- Supports collection, belongs-to, and has-one navigation properties; resolves relationship direction from existing metadata before falling back to GORM schema parsing.
- Retains GORM's join-table behavior for many-to-many and self-referential associations, while keeping the parent page on the fast-scan path.
- Adds regression coverage for direct and many-to-many relationships plus a repeatable handler benchmark.

## Root cause

A `Preload` on the parent statement makes `fastscan.Find` deliberately fall back to GORM's scanner. The parent page therefore lost the optimization even though expanded children already used fastscan.

## Performance

Measured with three 3-second `go test -bench` samples on Apple M5, SQLite in-memory, 50 products with `$top=50&$expand=Category`:

| metric | before | after | change |
|---|---:|---:|---:|
| median time/request | 103.2 µs | 89.8 µs | **-13.0%** |
| estimated throughput | 9,692 req/s | 11,135 req/s | **+14.9%** |
| allocations/request | 1,220 | 1,006 | **-17.5%** |
| bytes/request | 62,055 | 50,500 | **-18.6%** |

## Validation

- `go test ./...`
- `go build ./...`
- Focused expand regression tests and benchmark
- `golangci-lint run ./...` reports existing findings outside this change; the issue #835 files have no new lint findings.