### PR TITLE
fix(delete): cascade child rows and map FK violations to 409

### DIFF
--- a/cmd/complianceserver/entities/product.go
+++ b/cmd/complianceserver/entities/product.go
@@ -305,7 +305,7 @@ type Product struct {
 	PhotoContent     []byte   `json:"-"`                          // Photo stream content
 	// Navigation properties
 	Category        *Category            `json:"Category,omitempty" gorm:"foreignKey:CategoryID;references:ID"`
-	Descriptions    []ProductDescription `json:"Descriptions,omitempty" gorm:"foreignKey:ProductID;references:ID"`
+	Descriptions    []ProductDescription `json:"Descriptions,omitempty" gorm:"foreignKey:ProductID;references:ID;constraint:OnDelete:CASCADE"`
 	RelatedProducts []Product            `json:"RelatedProducts,omitempty" gorm:"many2many:product_relations;"`
 }
 

--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -35,6 +35,7 @@ const (
 	ErrMsgNotImplemented         = "Not implemented"
 	ErrMsgConflict               = "Conflict"
 	ErrDetailDuplicateKey        = "An entity with the same key already exists."
+	ErrDetailForeignKeyViolation = "The entity cannot be deleted because it is still referenced by related entities."
 )
 
 // Error detail format constants

--- a/internal/handlers/constraint_violation_test.go
+++ b/internal/handlers/constraint_violation_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestIsForeignKeyConstraintViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "gorm sentinel", err: gorm.ErrForeignKeyViolated, want: true},
+		{name: "wrapped gorm sentinel", err: fmt.Errorf("delete failed: %w", gorm.ErrForeignKeyViolated), want: true},
+		{
+			name: "postgres",
+			err:  errors.New(`ERROR: update or delete on table "Products" violates foreign key constraint "fk_Products_descriptions" on table "ProductDescriptions" (SQLSTATE 23503)`),
+			want: true,
+		},
+		{
+			name: "mysql",
+			err:  errors.New("Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails"),
+			want: true,
+		},
+		{
+			name: "sqlite",
+			err:  errors.New("FOREIGN KEY constraint failed"),
+			want: true,
+		},
+		{
+			name: "sqlserver",
+			err:  errors.New("The DELETE statement conflicted with the REFERENCE constraint \"FK_Products\". The conflict occurred in database ..."),
+			want: true,
+		},
+		{
+			name: "unique violation is not a foreign key violation",
+			err:  errors.New("UNIQUE constraint failed: Products.id"),
+			want: false,
+		},
+		{name: "unrelated error", err: errors.New("connection refused"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isForeignKeyConstraintViolation(tt.err); got != tt.want {
+				t.Errorf("isForeignKeyConstraintViolation(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -338,3 +338,43 @@ func (h *EntityHandler) writeCreateDatabaseError(w http.ResponseWriter, r *http.
 	}
 	h.writeDatabaseError(w, r, err)
 }
+
+// isForeignKeyConstraintViolation reports whether err represents a foreign key
+// constraint violation raised by the underlying database driver. As with
+// isUniqueConstraintViolation, gorm.ErrForeignKeyViolated is only produced when
+// the *gorm.DB was opened with Config.TranslateError enabled, which this library
+// does not control, so raw driver error text is matched too.
+func isForeignKeyConstraintViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrForeignKeyViolated) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "foreign key constraint"): // SQLite, PostgreSQL, MySQL, MariaDB
+		return true
+	case strings.Contains(msg, "violates foreign key"): // PostgreSQL (alternate wording)
+		return true
+	case strings.Contains(msg, "conflicted with the reference constraint"), // SQL Server
+		strings.Contains(msg, "reference constraint"):
+		return true
+	}
+	return false
+}
+
+// writeDeleteDatabaseError writes an error response for a failed entity deletion,
+// mapping foreign key constraint violations to 409 Conflict (the entity is still
+// referenced by related entities) instead of the generic 500 used for other
+// database errors.
+func (h *EntityHandler) writeDeleteDatabaseError(w http.ResponseWriter, r *http.Request, err error) {
+	if isForeignKeyConstraintViolation(err) {
+		if writeErr := response.WriteError(w, r, http.StatusConflict, ErrMsgConflict, ErrDetailForeignKeyViolation); writeErr != nil {
+			h.logger.Error("Error writing error response", "error", writeErr)
+		}
+		return
+	}
+	h.writeDatabaseError(w, r, err)
+}

--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -114,7 +114,7 @@ func (h *EntityHandler) handleDeleteEntity(w http.ResponseWriter, r *http.Reques
 		}
 
 		if err := tx.Delete(entity).Error; err != nil {
-			h.writeDatabaseError(w, r, err)
+			h.writeDeleteDatabaseError(w, r, err)
 			return newTransactionHandledError(err)
 		}
 


### PR DESCRIPTION
## Summary
The v1.0.3 OData compliance suite's `8.2.6_header_isolation` test deletes a `Product` that has child `ProductDescriptions` rows. On every FK-enforcing database (PostgreSQL, MySQL, MariaDB, MSSQL) this returned **500** because the delete violated the `fk_Products_descriptions` constraint. SQLite passed only because it does not enforce foreign keys by default.

## Changes
- **complianceserver**: declare `Product.Descriptions` with `constraint:OnDelete:CASCADE`. `ProductDescription` has a composite key embedding `ProductID` — it cannot exist without its parent — so cascade is the semantically correct ownership model. Deleting a `Product` now succeeds with **204** on all databases and removes its descriptions.
- **library**: map foreign-key constraint violations on `DELETE` to **409 Conflict** instead of a generic 500, mirroring the existing unique-key → 409 handling on create (`writeCreateDatabaseError`). A delete blocked by a genuinely still-referenced entity is a conflict, not a server error.

## Testing
- New unit test `TestIsForeignKeyConstraintViolation` covers PG/MySQL/SQLite/MSSQL driver error text plus the `gorm.ErrForeignKeyViolated` sentinel.
- Verified locally against PostgreSQL 17:
  - `DELETE Products(<laptop>)` (2 child descriptions) → **204**, descriptions cascade-deleted.
  - `DELETE Categories(<id>)` (still referenced by a Product, no cascade) → **409** (was 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)