### PR TITLE
perf(response): resolve entity field metadata from a cached per-type plan (#841)

### DIFF
--- a/internal/response/entity_plan.go
+++ b/internal/response/entity_plan.go
@@ -1,0 +1,83 @@
+package response
+
+import (
+	"reflect"
+	"sync"
+
+	internalMetadata "github.com/nlstn/go-odata/internal/metadata"
+)
+
+// entityFieldPlan is a cached, per-(entity type, *EntityMetadata) resolution of
+// the per-field metadata that processStructEntityOrderedInto would otherwise look
+// up from two hash maps on every field of every entity in every response.
+//
+// The plan pre-resolves, for each struct field (indexed to match
+// getFieldInfos(t) / entity.Field(j)):
+//   - whether the field is skipped (unexported or json:"-"),
+//   - its navigation-property descriptor (synthesized from the stable
+//     *EntityMetadata; only set for navigation fields), and
+//   - its full property metadata (for enum/stream/annotation/complex handling).
+//
+// Every value it carries is identical to what the per-field map lookups
+// (propMetaMap[name], fullPropMetaByName[name]) returned before — the plan just
+// does those lookups once per type instead of once per field per entity.
+type entityFieldPlan struct {
+	entries []entityFieldEntry
+}
+
+type entityFieldEntry struct {
+	skip     bool
+	jsonName string
+	// navProp is non-nil only for navigation-property fields. It is synthesized
+	// from the *EntityMetadata property so it matches the response.PropertyMetadata
+	// the metadata provider would have returned (which is itself a field-for-field
+	// copy of the same *EntityMetadata property — see metadataAdapter).
+	navProp  *PropertyMetadata
+	fullProp *internalMetadata.PropertyMetadata
+}
+
+type entityPlanKey struct {
+	t  reflect.Type
+	md *internalMetadata.EntityMetadata
+}
+
+var entityFieldPlanCache sync.Map // entityPlanKey -> *entityFieldPlan
+
+// getEntityFieldPlan returns the cached field plan for entities of type t
+// described by md. The result is safe to reuse concurrently and is never mutated
+// after construction.
+func getEntityFieldPlan(md *internalMetadata.EntityMetadata, t reflect.Type) *entityFieldPlan {
+	key := entityPlanKey{t: t, md: md}
+	if cached, ok := entityFieldPlanCache.Load(key); ok {
+		return cached.(*entityFieldPlan) //nolint:errcheck // value type guaranteed by our Store calls
+	}
+
+	byName := getFullPropMetaByName(md)
+	infos := getFieldInfos(t)
+	entries := make([]entityFieldEntry, len(infos))
+	for j := range infos {
+		info := infos[j]
+		e := entityFieldEntry{jsonName: info.JsonName}
+		if !info.IsExported || info.JsonName == "" {
+			e.skip = true
+			entries[j] = e
+			continue
+		}
+		fp := byName[info.Name]
+		e.fullProp = fp
+		if fp != nil && fp.IsNavigationProp {
+			e.navProp = &PropertyMetadata{
+				Name:              fp.Name,
+				JsonName:          fp.JsonName,
+				IsNavigationProp:  true,
+				NavigationTarget:  fp.NavigationTarget,
+				NavigationIsArray: fp.NavigationIsArray,
+			}
+		}
+		entries[j] = e
+	}
+
+	plan := &entityFieldPlan{entries: entries}
+	actual, _ := entityFieldPlanCache.LoadOrStore(key, plan)
+	return actual.(*entityFieldPlan) //nolint:errcheck // value type guaranteed by our Store calls
+}

--- a/internal/response/entity_plan_test.go
+++ b/internal/response/entity_plan_test.go
@@ -1,0 +1,65 @@
+package response
+
+import (
+	"reflect"
+	"testing"
+
+	metadata "github.com/nlstn/go-odata/internal/metadata"
+)
+
+func TestGetEntityFieldPlan(t *testing.T) {
+	type planEntity struct {
+		ID       int     `json:"ID"`
+		Name     string  `json:"Name"`
+		Secret   string  `json:"-"`
+		hidden   string  //nolint:unused // present to verify unexported fields are skipped
+		Category *string `json:"Category"`
+	}
+
+	md := &metadata.EntityMetadata{
+		Properties: []metadata.PropertyMetadata{
+			{Name: "ID", JsonName: "ID"},
+			{Name: "Name", JsonName: "Name"},
+			{Name: "Category", JsonName: "Category", IsNavigationProp: true, NavigationTarget: "Categories", NavigationIsArray: true},
+		},
+	}
+
+	plan := getEntityFieldPlan(md, reflect.TypeOf(planEntity{}))
+	if len(plan.entries) != reflect.TypeOf(planEntity{}).NumField() {
+		t.Fatalf("plan has %d entries, want %d", len(plan.entries), reflect.TypeOf(planEntity{}).NumField())
+	}
+
+	// Field 0: ID — plain, fullProp resolved, not nav.
+	if e := plan.entries[0]; e.skip || e.navProp != nil || e.fullProp == nil || e.jsonName != "ID" {
+		t.Errorf("ID entry = %+v, want plain resolved field", e)
+	}
+	// Field 2: Secret (json:"-") — skipped.
+	if e := plan.entries[2]; !e.skip {
+		t.Errorf("Secret entry = %+v, want skip", e)
+	}
+	// Field 3: hidden (unexported) — skipped.
+	if e := plan.entries[3]; !e.skip {
+		t.Errorf("hidden entry = %+v, want skip", e)
+	}
+	// Field 4: Category — navigation, navProp synthesized with matching values.
+	e := plan.entries[4]
+	if e.skip || e.navProp == nil {
+		t.Fatalf("Category entry = %+v, want navigation with navProp", e)
+	}
+	if !e.navProp.IsNavigationProp || e.navProp.Name != "Category" || e.navProp.JsonName != "Category" ||
+		e.navProp.NavigationTarget != "Categories" || !e.navProp.NavigationIsArray {
+		t.Errorf("Category navProp = %+v, want values copied from metadata", e.navProp)
+	}
+}
+
+func TestGetEntityFieldPlan_Cached(t *testing.T) {
+	type cachedEntity struct {
+		ID int `json:"ID"`
+	}
+	md := &metadata.EntityMetadata{Properties: []metadata.PropertyMetadata{{Name: "ID", JsonName: "ID"}}}
+	p1 := getEntityFieldPlan(md, reflect.TypeOf(cachedEntity{}))
+	p2 := getEntityFieldPlan(md, reflect.TypeOf(cachedEntity{}))
+	if p1 != p2 {
+		t.Error("expected the plan to be cached and reused (same pointer)")
+	}
+}

--- a/internal/response/navigation_links.go
+++ b/internal/response/navigation_links.go
@@ -234,15 +234,27 @@ func processStructEntityOrderedInto(entityMap *OrderedMap, entity reflect.Value,
 		}
 	}
 
-	// Process entity fields - optimized to reduce reflection calls
-	// Cache property metadata lookups per entity type
-	propMetaMap := getCachedPropertyMetadataMap(metadata)
-
-	// Get the dual-keyed (Name + JsonName) property metadata map for annotation/enum lookups.
-	// Cached per *EntityMetadata pointer — never rebuilt per entity.
-	var fullPropMetaByName map[string]*internalMetadata.PropertyMetadata
+	// Process entity fields. When full metadata is available, a cached
+	// per-(type, *EntityMetadata) plan pre-resolves the navigation and full
+	// property metadata for every field, replacing two per-field hash lookups
+	// (propMetaMap[name], fullPropMetaByName[name]) with a slice index. The plan
+	// carries identical values to those lookups. Without full metadata we fall
+	// back to the map-lookup path.
+	var plan *entityFieldPlan
 	if fullMetadata != nil {
-		fullPropMetaByName = getFullPropMetaByName(fullMetadata)
+		plan = getEntityFieldPlan(fullMetadata, entity.Type())
+		if len(plan.entries) != len(fieldInfos) {
+			plan = nil // defensive: never happens (same type), but never index out of range
+		}
+	}
+
+	var propMetaMap map[string]*PropertyMetadata
+	var fullPropMetaByName map[string]*internalMetadata.PropertyMetadata
+	if plan == nil {
+		propMetaMap = getCachedPropertyMetadataMap(metadata)
+		if fullMetadata != nil {
+			fullPropMetaByName = getFullPropMetaByName(fullMetadata)
+		}
 	}
 
 	for j := 0; j < entity.NumField(); j++ {
@@ -254,7 +266,18 @@ func processStructEntityOrderedInto(entityMap *OrderedMap, entity reflect.Value,
 			continue
 		}
 
-		propMeta := propMetaMap[info.Name]
+		var propMeta *PropertyMetadata
+		var fullProp *internalMetadata.PropertyMetadata
+		if plan != nil {
+			e := &plan.entries[j]
+			propMeta = e.navProp // nil for non-navigation fields
+			fullProp = e.fullProp
+		} else {
+			propMeta = propMetaMap[info.Name]
+			if fullPropMetaByName != nil {
+				fullProp = fullPropMetaByName[info.Name]
+			}
+		}
 
 		if propMeta != nil && propMeta.IsNavigationProp {
 			// For minimal metadata, skip navigation properties unless they're expanded
@@ -267,14 +290,7 @@ func processStructEntityOrderedInto(entityMap *OrderedMap, entity reflect.Value,
 			expandOpt := query.FindExpandOption(expandOptions, propMeta.Name, propMeta.JsonName)
 			processNavigationPropertyOrderedWithMetadata(entityMap, entity, propMeta, fieldValue, info.JsonName, expandOpt, selectedNavProps, baseURL, entitySetName, metadata, metadataLevel, keySegment, fullMetadata)
 		} else {
-			// Resolve the full property metadata once per field and reuse it below,
-			// instead of re-hashing fullPropMetaByName for the stream check, the
-			// annotations lookup, and enum formatting separately.
-			var fullProp *internalMetadata.PropertyMetadata
-			if fullPropMetaByName != nil {
-				fullProp = fullPropMetaByName[info.Name]
-			}
-
+			// fullProp was resolved above (from the plan or the fallback map).
 			// Skip stream properties — they are emitted as annotations below, not as inline values
 			if fullProp != nil && fullProp.IsStream {
 				continue


### PR DESCRIPTION
## Context

Follow-up to #848 (the "extend the plan to top-level entity properties" step). Profiling the entity-construction path (`processStructEntityOrderedInto`, ~17% of total CPU) showed it does **two hash-map lookups per field of every entity**:

- `propMetaMap[info.Name]` — the navigation-property check
- `fullPropMetaByName[info.Name]` — enum / stream / annotation / complex-type handling

Together those per-field lookups were **~6% of total CPU** — the second-largest construction cost after `OrderedMap.Set`.

## Change

A cached **per-`(entity type, *EntityMetadata)` field plan** pre-resolves, for each struct field (aligned to `getFieldInfos(t)` / `entity.Field(j)`):
- `skip` (unexported or `json:"-"`),
- the navigation descriptor (only for nav fields), and
- the full property metadata.

The hot loop then indexes `plan.entries[j]` instead of hashing two maps per field. `getCachedPropertyMetadataMap` / `getFullPropMetaByName` move off the per-request path (called once per type at plan build).

**Why this is a value-preserving, mechanical change:** `response.PropertyMetadata` is a field-for-field copy of the same `internalMetadata.PropertyMetadata` (`metadataAdapter` copies `Name`/`JsonName`/`IsNavigationProp`/`NavigationTarget`/`NavigationIsArray` straight across), so the navigation descriptor the plan synthesizes from `*EntityMetadata` carries the same values the map lookup returned. When full metadata is absent, the code falls back to the original map-lookup path unchanged.

## Correctness

Behavior is unchanged across metadata levels, `$select`, `$expand`, navigation, and property annotations — exercised by the existing `internal/response`, `internal/handlers`, and compliance suites (all green). Added unit tests for plan construction: field skipping (unexported, `json:"-"`), navigation-descriptor synthesis with copied values, and plan caching. `golangci-lint` clean.

## Measurements (perfserver, PostgreSQL, vs the post-#848 build)

| metric | before | after |
|---|--:|--:|
| per-field `mapaccess1_faststr` (share of CPU) | 6.3% | **3.9%** |
| `processStructEntityOrderedInto` (share of CPU) | 17.3% | **15.8%** |
| **CPU per request** (mixed workload) | 1.54 ms | **1.39 ms (−10%)** |
| allocation per request | 0.142 MB | 0.143 MB (unchanged) |

Throughput improved **+12–17% across every entity-read scenario** (`$top=500`, `$top=100`, `$select`, `$expand`, `Categories`) — unlike #848 this benefits *every* entity serialization, not just complex-type carriers. (CPU/req and alloc/req are normalized by 2xx responses served, so they're independent of the throughput delta between runs.)

## Where this leaves the #841 hotspot

The entity-construction path is now dominated by two remaining costs, both inherent to the ordered-envelope design:
- `OrderedMap.Set` (map insert + key append), and
- boxing each field value into `interface{}` (`enumOrRaw` / `convTstring`).

Removing those would require writing entities **directly to the buffer** from the plan (bypassing the `OrderedMap` intermediate for the common minimal-metadata / no-`$select` / no-`$expand` case, falling back otherwise). That's the largest remaining win but a materially riskier core-path change; I'd treat it as a separate, carefully-reviewed follow-up rather than fold it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)