### PR TITLE
perf(response): fast-path time.Time, pointer scalars & lazy encoder in JSON serialization (#841)

### DIFF
--- a/internal/response/ordered_map.go
+++ b/internal/response/ordered_map.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"sync"
+	"time"
 	"unicode/utf8"
 )
 
@@ -200,9 +201,11 @@ func releasePooledBuffer(buf *bytes.Buffer) {
 // Nested *OrderedMap and []interface{} values write into the same buf, eliminating
 // the per-entity bufferPool round-trip and intermediate copy that MarshalJSON performs.
 func (om *OrderedMap) marshalTo(buf *bytes.Buffer) error {
-	// enc is lazily used only for complex types (time.Time, decimal, etc.)
-	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
+	// enc is created lazily, only when a value needs the reflection-based
+	// encoding/json fallback (decimal, UUID, arbitrary structs, ...). Entities
+	// composed entirely of scalars, time.Time, pointers-to-scalars and nested
+	// *OrderedMap values never allocate an encoder.
+	var enc *json.Encoder
 
 	buf.WriteByte('{')
 
@@ -226,17 +229,96 @@ func (om *OrderedMap) marshalTo(buf *bytes.Buffer) error {
 
 		value := om.values[key]
 
+		// Dereference the common nullable-scalar pointer types up front so the
+		// main switch below handles them without falling through to reflection.
+		// A nil pointer serializes as JSON null.
+		switch p := value.(type) {
+		case *string:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *int:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *int64:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *int32:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *uint:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *uint64:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *uint32:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *float64:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *float32:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *bool:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		case *time.Time:
+			if p == nil {
+				buf.WriteString("null")
+				continue
+			}
+			value = *p
+		}
+
 		switch v := value.(type) {
 		case string:
 			if needsEscaping(v) {
-				if err := enc.Encode(v); err != nil {
+				if err := encodeFallback(buf, &enc, v); err != nil {
 					return err
 				}
-				buf.Truncate(buf.Len() - 1)
 			} else {
 				buf.WriteByte('"')
 				buf.WriteString(v)
 				buf.WriteByte('"')
+			}
+		case time.Time:
+			if !appendJSONTime(buf, v) {
+				// Years outside [0,9999] can't be represented as strict RFC 3339;
+				// defer to encoding/json, which reports the same error stdlib does.
+				if err := encodeFallback(buf, &enc, v); err != nil {
+					return err
+				}
 			}
 		case *OrderedMap:
 			if v == nil {
@@ -263,10 +345,9 @@ func (om *OrderedMap) marshalTo(buf *bytes.Buffer) error {
 						}
 					}
 				} else {
-					if err := enc.Encode(item); err != nil {
+					if err := encodeFallback(buf, &enc, item); err != nil {
 						return err
 					}
-					buf.Truncate(buf.Len() - 1)
 				}
 			}
 			buf.WriteByte(']')
@@ -295,15 +376,49 @@ func (om *OrderedMap) marshalTo(buf *bytes.Buffer) error {
 		case nil:
 			buf.WriteString("null")
 		default:
-			if err := enc.Encode(value); err != nil {
+			if err := encodeFallback(buf, &enc, value); err != nil {
 				return err
 			}
-			buf.Truncate(buf.Len() - 1)
 		}
 	}
 
 	buf.WriteByte('}')
 	return nil
+}
+
+// encodeFallback serializes val through the reflection-based encoding/json encoder,
+// creating the encoder on first use so callers pay the allocation only when a
+// value actually needs the fallback. It strips the trailing newline that
+// (*json.Encoder).Encode appends so the output composes with surrounding JSON.
+func encodeFallback(buf *bytes.Buffer, enc **json.Encoder, val interface{}) error {
+	if *enc == nil {
+		e := json.NewEncoder(buf)
+		e.SetEscapeHTML(false)
+		*enc = e
+	}
+	if err := (*enc).Encode(val); err != nil {
+		return err
+	}
+	buf.Truncate(buf.Len() - 1)
+	return nil
+}
+
+// appendJSONTime writes t as a JSON string using the same strict RFC 3339 (nano)
+// representation that time.Time.MarshalJSON produces, directly into buf without
+// allocating. It returns false (writing nothing) when the year falls outside
+// [0,9999], which strict RFC 3339 cannot represent; callers then fall back to
+// encoding/json to reproduce stdlib's error behavior exactly.
+func appendJSONTime(buf *bytes.Buffer, t time.Time) bool {
+	if y := t.Year(); y < 0 || y > 9999 {
+		return false
+	}
+	var tmp [len(time.RFC3339Nano) + 2]byte
+	b := tmp[:0]
+	b = append(b, '"')
+	b = t.AppendFormat(b, time.RFC3339Nano)
+	b = append(b, '"')
+	buf.Write(b)
+	return true
 }
 
 // writeInt writes an int64 to the buffer without allocation

--- a/internal/response/ordered_map_value_test.go
+++ b/internal/response/ordered_map_value_test.go
@@ -1,0 +1,163 @@
+package response
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// valueJSON returns the JSON encoding of a single value using the same settings
+// (HTML escaping disabled) that marshalTo uses, so we can assert byte-for-byte
+// that the fast paths match encoding/json.
+func valueJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal(%T) failed: %v", v, err)
+	}
+	return string(b)
+}
+
+// marshalOne marshals an OrderedMap holding a single key and returns the encoded
+// value portion (everything between `{"k":` and the closing `}`).
+func marshalOne(t *testing.T, v interface{}) string {
+	t.Helper()
+	om := NewOrderedMap()
+	om.Set("k", v)
+	b, err := om.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	s := string(b)
+	const prefix = `{"k":`
+	if len(s) < len(prefix)+1 || s[:len(prefix)] != prefix || s[len(s)-1] != '}' {
+		t.Fatalf("unexpected envelope: %s", s)
+	}
+	return s[len(prefix) : len(s)-1]
+}
+
+func TestMarshalTo_TimeMatchesStdlib(t *testing.T) {
+	cases := []time.Time{
+		time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		time.Date(2024, 1, 15, 10, 30, 0, 123456789, time.UTC),
+		time.Date(2024, 6, 1, 8, 0, 0, 0, time.FixedZone("CEST", 2*60*60)),
+		time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
+		{}, // zero time
+	}
+	for _, tc := range cases {
+		got := marshalOne(t, tc)
+		want := valueJSON(t, tc)
+		if got != want {
+			t.Errorf("time %v: got %s, want %s", tc, got, want)
+		}
+	}
+}
+
+func TestMarshalTo_PointerScalarsMatchStdlib(t *testing.T) {
+	s := "hello \"world\"\n"
+	i := 42
+	i64 := int64(-9007199254740991)
+	u := uint(7)
+	f := 3.14159
+	b := true
+	tm := time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	values := []interface{}{
+		&s, &i, &i64, &u, &f, &b, &tm,
+		(*string)(nil), (*int)(nil), (*int64)(nil), (*uint)(nil),
+		(*float64)(nil), (*bool)(nil), (*time.Time)(nil),
+	}
+	for _, v := range values {
+		got := marshalOne(t, v)
+		want := valueJSON(t, v)
+		if got != want {
+			t.Errorf("value %#v: got %s, want %s", v, got, want)
+		}
+	}
+}
+
+func TestMarshalTo_StringEscapingMatchesStdlib(t *testing.T) {
+	cases := []string{
+		"plain",
+		"with \"quotes\"",
+		"tab\tand\nnewline",
+		"unicode: café — 日本語",
+		"backslash \\ end",
+	}
+	for _, tc := range cases {
+		got := marshalOne(t, tc)
+		want := valueJSON(t, tc)
+		if got != want {
+			t.Errorf("string %q: got %s, want %s", tc, got, want)
+		}
+	}
+}
+
+// realisticProductEntity builds an OrderedMap mirroring the perfserver Product
+// entity: mixed scalars, a time.Time, nullable pointer fields, an enum rendered
+// as a string, and a nested *OrderedMap for an embedded complex type.
+func realisticProductEntity(id int) *OrderedMap {
+	desc := "A longer description for the product that might be a bit verbose"
+	catID := uint(id%100 + 1)
+	created := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	dims := AcquireOrderedMapWithCapacity(3)
+	dims.Set("Length", 12.5)
+	dims.Set("Width", 8.0)
+	dims.Set("Height", 3.25)
+
+	om := AcquireOrderedMapWithCapacity(12)
+	om.Set("@odata.id", "http://localhost/Products(1)")
+	om.Set("ID", uint(id))
+	om.Set("Name", "Product Name Here")
+	om.Set("Description", &desc)
+	om.Set("Price", 99.99)
+	om.Set("CategoryID", &catID)
+	om.Set("Status", "InStock, OnSale")
+	om.Set("Version", 1)
+	om.Set("CreatedAt", created)
+	om.Set("Dimensions", dims)
+	return om
+}
+
+// BenchmarkMarshalRealisticEntity exercises the value types that dominate the
+// #841 baseline profile (time.Time, nullable pointers, enum-as-string).
+func BenchmarkMarshalRealisticEntity(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		om := realisticProductEntity(i)
+		buf, err := om.marshalToPooledBuffer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		releasePooledBuffer(buf)
+		om.Release()
+	}
+}
+
+// BenchmarkMarshalRealisticCollection500 mirrors the heaviest baseline scenario:
+// serializing a 500-entity collection into one buffer.
+func BenchmarkMarshalRealisticCollection500(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		value := make([]interface{}, 500)
+		for j := range value {
+			value[j] = realisticProductEntity(j)
+		}
+		env := AcquireOrderedMapWithCapacity(2)
+		env.Set("@odata.context", "http://localhost/$metadata#Products")
+		env.Set("value", value)
+
+		buf, err := env.marshalToPooledBuffer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		releasePooledBuffer(buf)
+
+		for _, v := range value {
+			v.(*OrderedMap).Release() //nolint:errcheck // known type
+		}
+		env.Release()
+	}
+}


### PR DESCRIPTION
## Context

Now that fast-scan replaced GORM's reflection scan, JSON serialization is the dominant request-path CPU cost (#841). I profiled the `perfserver` under load (bombardier, PostgreSQL 16 and SQLite) to establish a baseline, then optimized the hottest path.

**Baseline finding (PostgreSQL, pure-Go pgx, all 16 cores):** request handling is ~90% of server CPU; within it JSON serialization (`WriteODataCollectionWithNavigation…`) is **57.5%** — the single largest phase, ahead of the entire DB read path (41.3%). Inside serialization, `OrderedMap.marshalTo` is ~25% of *total* CPU, and **~60% of that is the reflection-based `encoding/json.(*Encoder).Encode` fallback** — triggered by every entity's `time.Time` field, nullable pointer fields, and a `json.Encoder` allocated on every `marshalTo` call even when unused.

## Change

Direct, allocation-free handling in `OrderedMap.marshalTo` for:

- **`time.Time`** — written via `AppendFormat(RFC3339Nano)` straight into the buffer. Byte-for-byte identical to `time.Time.MarshalJSON` for years in `[0,9999]`; out-of-range years fall back to `encoding/json` to preserve stdlib's exact error behavior.
- **Common nullable pointer scalars** (`*string`, `*int`, `*int64`, `*int32`, `*uint`, `*uint64`, `*uint32`, `*float64`, `*float32`, `*bool`, `*time.Time`) — dereferenced up front; `nil` serializes as `null`.
- **Lazy `json.Encoder`** — created only on first fallback use, so entities composed entirely of fast-path values never allocate one (previously one per map, including every nested map).

No public API change. `OrderedMap`'s representation is untouched, so `omit_values.go`/`atom.go` readers are unaffected.

## Correctness

New tests in `ordered_map_value_test.go` assert **byte-for-byte parity with `encoding/json`** for `time.Time` (incl. zero, fractional seconds, non-UTC, year bounds), all pointer-scalar cases (incl. nil), and string escaping (quotes, control chars, unicode, backslash). Full suite green; `golangci-lint` clean.

## Measurements

**Microbenchmark** (noise-free, `benchstat`, n=8):

| benchmark | before | after | Δ |
|---|--:|--:|--:|
| `MarshalRealisticEntity` | 2.302µs | 1.881µs | **−18.3%** |
| `MarshalRealisticCollection500` | 1.275ms | 1.097ms | **−13.9%** |

**Perfserver CPU profile** (PostgreSQL, same host/load; normalized as % of samples so it's independent of total work done):

| symbol | baseline | optimized |
|---|--:|--:|
| `encoding/json.(*Encoder).Encode` | 14.74% | **9.91%** |
| `OrderedMap.marshalTo` | 24.61% | **21.97%** |
| serialization total | 51.86% | 50.10% |

**Allocations:** `time.Time.MarshalJSON` — **1.54 GB over the run → 0** (eliminated).

**Throughput** (directional; the load generator shares the 16-core host, so run-to-run variance is real): +8% to +22% across scenarios, e.g. `Products?$top=100` 4,095 → 5,004 req/s, p99 32ms → 23ms.

## Next step (tracked under #841)

The remaining `encoding/json` fallback is dominated by **embedded complex-type pointers** (`*Address`, `*Dimensions`) going through `ptrEncoder → structEncoder` (~43s) plus a `mapEncoder` (~24s). Recursively lowering complex-type struct values to `OrderedMap` is the next optimization; this PR is scoped to the scalar/time/encoder wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)