### PR TITLE
perf(response): serialize complex types from a cached plan; evaluate precompiled serializers (#841)

### DIFF
--- a/internal/response/complex_type.go
+++ b/internal/response/complex_type.go
@@ -1,0 +1,239 @@
+package response
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Complex-type serialization writes an embedded complex-type struct value
+// directly into the response buffer from a cached, reflection-free field plan,
+// using the same scalar/time writers marshalTo uses for the top-level entity.
+// This replaces the encoding/json reflection fallback (the
+// ptrEncoder->structEncoder hotspot in #841) without building an intermediate
+// map or boxing scalar fields into interface{}.
+//
+// It is deliberately conservative: a struct type is written this way only when
+// its JSON shape can be reproduced byte-for-byte from its exported fields. Types
+// that customize their own JSON (json.Marshaler / encoding.TextMarshaler) or use
+// anonymous embedding (which encoding/json promotes/flattens) are left to the
+// reflection fallback, so output never changes for those.
+
+type complexFieldPlan struct {
+	jsonName  string
+	index     int
+	omitEmpty bool
+}
+
+// complexPlan is the cached serialization plan for one struct type: the exported
+// fields to emit, in declaration order, with resolved JSON names and omitempty.
+type complexPlan struct {
+	fields []complexFieldPlan
+}
+
+// complexPlanCache memoizes plans (and non-serializable verdicts) per reflect.Type.
+// A stored nil *complexPlan means "not directly serializable — use the fallback".
+var complexPlanCache sync.Map // reflect.Type -> *complexPlan
+
+var (
+	jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+	timeType          = reflect.TypeOf(time.Time{})
+)
+
+// getComplexPlan returns the cached plan for t, or nil if t must use the fallback.
+func getComplexPlan(t reflect.Type) *complexPlan {
+	if cached, ok := complexPlanCache.Load(t); ok {
+		p, _ := cached.(*complexPlan) //nolint:errcheck // value type is guaranteed by our Store calls
+		return p
+	}
+	p := buildComplexPlan(t)
+	actual, _ := complexPlanCache.LoadOrStore(t, p)
+	cp, _ := actual.(*complexPlan) //nolint:errcheck // value type is guaranteed by our Store calls
+	return cp
+}
+
+// buildComplexPlan inspects t and returns a plan, or nil when t must be left to
+// the reflection fallback to preserve exact encoding/json output.
+func buildComplexPlan(t reflect.Type) *complexPlan {
+	if t.Kind() != reflect.Struct || t == timeType {
+		return nil
+	}
+	// Custom marshalers: let encoding/json invoke them so output is unchanged.
+	if implementsMarshaler(t) {
+		return nil
+	}
+	n := t.NumField()
+	fields := make([]complexFieldPlan, 0, n)
+	for i := 0; i < n; i++ {
+		f := t.Field(i)
+		if f.Anonymous {
+			// encoding/json promotes/flattens embedded fields with dominance
+			// rules we don't replicate; defer the whole struct to reflection.
+			return nil
+		}
+		if !f.IsExported() {
+			continue
+		}
+		name, omitEmpty, skip := parseJSONTag(f)
+		if skip {
+			continue
+		}
+		fields = append(fields, complexFieldPlan{jsonName: name, index: i, omitEmpty: omitEmpty})
+	}
+	return &complexPlan{fields: fields}
+}
+
+func implementsMarshaler(t reflect.Type) bool {
+	pt := reflect.PointerTo(t)
+	return t.Implements(jsonMarshalerType) || pt.Implements(jsonMarshalerType) ||
+		t.Implements(textMarshalerType) || pt.Implements(textMarshalerType)
+}
+
+// parseJSONTag mirrors encoding/json's tag handling for the subset we support:
+// name override, the omitempty option, and json:"-" exclusion.
+func parseJSONTag(f reflect.StructField) (name string, omitEmpty, skip bool) {
+	tag := f.Tag.Get("json")
+	if tag == "-" {
+		return "", false, true
+	}
+	name = f.Name
+	if tag == "" {
+		return name, false, false
+	}
+	first := tag
+	if idx := strings.IndexByte(tag, ','); idx != -1 {
+		first = tag[:idx]
+		for _, opt := range strings.Split(tag[idx+1:], ",") {
+			if opt == "omitempty" {
+				omitEmpty = true
+			}
+		}
+	}
+	if first != "" {
+		name = first
+	}
+	return name, omitEmpty, false
+}
+
+// writeComplexValue writes v (a struct, or pointer to one) to buf using its
+// cached plan, and reports whether it handled the value. It returns false
+// (writing nothing) when v is not a directly serializable struct — a non-struct
+// kind, or a type with a custom marshaler / anonymous embedding — so the caller
+// can fall back to encoding/json. A nil pointer to a serializable struct is
+// handled here as JSON null.
+func writeComplexValue(buf *bytes.Buffer, v reflect.Value, enc **json.Encoder) (bool, error) {
+	if !v.IsValid() {
+		return false, nil
+	}
+	t := v.Type()
+	isPtr := t.Kind() == reflect.Ptr
+	elem := t
+	if isPtr {
+		elem = t.Elem()
+	}
+	plan := getComplexPlan(elem)
+	if plan == nil {
+		return false, nil
+	}
+	if isPtr {
+		if v.IsNil() {
+			buf.WriteString("null")
+			return true, nil
+		}
+		v = v.Elem()
+	}
+	return true, writeComplexStruct(buf, v, plan, enc)
+}
+
+func writeComplexStruct(buf *bytes.Buffer, v reflect.Value, plan *complexPlan, enc **json.Encoder) error {
+	buf.WriteByte('{')
+	first := true
+	for i := range plan.fields {
+		f := &plan.fields[i]
+		fv := v.Field(f.index)
+		if f.omitEmpty && isEmptyValue(fv) {
+			continue
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		writeJSONKey(buf, f.jsonName)
+		buf.WriteByte(':')
+		if err := writeComplexField(buf, fv, enc); err != nil {
+			return err
+		}
+	}
+	buf.WriteByte('}')
+	return nil
+}
+
+// writeComplexField writes a single struct-field value, recursing into nested
+// pointers and complex structs and using the allocation-free scalar/time
+// writers. Anything it can't handle directly is routed to encoding/json.
+func writeComplexField(buf *bytes.Buffer, v reflect.Value, enc **json.Encoder) error {
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			buf.WriteString("null")
+			return nil
+		}
+		return writeComplexField(buf, v.Elem(), enc)
+	case reflect.String:
+		return writeJSONString(buf, v.String(), enc)
+	case reflect.Bool:
+		if v.Bool() {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		writeInt(buf, v.Int())
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		writeUint(buf, v.Uint())
+		return nil
+	case reflect.Float32, reflect.Float64:
+		writeFloat(buf, v.Float())
+		return nil
+	case reflect.Struct:
+		if v.Type() == timeType {
+			if appendJSONTime(buf, v.Interface().(time.Time)) { //nolint:errcheck // guarded by type check
+				return nil
+			}
+			return encodeFallback(buf, enc, v.Interface())
+		}
+		if plan := getComplexPlan(v.Type()); plan != nil {
+			return writeComplexStruct(buf, v, plan, enc)
+		}
+		return encodeFallback(buf, enc, v.Interface())
+	default:
+		return encodeFallback(buf, enc, v.Interface())
+	}
+}
+
+// isEmptyValue reports whether v is the zero value for its type, matching
+// encoding/json's omitempty semantics.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return v.IsNil()
+	}
+	return false
+}

--- a/internal/response/complex_type_test.go
+++ b/internal/response/complex_type_test.go
@@ -1,0 +1,229 @@
+package response
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// refJSON encodes v exactly as marshalTo's fallback would: encoding/json with
+// HTML escaping disabled and the trailing newline trimmed.
+func refJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		t.Fatalf("reference encode failed: %v", err)
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// loweredJSON runs v through writeComplexValue and returns the bytes it wrote,
+// matching how marshalTo serializes a complex-type value.
+func loweredJSON(t *testing.T, v interface{}) (string, bool) {
+	t.Helper()
+	var buf bytes.Buffer
+	var enc *json.Encoder
+	handled, err := writeComplexValue(&buf, reflect.ValueOf(v), &enc)
+	if err != nil {
+		t.Fatalf("writeComplexValue failed: %v", err)
+	}
+	if !handled {
+		return "", false
+	}
+	return buf.String(), true
+}
+
+// notLowered reports whether writeComplexValue declined to handle v (i.e. it
+// falls back to encoding/json).
+func notLowered(v reflect.Value) bool {
+	var buf bytes.Buffer
+	var enc *json.Encoder
+	handled, _ := writeComplexValue(&buf, v, &enc)
+	return handled
+}
+
+type addr struct {
+	Street  string `json:"Street"`
+	City    string `json:"City"`
+	Country string `json:"Country"`
+}
+
+type dims struct {
+	Length float64 `json:"Length"`
+	Width  float64 `json:"Width"`
+	Unit   string  `json:"Unit"`
+}
+
+func TestWriteComplexValue_MatchesStdlib(t *testing.T) {
+	a := addr{Street: "1 Main St", City: "Springfield", Country: "USA"}
+	d := dims{Length: 12.5, Width: 8, Unit: "cm"}
+
+	cases := []interface{}{
+		a,  // struct value
+		&a, // pointer to struct
+		d,  // floats incl. integer-valued
+		&d,
+	}
+	for _, v := range cases {
+		got, ok := loweredJSON(t, v)
+		if !ok {
+			t.Fatalf("expected %T to be lowerable", v)
+		}
+		if want := refJSON(t, v); got != want {
+			t.Errorf("%T: got %s, want %s", v, got, want)
+		}
+	}
+}
+
+func TestWriteComplexValue_NilPointerIsNull(t *testing.T) {
+	got, ok := loweredJSON(t, (*addr)(nil))
+	if !ok {
+		t.Fatal("nil pointer should be handled")
+	}
+	if got != "null" {
+		t.Errorf("nil pointer: got %s, want null", got)
+	}
+}
+
+func TestWriteComplexValue_TagsAndVisibility(t *testing.T) {
+	type tagged struct {
+		Kept       string `json:"kept"`
+		Renamed    int    `json:"renamed_name"`
+		Skipped    string `json:"-"`
+		unexported string //nolint:unused // present to verify it is skipped
+		NoTag      bool
+	}
+	v := tagged{Kept: "a", Renamed: 5, Skipped: "hidden", unexported: "x", NoTag: true}
+	got, ok := loweredJSON(t, v)
+	if !ok {
+		t.Fatal("expected lowerable")
+	}
+	if want := refJSON(t, v); got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestWriteComplexValue_OmitEmpty(t *testing.T) {
+	type withOmit struct {
+		Name  string  `json:"name,omitempty"`
+		Count int     `json:"count,omitempty"`
+		Rate  float64 `json:"rate,omitempty"`
+		Ptr   *string `json:"ptr,omitempty"`
+		Flag  bool    `json:"flag,omitempty"`
+		Tags  []int   `json:"tags,omitempty"`
+	}
+	s := "set"
+	cases := []withOmit{
+		{}, // everything empty -> all omitted
+		{Name: "x", Count: 1, Rate: 2.5, Ptr: &s, Flag: true, Tags: []int{1}}, // all present
+		{Count: 0, Name: "only"}, // mixed
+	}
+	for _, v := range cases {
+		got, ok := loweredJSON(t, v)
+		if !ok {
+			t.Fatalf("expected lowerable: %+v", v)
+		}
+		if want := refJSON(t, v); got != want {
+			t.Errorf("%+v: got %s, want %s", v, got, want)
+		}
+	}
+}
+
+func TestWriteComplexValue_NestedAndTime(t *testing.T) {
+	type outer struct {
+		Label   string    `json:"Label"`
+		Addr    addr      `json:"Addr"`
+		AddrPtr *addr     `json:"AddrPtr"`
+		When    time.Time `json:"When"`
+	}
+	v := outer{
+		Label:   "n",
+		Addr:    addr{Street: "s", City: "c", Country: "d"},
+		AddrPtr: &addr{Street: "s2", City: "c2", Country: "d2"},
+		When:    time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC),
+	}
+	got, ok := loweredJSON(t, v)
+	if !ok {
+		t.Fatal("expected lowerable")
+	}
+	if want := refJSON(t, v); got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+// marshalerStruct customizes its own JSON and therefore must NOT be lowered.
+type marshalerStruct struct {
+	X int
+}
+
+func (marshalerStruct) MarshalJSON() ([]byte, error) { return []byte(`"custom"`), nil }
+
+func TestWriteComplexValue_CustomMarshalerNotLowered(t *testing.T) {
+	if notLowered(reflect.ValueOf(marshalerStruct{X: 1})) {
+		t.Error("types with custom MarshalJSON must not be lowered")
+	}
+}
+
+func TestWriteComplexValue_AnonymousEmbeddingNotLowered(t *testing.T) {
+	type base struct {
+		A string `json:"A"`
+	}
+	type withEmbed struct {
+		base
+		B string `json:"B"`
+	}
+	if notLowered(reflect.ValueOf(withEmbed{})) {
+		t.Error("structs with anonymous embedded fields must not be lowered")
+	}
+}
+
+func TestWriteComplexValue_NonStructNotLowered(t *testing.T) {
+	for _, v := range []interface{}{"s", 42, 3.14, true} {
+		if notLowered(reflect.ValueOf(v)) {
+			t.Errorf("%T should not be lowerable", v)
+		}
+	}
+}
+
+// benchAddr mirrors a typical embedded complex type (flat scalar struct).
+type benchAddr struct {
+	Street     string `json:"Street"`
+	City       string `json:"City"`
+	State      string `json:"State"`
+	PostalCode string `json:"PostalCode"`
+	Country    string `json:"Country"`
+}
+
+// BenchmarkComplexValue_DirectWrite measures the plan-based direct buffer write.
+func BenchmarkComplexValue_DirectWrite(b *testing.B) {
+	v := reflect.ValueOf(&benchAddr{Street: "123 Main St", City: "Springfield", State: "IL", PostalCode: "62704", Country: "USA"})
+	var buf bytes.Buffer
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		var enc *json.Encoder
+		if _, err := writeComplexValue(&buf, v, &enc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkComplexValue_Fallback measures the previous reflection path
+// (encoding/json.Encoder) for the same value.
+func BenchmarkComplexValue_Fallback(b *testing.B) {
+	val := &benchAddr{Street: "123 Main St", City: "Springfield", State: "IL", PostalCode: "62704", Country: "USA"}
+	var buf bytes.Buffer
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		var enc *json.Encoder
+		if err := encodeFallback(&buf, &enc, val); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/response/ordered_map.go
+++ b/internal/response/ordered_map.go
@@ -3,6 +3,7 @@ package response
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -303,14 +304,8 @@ func (om *OrderedMap) marshalTo(buf *bytes.Buffer) error {
 
 		switch v := value.(type) {
 		case string:
-			if needsEscaping(v) {
-				if err := encodeFallback(buf, &enc, v); err != nil {
-					return err
-				}
-			} else {
-				buf.WriteByte('"')
-				buf.WriteString(v)
-				buf.WriteByte('"')
+			if err := writeJSONString(buf, v, &enc); err != nil {
+				return err
 			}
 		case time.Time:
 			if !appendJSONTime(buf, v) {
@@ -376,7 +371,14 @@ func (om *OrderedMap) marshalTo(buf *bytes.Buffer) error {
 		case nil:
 			buf.WriteString("null")
 		default:
-			if err := encodeFallback(buf, &enc, value); err != nil {
+			// Complex-type (embedded struct) values are written directly from a
+			// cached field plan; only shapes the plan can't reproduce exactly fall
+			// through to the reflection-based encoding/json encoder.
+			if handled, err := writeComplexValue(buf, reflect.ValueOf(value), &enc); handled {
+				if err != nil {
+					return err
+				}
+			} else if err := encodeFallback(buf, &enc, value); err != nil {
 				return err
 			}
 		}
@@ -461,6 +463,34 @@ func writeUint(buf *bytes.Buffer, v uint64) {
 func writeFloat(buf *bytes.Buffer, v float64) {
 	// Use strconv for proper float formatting
 	buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+}
+
+// writeJSONKey writes a JSON object key (quoted string) to buf, escaping only
+// when necessary. Mirrors the key handling inlined in marshalTo.
+func writeJSONKey(buf *bytes.Buffer, key string) {
+	if needsEscaping(key) {
+		keyBytes, err := json.Marshal(key)
+		if err == nil {
+			buf.Write(keyBytes)
+			return
+		}
+	}
+	buf.WriteByte('"')
+	buf.WriteString(key)
+	buf.WriteByte('"')
+}
+
+// writeJSONString writes a JSON string value to buf. Strings that need escaping
+// are routed through the encoder (which handles escaping identically to the rest
+// of the response); the common no-escape case is written directly.
+func writeJSONString(buf *bytes.Buffer, s string, enc **json.Encoder) error {
+	if needsEscaping(s) {
+		return encodeFallback(buf, enc, s)
+	}
+	buf.WriteByte('"')
+	buf.WriteString(s)
+	buf.WriteByte('"')
+	return nil
 }
 
 // needsEscaping checks if a string needs JSON escaping


### PR DESCRIPTION
## Context

After the scalar/time/lazy-encoder fast paths (#846), the remaining JSON hotspot in the #841 profile was **embedded complex-type struct values** (`Address`, `Dimensions`, …), which were handed to the reflection-based `encoding/json` fallback — the `ptrEncoder → structEncoder` path, ~half of the residual `Encoder.Encode` cost.

## Change

A lightweight **per-type serialization plan** (`complexPlan`), built once and cached per `reflect.Type`, writes a complex-type struct **directly into the response buffer** using the same allocation-free scalar/time writers `marshalTo` already uses:

- Scalar fields are written via typed `reflect.Value` accessors (`.Int()`, `.String()`, …) — **no interface boxing, no intermediate map**.
- Nested structs and pointers recurse; `time.Time` uses the existing RFC3339 fast path; nil pointers → `null`.
- Anything the plan can't reproduce exactly — types with a custom `json.Marshaler`/`encoding.TextMarshaler`, or **anonymous embedding** (which `encoding/json` promotes/flattens) — falls back to `encoding/json`, so **output never changes**. `json` tag semantics (rename, `omitempty`, `-`) and unexported-field skipping are honored.

> An earlier attempt lowered complex types into nested `*OrderedMap` values. I reverted it: the map allocation + interface boxing cost *more* than the reflection it replaced (measured **+0.05 MB/req** and no throughput gain). Writing straight to the buffer avoids both. This is documented here because it's the crux of why the final design looks the way it does.

## Correctness

New tests assert **byte-for-byte parity with `encoding/json`** (HTML escaping disabled, matching `marshalTo`) across: value/pointer/nil, tag rename, `json:"-"`, unexported fields, `omitempty` (empty + populated), nested structs, `time.Time`, plus the guarded fall-back cases (custom marshaler, anonymous embedding, non-struct). Full suite green; `golangci-lint` clean.

## Measurements (perfserver, PostgreSQL, vs the post-#846 build)

| metric | before | after |
|---|--:|--:|
| CPU per request (mixed workload) | 2.06 ms | **1.54 ms (−25%)** |
| Allocation per request | 0.160 MB | **0.142 MB (−12%)** |
| Micro: one complex value | 229 ns, 1 alloc | **189 ns, 0 allocs** |
| `encodeFallback` share of CPU | 10.6% | 5.1% |
| `encoding/json.(*Encoder).Encode` share | 9.9% | 4.4% |

Throughput on complex-carrying endpoints: `/Products?$top=500` **+26%**, `$top=100` **+23%**, `$expand` **+23%**. (`$select`/`Categories` carry no complex types; their run-to-run deltas are load-generator noise.)

CPU-per-request and alloc-per-request are normalized by 2xx responses served, so they're independent of the throughput difference between runs.

---

## Evaluation: precompiled serializers (requested)

"Precompiled serializer" can mean three things; I evaluated all three against this library's constraints (entities are **user-defined structs registered at runtime**, and every response is an **ordered envelope with interleaved `@odata.*` annotations, computed links, and `$select`/`$expand`/metadata-level shaping** — not a plain struct marshal).

**1. Build-time codegen (easyjson / ffjson style).** Generates `MarshalJSON` per type at build time.
❌ Doesn't fit: would force a codegen step into every downstream user's build, and generated per-struct marshalers emit a fixed shape — they can't produce the OData envelope (key ordering, annotations, per-request `$select`/`$expand` projection, metadata levels). Rejected.

**2. Drop-in fast JSON library (goccy/go-json, jsoniter, sonic).** Replace `encoding/json` wholesale.
❌ Doesn't fit as a drop-in: the response is built as an `OrderedMap` precisely because the output isn't a struct — it's annotations interleaved with projected/expanded fields. A faster generic marshaler still needs that same intermediate, so it can't be applied to the whole response. It *could* speed up the leaf `encodeFallback` values (decimal, UUID), but that path is now ~5% of CPU and shrinking — marginal, and it adds a dependency + its own reflection cache. Not worth it now.

**3. Runtime-cached per-type encoder plan (this PR).** Inspect each type once, cache a reflection-free field plan, and drive direct buffer writes.
✅ This is what `encoding/json`, jsoniter, and goccy all do *internally*, and it's the only option that composes with the OData envelope. It needs no build step, no dependency, and no output change, and it's **extensible**: the same plan mechanism could later drive the **top-level entity property loop** (which today still does per-field metadata-map lookups + `enumOrRaw`), yielding a cached per-entity-type plan — the natural next step.

**Recommendation:** continue the incremental cached-plan approach (this PR), and consider extending the plan to top-level entity properties as a follow-up. Do **not** adopt codegen or swap the JSON library — neither fits the ordered/annotated envelope, and both add cost (build step / dependency) for a shrinking slice of CPU.

## Next
The largest remaining serialization cost is now `marshalTo` itself over scalar fields plus the per-field metadata lookups in the entity property loop — the candidate for a per-entity-type plan as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)