### PR TITLE
fast-scan single-entity reads (First)

### DIFF
--- a/internal/fastscan/fastscan.go
+++ b/internal/fastscan/fastscan.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 )
 
@@ -137,6 +138,86 @@ func Find(db *gorm.DB, dest interface{}) error {
 
 	sliceVal.Set(result)
 	tx.RowsAffected = int64(result.Len())
+	return nil
+}
+
+// First executes db as a single-row query with db.First semantics: it adds
+// LIMIT 1 and an ORDER BY primary key (matching gorm.First's clauses), scans
+// the row into dest — a pointer to a struct — with the compiled plan, and
+// returns gorm.ErrRecordNotFound when no row matches. Queries or destination
+// types the plan cannot faithfully reproduce fall back to db.First, so behavior
+// is always at least as correct as GORM's.
+func First(db *gorm.DB, dest interface{}) error {
+	destVal := reflect.ValueOf(dest)
+	if destVal.Kind() != reflect.Pointer || destVal.IsNil() || destVal.Elem().Kind() != reflect.Struct {
+		return db.First(dest).Error
+	}
+	elemType := destVal.Elem().Type()
+	// time.Time is a struct but a leaf scan target, not an entity to populate.
+	if elemType == timeType {
+		return db.First(dest).Error
+	}
+	if db.DryRun {
+		return db.First(dest).Error
+	}
+
+	// Mirror what First's Execute does: default the model to the destination,
+	// then parse it so the schema (and its cached scan plan) is available.
+	tx := db
+	if tx.Statement.Model == nil {
+		tx = tx.Model(dest)
+	}
+	if err := tx.Statement.Parse(tx.Statement.Model); err != nil {
+		return tx.First(dest).Error
+	}
+	sch := tx.Statement.Schema
+	if sch == nil || sch.ModelType != elemType {
+		return tx.First(dest).Error
+	}
+	p := planFor(sch)
+	if p == nil || p.disabled.Load() || !eligibleStatement(tx.Statement, sch) {
+		return tx.First(dest).Error
+	}
+
+	// Reproduce gorm.First's clauses so the SQL is identical: LIMIT 1 and an
+	// ORDER BY primary key (the clause builder expands clause.PrimaryKey from
+	// the parsed schema). A ByKey query already has a unique WHERE, but keeping
+	// the same SQL preserves dialect and plan-cache behavior.
+	tx = tx.Limit(1)
+	if len(sch.PrimaryFields) > 0 {
+		tx = tx.Order(clause.OrderByColumn{
+			Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey},
+		})
+	}
+
+	rows, err := tx.Rows()
+	if err != nil {
+		return err
+	}
+	found, err := scanFirstRow(tx.Statement.Context, rows, p, destVal.Elem())
+	closeErr := rows.Close()
+	if err != nil {
+		if scanErr, ok := err.(*rowScanError); ok {
+			// A row failed to scan. If the context is gone this is just
+			// cancellation; otherwise the plan mis-handled a driver value that
+			// GORM's conversions might accept. Disable the plan for this schema
+			// and re-run through GORM, which either succeeds or reports its own
+			// (equivalent) error.
+			if ctxErr := contextErr(tx.Statement.Context); ctxErr != nil {
+				return scanErr.err
+			}
+			p.disabled.Store(true)
+			return tx.First(dest).Error
+		}
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if !found {
+		return gorm.ErrRecordNotFound
+	}
+	tx.RowsAffected = 1
 	return nil
 }
 
@@ -411,44 +492,79 @@ func scanRows(ctx context.Context, rows *sql.Rows, p *plan, slice reflect.Value,
 	for rows.Next() {
 		result = reflect.Append(result, zero)
 		elem := result.Index(result.Len() - 1)
-		for _, d := range bindings.direct {
-			bindings.dests[d.colIdx] = d.field.ReflectValueOf(ctx, elem).Addr().Interface()
-		}
-		if err := rows.Scan(bindings.dests...); err != nil {
-			return reflect.Value{}, &rowScanError{err: err}
-		}
-		for _, b := range bindings.buffered {
-			// A NULL column leaves the field at its zero value, like GORM.
-			switch b.mode {
-			case scanInt:
-				if b.intBuf.Valid {
-					b.field.ReflectValueOf(ctx, elem).SetInt(b.intBuf.Int64)
-				}
-			case scanUint:
-				if b.intBuf.Valid {
-					b.field.ReflectValueOf(ctx, elem).SetUint(uint64(b.intBuf.Int64))
-				}
-			case scanFloat:
-				if b.floatBuf.Valid {
-					b.field.ReflectValueOf(ctx, elem).SetFloat(b.floatBuf.Float64)
-				}
-			case scanBool:
-				if b.boolBuf.Valid {
-					b.field.ReflectValueOf(ctx, elem).SetBool(b.boolBuf.Bool)
-				}
-			case scanString:
-				if b.stringBuf.Valid {
-					b.field.ReflectValueOf(ctx, elem).SetString(b.stringBuf.String)
-				}
-			case scanTime:
-				if b.timeBuf.Valid {
-					b.field.ReflectValueOf(ctx, elem).Set(reflect.ValueOf(b.timeBuf.Time))
-				}
-			}
+		if err := scanRowInto(ctx, rows, bindings, elem); err != nil {
+			return reflect.Value{}, err
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return reflect.Value{}, err
 	}
 	return result, nil
+}
+
+// scanFirstRow scans at most one row into elem (an addressable struct value),
+// reporting whether a row was present. It mirrors gorm.First: the query already
+// carries LIMIT 1, so only the leading row is consumed.
+func scanFirstRow(ctx context.Context, rows *sql.Rows, p *plan, elem reflect.Value) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	columns, err := rows.Columns()
+	if err != nil {
+		return false, err
+	}
+
+	bindings := p.acquireBindingSet(columns)
+	defer p.releaseBindingSet(bindings)
+
+	if !rows.Next() {
+		return false, rows.Err()
+	}
+	if err := scanRowInto(ctx, rows, bindings, elem); err != nil {
+		return false, err
+	}
+	return true, rows.Err()
+}
+
+// scanRowInto scans the current row into elem (an addressable struct value)
+// using the prepared binding set: direct fields receive their addresses, then
+// buffered scalars are copied out with NULL leaving the field at its zero value,
+// exactly as GORM does.
+func scanRowInto(ctx context.Context, rows *sql.Rows, bindings *bindingSet, elem reflect.Value) error {
+	for _, d := range bindings.direct {
+		bindings.dests[d.colIdx] = d.field.ReflectValueOf(ctx, elem).Addr().Interface()
+	}
+	if err := rows.Scan(bindings.dests...); err != nil {
+		return &rowScanError{err: err}
+	}
+	for _, b := range bindings.buffered {
+		// A NULL column leaves the field at its zero value, like GORM.
+		switch b.mode {
+		case scanInt:
+			if b.intBuf.Valid {
+				b.field.ReflectValueOf(ctx, elem).SetInt(b.intBuf.Int64)
+			}
+		case scanUint:
+			if b.intBuf.Valid {
+				b.field.ReflectValueOf(ctx, elem).SetUint(uint64(b.intBuf.Int64))
+			}
+		case scanFloat:
+			if b.floatBuf.Valid {
+				b.field.ReflectValueOf(ctx, elem).SetFloat(b.floatBuf.Float64)
+			}
+		case scanBool:
+			if b.boolBuf.Valid {
+				b.field.ReflectValueOf(ctx, elem).SetBool(b.boolBuf.Bool)
+			}
+		case scanString:
+			if b.stringBuf.Valid {
+				b.field.ReflectValueOf(ctx, elem).SetString(b.stringBuf.String)
+			}
+		case scanTime:
+			if b.timeBuf.Valid {
+				b.field.ReflectValueOf(ctx, elem).Set(reflect.ValueOf(b.timeBuf.Time))
+			}
+		}
+	}
+	return nil
 }

--- a/internal/fastscan/fastscan_benchmark_test.go
+++ b/internal/fastscan/fastscan_benchmark_test.go
@@ -92,6 +92,36 @@ func BenchmarkFastscanFind(b *testing.B) {
 	}
 }
 
+// firstQuery mirrors a single-entity read by primary key: WHERE id = ? with the
+// LIMIT 1 / ORDER BY primary key that First adds itself.
+func firstQuery(db *gorm.DB) *gorm.DB {
+	return db.Where("id = ?", benchRows/2)
+}
+
+func BenchmarkGormFirst(b *testing.B) {
+	db := setupBenchDB(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var product BenchProduct
+		if err := firstQuery(db).First(&product).Error; err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFastscanFirst(b *testing.B) {
+	db := setupBenchDB(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var product BenchProduct
+		if err := First(firstQuery(db), &product); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // benchApplyQuery mirrors the $apply groupby/aggregate shape that reaches map
 // scanning: one grouping key plus one aggregate, producing one row per group.
 // With benchRows products spread over benchGroups categories the result is

--- a/internal/fastscan/fastscan_test.go
+++ b/internal/fastscan/fastscan_test.go
@@ -3,6 +3,7 @@ package fastscan
 import (
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -399,6 +400,130 @@ func TestFindNonSliceDestFallsBack(t *testing.T) {
 	}
 	if len(maps) != 2 {
 		t.Fatalf("map fallback returned %d rows", len(maps))
+	}
+}
+
+// firstBoth runs the same query through fastscan.First and GORM's First and
+// requires identical results.
+func firstBoth(t *testing.T, build func() *gorm.DB, makeDest func() interface{}) interface{} {
+	t.Helper()
+	fast := makeDest()
+	if err := First(build(), fast); err != nil {
+		t.Fatalf("fastscan.First: %v", err)
+	}
+	slow := makeDest()
+	if err := build().First(slow).Error; err != nil {
+		t.Fatalf("gorm First: %v", err)
+	}
+	fastVal := reflect.ValueOf(fast).Elem().Interface()
+	slowVal := reflect.ValueOf(slow).Elem().Interface()
+	if !reflect.DeepEqual(fastVal, slowVal) {
+		t.Fatalf("fastscan.First result differs from GORM:\nfast: %#v\ngorm: %#v", fastVal, slowVal)
+	}
+	return fast
+}
+
+func TestFirstMatchesGorm(t *testing.T) {
+	db := openDB(t)
+	widgets := seedWidgets(t, db)
+
+	full := firstBoth(t,
+		func() *gorm.DB { return db.Where("id = ?", widgets[0].ID) },
+		func() interface{} { return &Widget{} },
+	).(*Widget)
+	if full.Name != "full" || full.Description == nil || *full.Description != "a widget" {
+		t.Errorf("full widget scanned incorrectly: %+v", full)
+	}
+	if full.Payload.Raw != "payload" || full.Status != Status(3) || !full.Active {
+		t.Errorf("scanner/named/bool fields scanned incorrectly: %+v", full)
+	}
+
+	nulls := firstBoth(t,
+		func() *gorm.DB { return db.Where("id = ?", widgets[1].ID) },
+		func() interface{} { return &Widget{} },
+	).(*Widget)
+	if nulls.Description != nil || nulls.Quantity != nil || nulls.Data != nil {
+		t.Errorf("NULL columns must stay nil: %+v", nulls)
+	}
+}
+
+func TestFirstOrdersByPrimaryKey(t *testing.T) {
+	db := openDB(t)
+	seedWidgets(t, db)
+
+	// With no WHERE, First must return the lowest primary key, exactly like
+	// gorm.First's implicit ORDER BY primary key.
+	got := firstBoth(t,
+		func() *gorm.DB { return db.Model(&Widget{}) },
+		func() interface{} { return &Widget{} },
+	).(*Widget)
+	if got.Name != "full" {
+		t.Fatalf("First did not order by primary key: got %+v", got)
+	}
+}
+
+func TestFirstReturnsRecordNotFound(t *testing.T) {
+	db := openDB(t)
+	seedWidgets(t, db)
+
+	var w Widget
+	if err := First(db.Where("id = ?", 99999), &w); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected gorm.ErrRecordNotFound, got %v", err)
+	}
+	// GORM agrees on the no-row error.
+	var g Widget
+	if err := db.Where("id = ?", 99999).First(&g).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("gorm baseline: expected ErrRecordNotFound, got %v", err)
+	}
+}
+
+func TestFirstFallsBackForAfterFindHook(t *testing.T) {
+	db := openDB(t)
+	if err := db.AutoMigrate(&Hooked{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := db.Create(&Hooked{Name: "h"}).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var h Hooked
+	if err := First(db.Model(&Hooked{}), &h); err != nil {
+		t.Fatalf("fastscan.First: %v", err)
+	}
+	if h.Count != 42 {
+		t.Fatalf("AfterFind hook did not run, so fallback was skipped: %+v", h)
+	}
+}
+
+func TestFirstFallsBackForPreload(t *testing.T) {
+	db := openDB(t)
+	if err := db.AutoMigrate(&Parent{}, &Child{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	parent := Parent{Name: "p", Children: []Child{{Name: "c1"}, {Name: "c2"}}}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var got Parent
+	if err := First(db.Preload("Children").Where("id = ?", parent.ID), &got); err != nil {
+		t.Fatalf("fastscan.First: %v", err)
+	}
+	if len(got.Children) != 2 {
+		t.Fatalf("preload did not populate children, so fallback was skipped: %+v", got)
+	}
+}
+
+func TestFirstNonStructDestFallsBack(t *testing.T) {
+	db := openDB(t)
+	seedWidgets(t, db)
+
+	m := map[string]interface{}{}
+	if err := First(db.Model(&Widget{}), &m); err != nil {
+		t.Fatalf("fastscan.First with map dest: %v", err)
+	}
+	if m["name"] == nil {
+		t.Fatalf("map fallback did not populate: %+v", m)
 	}
 }
 

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/nlstn/go-odata/internal/etag"
+	"github.com/nlstn/go-odata/internal/fastscan"
 	"github.com/nlstn/go-odata/internal/odataerrors"
 	"github.com/nlstn/go-odata/internal/preference"
 	"github.com/nlstn/go-odata/internal/query"
@@ -165,7 +166,10 @@ func (h *EntityHandler) fetchEntityByKey(ctx context.Context, entityKey string, 
 		db = query.ApplyExpandOnly(db, queryOptions.Expand, h.metadata, h.logger)
 	}
 
-	if err := db.First(result).Error; err != nil {
+	// fastscan.First scans the row with a compiled per-schema plan, falling back
+	// to db.First for anything it cannot faithfully reproduce (preloads,
+	// association joins, hooks). It preserves gorm.ErrRecordNotFound semantics.
+	if err := fastscan.First(db, result); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes #837.

## Summary

PR #834 wired `fastscan.Find` into collection reads but left single-entity reads (`/Products(1)`, `fetchEntityByKey`, GORM `First`) on GORM's scan path. This PR adds `fastscan.First` and wires it into `fetchEntityByKey`.

`fastscan.First` reproduces `gorm.First`'s clauses (`LIMIT 1` + `ORDER BY` primary key) so the SQL is identical, preserves `gorm.ErrRecordNotFound` semantics, and falls back to `db.First` for anything the compiled plan can't faithfully reproduce (preloads, association joins, `AfterFind` hooks, non-struct destinations). The per-row scan logic is now shared between `Find` and `First` via `scanRowInto`.

## Should we implement it? (issue's decision criterion)

The issue asked to measure first and implement only if the fast path pays off for n=1. It does — both at the micro and end-to-end level.

### Microbenchmark (`internal/fastscan`, Apple M5, sqlite in-memory, `-benchtime=2s -count=3`)

| Benchmark | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `GormFirst` | ~5,932 | 4,638 | 90 |
| `FastscanFirst` | ~5,502 | 4,564 | 85 |

≈ **7% lower latency, 5 fewer allocs** per single-entity read. (For reference, the n=100 `Find` path is ~29% faster — per-query overhead dominates more at n=1, exactly as the issue predicted.)

### End-to-end load test — `single_entity` (`GET /Products(1)`)

`wrk -t10 -c100 -d20s`, perfserver on sqlite (`-extensive`), 3 alternating rounds each to control for thermal drift. Ranges do not overlap:

| Metric | Before (`gorm.First`) | After (`fastscan.First`) | Δ |
|---|---:|---:|---:|
| Requests/sec (mean) | 32,925 | 35,727 | **+8.5%** |
| Requests/sec (range) | 32,534 – 33,279 | 35,486 – 36,081 | |
| Avg latency | 3.55 ms | 3.27 ms | −7.9% |
| p50 latency | 2.82 ms | 2.60 ms | −7.8% |
| p99 latency | 14.68 ms | 13.49 ms | −8.1% |

Both builds returned byte-identical responses for `/Products(1)` (same ETag). The `Product` model — embedded pointer complex types (`ShippingAddress`, `Dimensions`) plus relationships — was verified to engage the fast path rather than fall back.

This contrasts with #834's `single_entity` measurement of −2.5% (within noise): that PR never touched the single-entity path, so no change was expected there.

## Testing

- `go test ./...` passes.
- New correctness tests in `internal/fastscan` mirror the existing `findBoth` pattern (`firstBoth`): value fidelity vs GORM, implicit ORDER BY primary key, `ErrRecordNotFound`, and fallback for `AfterFind` hooks, preloads, and non-struct destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)