### PR TITLE
ci: bump odata-compliance-suite to v1.0.3

### DIFF
--- a/.github/workflows/mariadb-compliance.yml
+++ b/.github/workflows/mariadb-compliance.yml
@@ -70,7 +70,7 @@ jobs:
         echo "Started complianceserver (pid $!)"
 
     - name: Run compliance suite
-      uses: NLstn/odata-compliance-suite@9b28c9c52d9faac56346bcbbed159db362bdd6cf # PR #53
+      uses: NLstn/odata-compliance-suite@eee4d3024decfa230533adb61292d9f473ddde77 # v1.0.3
       with:
         server: http://localhost:9090
         timeout: 60

--- a/.github/workflows/mssql-compliance.yml
+++ b/.github/workflows/mssql-compliance.yml
@@ -73,7 +73,7 @@ jobs:
         echo "Started complianceserver (pid $!)"
 
     - name: Run compliance suite
-      uses: NLstn/odata-compliance-suite@9b28c9c52d9faac56346bcbbed159db362bdd6cf # PR #53
+      uses: NLstn/odata-compliance-suite@eee4d3024decfa230533adb61292d9f473ddde77 # v1.0.3
       with:
         server: http://localhost:9090
         timeout: 60

--- a/.github/workflows/mysql-compliance.yml
+++ b/.github/workflows/mysql-compliance.yml
@@ -70,7 +70,7 @@ jobs:
         echo "Started complianceserver (pid $!)"
 
     - name: Run compliance suite
-      uses: NLstn/odata-compliance-suite@9b28c9c52d9faac56346bcbbed159db362bdd6cf # PR #53
+      uses: NLstn/odata-compliance-suite@eee4d3024decfa230533adb61292d9f473ddde77 # v1.0.3
       with:
         server: http://localhost:9090
         timeout: 60

--- a/.github/workflows/postgres-compliance.yml
+++ b/.github/workflows/postgres-compliance.yml
@@ -69,7 +69,7 @@ jobs:
         echo "Started complianceserver (pid $!)"
 
     - name: Run compliance suite
-      uses: NLstn/odata-compliance-suite@9b28c9c52d9faac56346bcbbed159db362bdd6cf # PR #53
+      uses: NLstn/odata-compliance-suite@eee4d3024decfa230533adb61292d9f473ddde77 # v1.0.3
       with:
         server: http://localhost:9090
         timeout: 60

--- a/.github/workflows/sqlite-compliance.yml
+++ b/.github/workflows/sqlite-compliance.yml
@@ -53,7 +53,7 @@ jobs:
         echo "Started complianceserver (pid $!)"
 
     - name: Run compliance suite
-      uses: NLstn/odata-compliance-suite@9b28c9c52d9faac56346bcbbed159db362bdd6cf # PR #53
+      uses: NLstn/odata-compliance-suite@eee4d3024decfa230533adb61292d9f473ddde77 # v1.0.3
       with:
         server: http://localhost:9090
         timeout: 60


### PR DESCRIPTION
## Summary
Updates the pinned `NLstn/odata-compliance-suite` action across all database compliance workflows from the old `# PR #53` commit (`9b28c9c`) to the latest release **v1.0.3** (`eee4d30`).

Affected workflows:
- `postgres-compliance.yml`
- `mysql-compliance.yml`
- `mariadb-compliance.yml`
- `sqlite-compliance.yml`
- `mssql-compliance.yml`

The action stays pinned by full commit SHA for supply-chain safety, with the trailing comment updated to name the release tag `v1.0.3`.

## Test plan
- CI compliance workflows run the updated suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)