### PR TITLE
perf(harness): switch load-test harness from wrk to bombardier

### DIFF
--- a/.devcontainer/mariadb/README.md
+++ b/.devcontainer/mariadb/README.md
@@ -15,7 +15,7 @@ This directory contains the MariaDB-based development container configuration fo
   - golangci-lint for code linting
   - Go language server for enhanced IDE features
   - air for hot-reload development server
-  - wrk for HTTP load testing
+  - bombardier for HTTP load testing
   - MariaDB client for database debugging
 - **Port Forwarding**: Port 8080 is automatically forwarded for the development server
 

--- a/.devcontainer/mariadb/setup.sh
+++ b/.devcontainer/mariadb/setup.sh
@@ -11,13 +11,13 @@ go mod download
 echo "🔍 Installing golangci-lint..."
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.5.0
 
-# Install wrk for load testing
-echo "⚡ Installing wrk..."
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends wrk
+# Install bombardier for load testing
+echo "⚡ Installing bombardier..."
+go install github.com/codesenberg/bombardier@latest
 
 # Install MariaDB client for debugging
 echo "🐬 Installing MariaDB client..."
+sudo apt-get update
 sudo apt-get install -y --no-install-recommends mariadb-client
 
 echo "✅ Development environment setup complete!"

--- a/.devcontainer/mssql/README.md
+++ b/.devcontainer/mssql/README.md
@@ -15,7 +15,7 @@ This directory contains the MSSQL-based development container configuration for 
   - golangci-lint for code linting
   - Go language server for enhanced IDE features
   - air for hot-reload development server
-  - wrk for HTTP load testing
+  - bombardier for HTTP load testing
 - **Port Forwarding**: Port 8080 is automatically forwarded for the development server
 
 ## Getting Started

--- a/.devcontainer/mssql/setup.sh
+++ b/.devcontainer/mssql/setup.sh
@@ -11,10 +11,9 @@ go mod download
 echo "🔍 Installing golangci-lint..."
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.5.0
 
-# Install wrk for load testing
-echo "⚡ Installing wrk..."
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends wrk
+# Install bombardier for load testing
+echo "⚡ Installing bombardier..."
+go install github.com/codesenberg/bombardier@latest
 
 echo "✅ Development environment setup complete!"
 echo ""

--- a/.devcontainer/mysql/README.md
+++ b/.devcontainer/mysql/README.md
@@ -15,7 +15,7 @@ This directory contains the MySQL-based development container configuration for 
   - golangci-lint for code linting
   - Go language server for enhanced IDE features
   - air for hot-reload development server
-  - wrk for HTTP load testing
+  - bombardier for HTTP load testing
   - MySQL client for database debugging
 - **Port Forwarding**: Port 8080 is automatically forwarded for the development server
 

--- a/.devcontainer/mysql/setup.sh
+++ b/.devcontainer/mysql/setup.sh
@@ -11,13 +11,13 @@ go mod download
 echo "🔍 Installing golangci-lint..."
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.5.0
 
-# Install wrk for load testing
-echo "⚡ Installing wrk..."
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends wrk
+# Install bombardier for load testing
+echo "⚡ Installing bombardier..."
+go install github.com/codesenberg/bombardier@latest
 
 # Install MySQL-compatible client for debugging (Debian provides MariaDB client)
 echo "🐬 Installing MySQL-compatible client..."
+sudo apt-get update
 sudo apt-get install -y --no-install-recommends mariadb-client-compat
 
 echo "✅ Development environment setup complete!"

--- a/.devcontainer/postgres/README.md
+++ b/.devcontainer/postgres/README.md
@@ -14,7 +14,7 @@ This directory contains the PostgreSQL-based development container configuration
   - golangci-lint for code linting
   - Go language server for enhanced IDE features
   - air for hot-reload development server
-  - wrk for HTTP load testing
+  - bombardier for HTTP load testing
 - **Port Forwarding**: Port 8080 is automatically forwarded for the development server
 
 ## Getting Started

--- a/.devcontainer/postgres/setup.sh
+++ b/.devcontainer/postgres/setup.sh
@@ -11,9 +11,8 @@ go mod download
 echo "🔍 Installing golangci-lint..."
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.5.0
 
-# Install wrk for load testing
-echo "⚡ Installing wrk..."
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends wrk
+# Install bombardier for load testing
+echo "⚡ Installing bombardier..."
+go install github.com/codesenberg/bombardier@latest
 
 echo "✅ Development environment setup complete!"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -138,7 +138,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -t 10 -C 100 -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -C 100 -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -155,7 +155,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db postgres --dsn postgresql://odata:odata_dev@localhost:5432/odata_test?sslmode=disable -d 30s -t 10 -C 100 -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db postgres --dsn postgresql://odata:odata_dev@localhost:5432/odata_test?sslmode=disable -d 30s -C 100 -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -172,7 +172,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -t 10 -C 100 --cpu-profile -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -C 100 --cpu-profile -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -189,7 +189,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -t 10 -C 100 --sql-trace -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -C 100 --sql-trace -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -206,7 +206,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -t 10 -C 100 --cpu-profile --sql-trace -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db sqlite -d 30s -C 100 --cpu-profile --sql-trace -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -288,7 +288,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -305,7 +305,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 --cpu-profile -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 --cpu-profile -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -322,7 +322,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 --sql-trace -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 --sql-trace -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -339,7 +339,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 --cpu-profile --sql-trace -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mariadb --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 --cpu-profile --sql-trace -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -421,7 +421,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -438,7 +438,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 --cpu-profile -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 --cpu-profile -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -455,7 +455,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 --sql-trace -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 --sql-trace -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -472,7 +472,7 @@
             "command": "bash",
             "args": [
                 "-lc",
-                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -t 10 -C 100 --cpu-profile --sql-trace -o ${workspaceFolder}/load-test-results"
+                "./cmd/perfserver/run_load_tests.sh --db mysql --dsn odata:odata_dev@tcp\\(localhost:3306\\)/odata_test?parseTime=true -d 30s -C 100 --cpu-profile --sql-trace -o ${workspaceFolder}/load-test-results"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/cmd/perfserver/PERFORMANCE_ANALYSIS.md
+++ b/cmd/perfserver/PERFORMANCE_ANALYSIS.md
@@ -19,7 +19,7 @@ This guide explains how to analyze performance bottlenecks in the go-odata libra
 
 ```bash
 cd cmd/perfserver
-./run_load_tests.sh --wrk -d 30s
+./run_load_tests.sh -d 30s
 ```
 
 This provides:
@@ -46,7 +46,7 @@ This generates `load-test-results/cpu.prof`, `heap.prof`, and `alloc.prof` showi
 ### Load Test with SQL Tracing
 
 ```bash
-./run_load_tests.sh --wrk -d 30s --sql-trace
+./run_load_tests.sh -d 30s --sql-trace
 ```
 
 This generates `load-test-results/sql-trace.txt` showing:
@@ -75,24 +75,23 @@ After running tests, examine the results in `load-test-results/`:
 ### Key Files
 
 - `summary.txt` - Test execution summary
-- `wrk_*.txt` - Individual test results
+- `bombardier_*.txt` - Individual test results
 
 ### Interpreting Results
 
 ```
-Running 30s test @ http://localhost:9091/Products
-  10 threads and 100 connections
-  Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency     2.00ms    1.99ms  23.85ms   85.10%
-    Req/Sec     6.27k   767.00    41.01k    93.07%
+Bombarding http://localhost:9091/Products for 30s using 100 connections
+Statistics        Avg      Stdev        Max
+  Reqs/sec     62169.18   4213.00   71050.42   ← Throughput (average requests/sec)
+  Latency        1.61ms   1.02ms    23.85ms
   Latency Distribution
      50%    1.42ms    ← Half of requests complete in 1.42ms
      75%    2.97ms    ← 75% complete in under 2.97ms
      90%    4.75ms    ← 90% complete in under 4.75ms
      99%    8.59ms    ← 99% complete in under 8.59ms (tail latency)
-  1,871,303 requests in 30.10s, 488.98MB read
-Requests/sec: 62,169.18    ← Throughput
-Transfer/sec:     16.25MB
+  HTTP codes:
+    1xx - 0, 2xx - 1871303, 3xx - 0, 4xx - 0, 5xx - 0
+  Throughput:    16.25MB/s
 ```
 
 ### Performance Benchmarks
@@ -118,7 +117,7 @@ Compare throughput across different query types:
 
 ```bash
 # Extract requests/sec from all tests
-grep "Requests/sec:" load-test-results/wrk_*.txt | sort -t: -k2 -n
+grep "Reqs/sec" load-test-results/bombardier_*.txt
 ```
 
 **Look for:**
@@ -308,29 +307,29 @@ db.Preload("Category").Find(&products)
 
 1. **Run basic load test** - Identify slow endpoints
    ```bash
-   ./run_load_tests.sh --wrk -d 30s
+   ./run_load_tests.sh -d 30s
    ```
 
 2. **Check HTTP metrics** - Which queries are slow?
    ```bash
-   grep "Requests/sec:" load-test-results/wrk_*.txt | sort -t: -k2 -n
+   grep "Reqs/sec" load-test-results/bombardier_*.txt
    ```
 
 3. **Run with SQL tracing** - Is database the bottleneck?
    ```bash
-   ./run_load_tests.sh --wrk -d 30s --sql-trace
+   ./run_load_tests.sh -d 30s --sql-trace
    cat load-test-results/sql-trace.txt
    ```
 
 4. **If SQL is fast, run CPU profiling** - Where is CPU time spent?
    ```bash
-   ./run_load_tests.sh --wrk -d 30s --cpu-profile
+   ./run_load_tests.sh -d 30s --cpu-profile
    go tool pprof -http=:8080 load-test-results/cpu.prof
    ```
 
 5. **Optimize and re-test** - Verify improvements
    ```bash
-   ./run_load_tests.sh --wrk -d 30s
+   ./run_load_tests.sh -d 30s
    ```
 
 ### Example Investigation
@@ -453,7 +452,7 @@ Avg time: 0.8ms  ← SQL is fast!
 
 ### Metrics to Track
 
-1. **Throughput** - Requests/sec
+1. **Throughput** - Reqs/sec
 2. **Latency** - p50, p95, p99
 3. **Error rate** - Non-2xx responses
 4. **CPU usage** - System-wide and per-core
@@ -466,7 +465,7 @@ Avg time: 0.8ms  ← SQL is fast!
 
 ### Load Testing Tools
 
-- **wrk** - Fast, scriptable HTTP benchmarking (recommended)
+- **bombardier** - Fast, Go-native HTTP benchmarking (recommended; used by run_load_tests.sh)
 - **vegeta** - Constant rate load testing
 - **k6** - Programmable load testing
 
@@ -480,9 +479,8 @@ Avg time: 0.8ms  ← SQL is fast!
 ### Installation
 
 ```bash
-# wrk
-sudo apt-get install wrk  # Debian/Ubuntu
-brew install wrk          # macOS
+# bombardier
+go install github.com/codesenberg/bombardier@latest
 
 # graphviz (for pprof web view)
 sudo apt-get install graphviz

--- a/cmd/perfserver/README.md
+++ b/cmd/perfserver/README.md
@@ -117,8 +117,8 @@ Use the tasks defined in `.vscode/tasks.json`:
 - "Start Dev Server (PostgreSQL)" - Launch dev server with PostgreSQL database
 
 ### Load Testing Tasks
-- "Run load tests (SQLite)" - Automated load tests with wrk
-- "Run load tests (PostgreSQL)" - PostgreSQL load tests with wrk
+- "Run load tests (SQLite)" - Automated load tests with bombardier
+- "Run load tests (PostgreSQL)" - PostgreSQL load tests with bombardier
 - "Run load tests with CPU profiling (SQLite)" - With CPU profiling enabled
 - "Run load tests with SQL tracing (SQLite)" - With SQL query tracing
 - "Run load tests with full profiling (SQLite)" - With both CPU and SQL profiling
@@ -132,11 +132,11 @@ Use the tasks defined in `.vscode/tasks.json`:
 Use the included load testing script to run comprehensive performance tests:
 
 ```bash
-# Run all load tests with wrk (auto-starts perfserver)
+# Run all load tests with bombardier (auto-starts perfserver)
 ./run_load_tests.sh
 
 # Custom configuration
-./run_load_tests.sh -d 60s -t 12 -C 200 -o ./my-results
+./run_load_tests.sh -d 60s -C 200 -o ./my-results
 
 # Use PostgreSQL
 ./run_load_tests.sh --db postgres --dsn "postgresql://user:pass@localhost/dbname"
@@ -163,10 +163,9 @@ The script automatically:
 - Saves detailed results to `./load-test-results/`
 - Stops the server when complete
 
-**Prerequisites:** Install wrk:
+**Prerequisites:** Install bombardier:
 ```bash
-sudo apt-get install wrk  # Debian/Ubuntu
-brew install wrk          # macOS
+go install github.com/codesenberg/bombardier@latest
 ```
 
 ### Manual Query Performance Tests
@@ -187,13 +186,13 @@ curl "http://localhost:9091/Products?\$apply=groupby((CategoryID),aggregate(Pric
 
 ### Manual Load Testing
 
-Use wrk for load testing:
+Use bombardier for load testing:
 ```bash
 # Basic load test
-wrk -t10 -c100 -d30s http://localhost:9091/Products
+bombardier -c100 -d30s http://localhost:9091/Products
 
-# With more threads and connections
-wrk -t12 -c200 -d60s --latency http://localhost:9091/Products
+# More connections, with latency percentiles
+bombardier -c200 -d60s -l http://localhost:9091/Products
 ```
 
 ## Analyzing Results

--- a/cmd/perfserver/run_load_tests.sh
+++ b/cmd/perfserver/run_load_tests.sh
@@ -17,9 +17,8 @@ NC='\033[0m' # No Color
 # Configuration
 SERVER_URL="${SERVER_URL:-http://localhost:9091}"
 OUTPUT_DIR="${OUTPUT_DIR:-./load-test-results}"
-WRK_DURATION="${WRK_DURATION:-30s}"
-WRK_THREADS="${WRK_THREADS:-10}"
-WRK_CONNECTIONS="${WRK_CONNECTIONS:-100}"
+LOAD_DURATION="${LOAD_DURATION:-30s}"
+LOAD_CONNECTIONS="${LOAD_CONNECTIONS:-100}"
 DB_TYPE="sqlite"           # sqlite | postgres
 DB_DSN=""                  # Optional; for postgres defaults if empty
 EXTERNAL_SERVER=0          # Don't start/stop server automatically
@@ -149,25 +148,27 @@ print_header() {
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
 }
 
-# Function to run wrk test
+# Function to run a bombardier test
 run_test() {
     local name="$1"
     local url="$2"
-    local output_file="$OUTPUT_DIR/wrk_${name}.txt"
-    
+    local output_file="$OUTPUT_DIR/bombardier_${name}.txt"
+
     echo -e "${YELLOW}Testing: ${name}${NC}"
     echo -e "URL: ${url}"
-    echo -e "Duration: ${WRK_DURATION}, Threads: ${WRK_THREADS}, Connections: ${WRK_CONNECTIONS}\n"
-    
-    if command -v wrk &> /dev/null; then
-        wrk -t"$WRK_THREADS" -c"$WRK_CONNECTIONS" -d"$WRK_DURATION" --latency "$url" > "$output_file" 2>&1
-        
+    echo -e "Duration: ${LOAD_DURATION}, Connections: ${LOAD_CONNECTIONS}\n"
+
+    if command -v bombardier &> /dev/null; then
+        # --print result suppresses the live progress bar so the captured file
+        # holds only the final statistics block; -l adds latency percentiles.
+        bombardier -c "$LOAD_CONNECTIONS" -d "$LOAD_DURATION" -l --print result "$url" > "$output_file" 2>&1
+
         # Display results
         echo -e "${GREEN}Results:${NC}"
         cat "$output_file"
         echo ""
     else
-        echo -e "${RED}wrk not found. Please install wrk to run load tests.${NC}\n"
+        echo -e "${RED}bombardier not found. Install it with: go install github.com/codesenberg/bombardier@latest${NC}\n"
         exit 1
     fi
 }
@@ -184,13 +185,14 @@ warm_cached_feature_flags() {
 }
 
 extract_requests_per_sec() {
-    local wrk_file="$1"
-    awk '/Requests\/sec:/ {print $2}' "$wrk_file" | tail -n 1
+    local result_file="$1"
+    # bombardier prints "  Reqs/sec   <avg> <stdev> <max>"; take the average column.
+    awk '/Reqs\/sec/ {print $2}' "$result_file" | tail -n 1
 }
 
 compare_feature_flag_results() {
-    local cached_file="$OUTPUT_DIR/wrk_feature_flags_cached.txt"
-    local uncached_file="$OUTPUT_DIR/wrk_feature_flags_uncached.txt"
+    local cached_file="$OUTPUT_DIR/bombardier_feature_flags_cached.txt"
+    local uncached_file="$OUTPUT_DIR/bombardier_feature_flags_uncached.txt"
 
     if [ ! -f "$cached_file" ] || [ ! -f "$uncached_file" ]; then
         echo -e "${YELLOW}⚠ Feature flag benchmark files missing, skipping comparison${NC}"
@@ -203,7 +205,7 @@ compare_feature_flag_results() {
     uncached_rps=$(extract_requests_per_sec "$uncached_file")
 
     if [ -z "$cached_rps" ] || [ -z "$uncached_rps" ]; then
-        echo -e "${YELLOW}⚠ Could not parse Requests/sec from wrk outputs${NC}"
+        echo -e "${YELLOW}⚠ Could not parse Reqs/sec from bombardier outputs${NC}"
         return 0
     fi
 
@@ -345,7 +347,7 @@ display_summary() {
     fi
     
     echo -e "\n${YELLOW}Analysis Tips:${NC}"
-    echo -e "  • Review wrk_*.txt files for detailed metrics"
+    echo -e "  • Review bombardier_*.txt files for detailed metrics"
     echo -e "  • Compare results across different query patterns"
     echo -e "  • Look for high latency or low throughput"
     echo -e "  • Monitor CPU/memory usage during tests\n"
@@ -358,9 +360,8 @@ main() {
     echo -e "Configuration:"
     echo -e "  Server URL: ${GREEN}${SERVER_URL}${NC}"
     echo -e "  Output Directory: ${GREEN}${OUTPUT_DIR}${NC}"
-    echo -e "  Duration: ${GREEN}${WRK_DURATION}${NC}"
-    echo -e "  Threads: ${GREEN}${WRK_THREADS}${NC}"
-    echo -e "  Connections: ${GREEN}${WRK_CONNECTIONS}${NC}"
+    echo -e "  Duration: ${GREEN}${LOAD_DURATION}${NC}"
+    echo -e "  Connections: ${GREEN}${LOAD_CONNECTIONS}${NC}"
     echo -e "  Database: ${GREEN}${DB_TYPE}${DB_DSN:+ (dsn provided)}${NC}"
     echo ""
     
@@ -479,15 +480,16 @@ show_help() {
     cat << EOF
 Usage: $0 [OPTIONS]
 
-Run load tests against the go-odata performance server using wrk.
+Run load tests against the go-odata performance server using bombardier.
 
 OPTIONS:
     -h, --help              Show this help message
     -u, --url URL           Server URL (default: http://localhost:9091)
     -o, --output DIR        Output directory for results (default: ./load-test-results)
-    -d, --duration TIME     Duration for wrk tests (default: 30s)
-    -t, --threads NUM       Number of threads for wrk (default: 10)
-    -C, --connections NUM   Number of connections for wrk (default: 100)
+    -d, --duration TIME     Duration for each test (default: 30s)
+    -C, --connections NUM   Number of concurrent connections (default: 100)
+    -t, --threads NUM       Accepted for backward compatibility; ignored
+                            (bombardier manages its own worker goroutines)
     --db TYPE               Database type to use: sqlite | postgres (default: sqlite)
     --dsn DSN              Database DSN/connection string (required for postgres)
     --external-server      Use an external server (don't start/stop the perfserver)
@@ -508,8 +510,8 @@ EXAMPLES:
     $0
 
     # Run with custom parameters
-    $0 -d 60s -t 12 -C 200
-    
+    $0 -d 60s -C 200
+
     # Enable CPU, memory, and SQL profiling
     $0 --cpu-profile --memory-profile --sql-trace
 
@@ -520,12 +522,11 @@ EXAMPLES:
     $0 --db postgres --dsn "postgresql://user:pass@localhost:5432/dbname" --cpu-profile
 
 PREREQUISITES:
-    - wrk must be installed
+    - bombardier must be installed
     - Go must be installed (to build the perfserver)
 
-    Install wrk:
-        sudo apt-get install wrk            # Debian/Ubuntu
-        brew install wrk                    # macOS
+    Install bombardier:
+        go install github.com/codesenberg/bombardier@latest
 
 NOTE:
     The script automatically starts and stops the performance server.
@@ -550,15 +551,15 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -d|--duration)
-            WRK_DURATION="$2"
+            LOAD_DURATION="$2"
             shift 2
             ;;
         -t|--threads)
-            WRK_THREADS="$2"
+            # Accepted for backward compatibility; bombardier has no threads knob.
             shift 2
             ;;
         -C|--connections)
-            WRK_CONNECTIONS="$2"
+            LOAD_CONNECTIONS="$2"
             shift 2
             ;;
         --db)


### PR DESCRIPTION
## Why

`wrk` is effectively unmaintained (no release in years) and has to be installed as a system package (`apt`/`brew`, needs sudo). While establishing the #841 serialization baseline I hit exactly this: `wrk` wasn't available and the whole `run_load_tests.sh` harness depends on it.

**bombardier** is a modern, actively-maintained, Go-native HTTP load generator: a single static binary installed with `go install` — no sudo, no apt, and it matches this repo's toolchain. Its per-URL throughput model maps 1:1 onto the existing one-endpoint-per-scenario harness.

## Changes

- **`run_load_tests.sh`** — drive `bombardier -c <conns> -d <dur> -l --print result` instead of `wrk`. Parse bombardier's `Reqs/sec` average for the cached/uncached feature-flag speedup validation. Result files renamed `wrk_*.txt` → `bombardier_*.txt`. Prereq check and help updated. `WRK_DURATION`/`WRK_THREADS`/`WRK_CONNECTIONS` → `LOAD_DURATION`/`LOAD_CONNECTIONS`. `-t/--threads` is still accepted but ignored (bombardier manages its own worker goroutines), so existing invocations keep working.
- **`.devcontainer/{postgres,mysql,mariadb,mssql}/setup.sh`** — install bombardier via `go install github.com/codesenberg/bombardier@latest` instead of `apt-get install wrk`; kept `apt-get update` where the following DB-client install still needs it.
- **`.vscode/tasks.json`** — dropped the now-ignored `-t 10` from the load-test task invocations.
- **Docs** — `cmd/perfserver/README.md`, `PERFORMANCE_ANALYSIS.md`, and the four devcontainer READMEs updated: install steps, prerequisites, example output (bombardier's format), and the throughput-comparison commands.

## Verification

Ran the full suite end-to-end (`--db sqlite -d 2s -C 20`): all **17 scenarios** execute, throughput parses from every result file, the feature-flag speedup comparison computes and validates, and the script exits 0. `bash -n` clean on the script and all four setup scripts.

## Notes

- No Go source changes; this is tooling/docs only.
- Companion to the #841 serialization work (#846), which used bombardier to measure the before/after baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)