### PR TITLE
fix(query): guard arithmetic against divide-by-zero and enforce float div semantics

### DIFF
--- a/internal/query/apply_filter.go
+++ b/internal/query/apply_filter.go
@@ -1516,22 +1516,24 @@ func buildFunctionSQL(dialect string, op FilterOperator, columnName string, valu
 		}
 		return fmt.Sprintf("(%s * ?)", columnName), []interface{}{value}
 	case OpDiv:
-		return fmt.Sprintf("(%s / ?)", columnName), []interface{}{value}
+		// NULLIF guards against division by zero raising a database error on
+		// PostgreSQL/SQL Server; the row yields NULL and is excluded instead.
+		return fmt.Sprintf("(%s / NULLIF(?, 0))", columnName), []interface{}{value}
 	case OpDivBy:
 		// divby performs decimal (floating-point) division; cast to avoid integer truncation
 		switch dialect {
 		case "postgres":
-			return fmt.Sprintf("(CAST(%s AS FLOAT) / ?)", columnName), []interface{}{value}
+			return fmt.Sprintf("(CAST(%s AS FLOAT) / NULLIF(?, 0))", columnName), []interface{}{value}
 		case "mysql", "mariadb":
-			return fmt.Sprintf("(CAST(%s AS DOUBLE) / ?)", columnName), []interface{}{value}
+			return fmt.Sprintf("(CAST(%s AS DOUBLE) / NULLIF(?, 0))", columnName), []interface{}{value}
 		default:
-			return fmt.Sprintf("(CAST(%s AS REAL) / ?)", columnName), []interface{}{value}
+			return fmt.Sprintf("(CAST(%s AS REAL) / NULLIF(?, 0))", columnName), []interface{}{value}
 		}
 	case OpMod:
 		if dialect == "sqlserver" || dialect == "mssql" {
-			return fmt.Sprintf("(CAST(%s AS DECIMAL(38,10)) %% CAST(? AS DECIMAL(38,10)))", columnName), []interface{}{value}
+			return fmt.Sprintf("(CAST(%s AS DECIMAL(38,10)) %% CAST(NULLIF(?, 0) AS DECIMAL(38,10)))", columnName), []interface{}{value}
 		}
-		return fmt.Sprintf("(%s %% ?)", columnName), []interface{}{value}
+		return fmt.Sprintf("(%s %% NULLIF(?, 0))", columnName), []interface{}{value}
 	case OpYear:
 		switch dialect {
 		case "postgres":

--- a/internal/query/apply_transform.go
+++ b/internal/query/apply_transform.go
@@ -781,33 +781,15 @@ func buildComputeSQLWithDB(dialect string, computeExpr ComputeExpression, entity
 			return "", "", ""
 		}
 
-		rightSQL := buildComputeExpressionSQL(dialect, &FilterExpression{Value: expression.Value}, entityMetadata)
+		rightOperand := &FilterExpression{Value: expression.Value}
+		rightSQL := buildComputeExpressionSQL(dialect, rightOperand, entityMetadata)
 		if rightSQL == "" {
 			return "", "", ""
 		}
 
-		var exprSQL string
-		switch expression.Operator {
-		case OpAdd:
-			exprSQL = fmt.Sprintf("(%s + %s)", leftSQL, rightSQL)
-		case OpSub:
-			exprSQL = fmt.Sprintf("(%s - %s)", leftSQL, rightSQL)
-		case OpMul:
-			exprSQL = fmt.Sprintf("(%s * %s)", leftSQL, rightSQL)
-		case OpDiv:
-			exprSQL = fmt.Sprintf("(%s / %s)", leftSQL, rightSQL)
-		case OpDivBy:
-			switch dialect {
-			case "postgres":
-				exprSQL = fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL)
-			case "mysql", "mariadb":
-				exprSQL = fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL)
-			default:
-				exprSQL = fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL)
-			}
-		case OpMod:
-			exprSQL = buildModuloSQL(dialect, leftSQL, rightSQL)
-		default:
+		exprSQL := buildArithmeticSQL(dialect, expression.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expression.Left, entityMetadata), arithmeticOperandIsFloat(rightOperand, entityMetadata))
+		if exprSQL == "" {
 			return "", "", ""
 		}
 
@@ -815,34 +797,17 @@ func buildComputeSQLWithDB(dialect string, computeExpr ComputeExpression, entity
 	}
 
 	if expression.Property != "" && expression.Value != nil && expression.Left == nil && expression.Right == nil && expression.Operator != "" {
-		leftSQL := buildComputeExpressionSQL(dialect, &FilterExpression{Property: expression.Property}, entityMetadata)
-		rightSQL := buildComputeExpressionSQL(dialect, &FilterExpression{Value: expression.Value}, entityMetadata)
+		leftOperand := &FilterExpression{Property: expression.Property}
+		rightOperand := &FilterExpression{Value: expression.Value}
+		leftSQL := buildComputeExpressionSQL(dialect, leftOperand, entityMetadata)
+		rightSQL := buildComputeExpressionSQL(dialect, rightOperand, entityMetadata)
 		if leftSQL == "" || rightSQL == "" {
 			return "", "", ""
 		}
 
-		var exprSQL string
-		switch expression.Operator {
-		case OpAdd:
-			exprSQL = fmt.Sprintf("(%s + %s)", leftSQL, rightSQL)
-		case OpSub:
-			exprSQL = fmt.Sprintf("(%s - %s)", leftSQL, rightSQL)
-		case OpMul:
-			exprSQL = fmt.Sprintf("(%s * %s)", leftSQL, rightSQL)
-		case OpDiv:
-			exprSQL = fmt.Sprintf("(%s / %s)", leftSQL, rightSQL)
-		case OpDivBy:
-			switch dialect {
-			case "postgres":
-				exprSQL = fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL)
-			case "mysql", "mariadb":
-				exprSQL = fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL)
-			default:
-				exprSQL = fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL)
-			}
-		case OpMod:
-			exprSQL = buildModuloSQL(dialect, leftSQL, rightSQL)
-		default:
+		exprSQL := buildArithmeticSQL(dialect, expression.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(leftOperand, entityMetadata), arithmeticOperandIsFloat(rightOperand, entityMetadata))
+		if exprSQL == "" {
 			return "", "", ""
 		}
 
@@ -860,28 +825,9 @@ func buildComputeSQLWithDB(dialect string, computeExpr ComputeExpression, entity
 			return "", "", ""
 		}
 
-		var exprSQL string
-		switch expression.Logical {
-		case "add":
-			exprSQL = fmt.Sprintf("(%s + %s)", leftSQL, rightSQL)
-		case "sub":
-			exprSQL = fmt.Sprintf("(%s - %s)", leftSQL, rightSQL)
-		case "mul":
-			exprSQL = fmt.Sprintf("(%s * %s)", leftSQL, rightSQL)
-		case "div":
-			exprSQL = fmt.Sprintf("(%s / %s)", leftSQL, rightSQL)
-		case "divby":
-			switch dialect {
-			case "postgres":
-				exprSQL = fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL)
-			case "mysql", "mariadb":
-				exprSQL = fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL)
-			default:
-				exprSQL = fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL)
-			}
-		case "mod":
-			exprSQL = buildModuloSQL(dialect, leftSQL, rightSQL)
-		default:
+		exprSQL := buildArithmeticSQL(dialect, FilterOperator(expression.Logical), leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expression.Left, entityMetadata), arithmeticOperandIsFloat(expression.Right, entityMetadata))
+		if exprSQL == "" {
 			return "", "", ""
 		}
 
@@ -928,21 +874,26 @@ func buildComputeExpressionSQL(dialect string, expr *FilterExpression, entityMet
 		expr.Right == nil &&
 		expr.Operator != "" &&
 		(expr.Operator != OpEqual || expr.Value != true) {
-		leftSQL := buildComputeExpressionSQL(dialect, &FilterExpression{Property: expr.Property}, entityMetadata)
-		rightSQL := buildComputeExpressionSQL(dialect, &FilterExpression{Value: expr.Value}, entityMetadata)
+		leftOperand := &FilterExpression{Property: expr.Property}
+		rightOperand := &FilterExpression{Value: expr.Value}
+		leftSQL := buildComputeExpressionSQL(dialect, leftOperand, entityMetadata)
+		rightSQL := buildComputeExpressionSQL(dialect, rightOperand, entityMetadata)
 		if leftSQL == "" || rightSQL == "" {
 			return ""
 		}
-		return buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL)
+		return buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(leftOperand, entityMetadata), arithmeticOperandIsFloat(rightOperand, entityMetadata))
 	}
 
 	if expr.Left != nil && expr.Value != nil && expr.Right == nil && expr.Operator != "" {
+		rightOperand := &FilterExpression{Value: expr.Value}
 		leftSQL := buildComputeExpressionSQL(dialect, expr.Left, entityMetadata)
-		rightSQL := buildComputeExpressionSQL(dialect, &FilterExpression{Value: expr.Value}, entityMetadata)
+		rightSQL := buildComputeExpressionSQL(dialect, rightOperand, entityMetadata)
 		if leftSQL == "" || rightSQL == "" {
 			return ""
 		}
-		return buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL)
+		return buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expr.Left, entityMetadata), arithmeticOperandIsFloat(rightOperand, entityMetadata))
 	}
 
 	if expr.Left != nil && expr.Right != nil && expr.Operator != "" {
@@ -951,7 +902,8 @@ func buildComputeExpressionSQL(dialect string, expr *FilterExpression, entityMet
 		if leftSQL == "" || rightSQL == "" {
 			return ""
 		}
-		return buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL)
+		return buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expr.Left, entityMetadata), arithmeticOperandIsFloat(expr.Right, entityMetadata))
 	}
 
 	if expr.Left != nil && expr.Right != nil && expr.Logical != "" {
@@ -962,13 +914,21 @@ func buildComputeExpressionSQL(dialect string, expr *FilterExpression, entityMet
 		}
 
 		op := FilterOperator(expr.Logical)
-		return buildArithmeticSQL(dialect, op, leftSQL, rightSQL)
+		return buildArithmeticSQL(dialect, op, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expr.Left, entityMetadata), arithmeticOperandIsFloat(expr.Right, entityMetadata))
 	}
 
 	return ""
 }
 
-func buildArithmeticSQL(dialect string, op FilterOperator, leftSQL string, rightSQL string) string {
+// buildArithmeticSQL renders an OData arithmetic operator to SQL. leftIsFloat and
+// rightIsFloat indicate whether the operands evaluate to a floating-point
+// (Edm.Double/Edm.Single) value, which controls whether `div` performs IEEE 754
+// floating division or integer division (OData §5.1.1.6.1: `div` is integer
+// division only when both operands are integers). Every divisor is wrapped in
+// NULLIF so that division or modulo by zero yields NULL on all dialects instead
+// of a database error (see nullIfZero).
+func buildArithmeticSQL(dialect string, op FilterOperator, leftSQL, rightSQL string, leftIsFloat, rightIsFloat bool) string {
 	switch op {
 	case OpAdd:
 		return fmt.Sprintf("(%s + %s)", leftSQL, rightSQL)
@@ -977,16 +937,17 @@ func buildArithmeticSQL(dialect string, op FilterOperator, leftSQL string, right
 	case OpMul:
 		return fmt.Sprintf("(%s * %s)", leftSQL, rightSQL)
 	case OpDiv:
-		return fmt.Sprintf("(%s / %s)", leftSQL, rightSQL)
-	case OpDivBy:
-		switch dialect {
-		case "postgres":
-			return fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL)
-		case "mysql", "mariadb":
-			return fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL)
-		default:
-			return fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL)
+		// If either operand is a floating-point value the result is IEEE 754
+		// division; cast the dividend to a floating type so the division is
+		// performed in floating point even when the column is stored as an exact
+		// decimal/numeric type (e.g. PostgreSQL maps Go float64 to numeric).
+		if leftIsFloat || rightIsFloat {
+			return fmt.Sprintf("(%s / %s)", castToFloat(dialect, leftSQL), nullIfZero(rightSQL))
 		}
+		return fmt.Sprintf("(%s / %s)", leftSQL, nullIfZero(rightSQL))
+	case OpDivBy:
+		// divby is always fractional division.
+		return fmt.Sprintf("(%s / %s)", castToFloat(dialect, leftSQL), nullIfZero(rightSQL))
 	case OpMod:
 		return buildModuloSQL(dialect, leftSQL, rightSQL)
 	default:
@@ -995,10 +956,77 @@ func buildArithmeticSQL(dialect string, op FilterOperator, leftSQL string, right
 }
 
 func buildModuloSQL(dialect string, leftSQL string, rightSQL string) string {
-	if dialect == "sqlserver" {
-		return fmt.Sprintf("(CAST(%s AS DECIMAL(38, 10)) %% CAST(%s AS DECIMAL(38, 10)))", leftSQL, rightSQL)
+	if dialect == "sqlserver" || dialect == "mssql" {
+		return fmt.Sprintf("(CAST(%s AS DECIMAL(38, 10)) %% CAST(%s AS DECIMAL(38, 10)))", leftSQL, nullIfZero(rightSQL))
 	}
-	return fmt.Sprintf("(%s %% %s)", leftSQL, rightSQL)
+	return fmt.Sprintf("(%s %% %s)", leftSQL, nullIfZero(rightSQL))
+}
+
+// castToFloat casts an expression to the dialect's IEEE 754 double-precision
+// floating type. SQL Server FLOAT and PostgreSQL FLOAT are both 8-byte doubles;
+// SQLite REAL is an 8-byte float.
+func castToFloat(dialect, expr string) string {
+	switch dialect {
+	case "mysql", "mariadb":
+		return fmt.Sprintf("CAST(%s AS DOUBLE)", expr)
+	case "sqlite":
+		return fmt.Sprintf("CAST(%s AS REAL)", expr)
+	default: // postgres, sqlserver/mssql
+		return fmt.Sprintf("CAST(%s AS FLOAT)", expr)
+	}
+}
+
+// nullIfZero wraps a divisor expression so that division or modulo by zero yields
+// NULL on every dialect. PostgreSQL and SQL Server raise a "division by zero"
+// error otherwise; SQLite and MySQL already return NULL. OData arithmetic follows
+// IEEE 754 where x/0 is ±Infinity or NaN, so the affected rows are simply
+// excluded from comparisons rather than aborting the request with a 500.
+func nullIfZero(divisorSQL string) string {
+	return fmt.Sprintf("NULLIF(%s, 0)", divisorSQL)
+}
+
+// arithmeticOperandIsFloat reports whether an arithmetic operand evaluates to a
+// floating-point value, used to decide whether `div` is floating or integer
+// division. Nested arithmetic propagates float-ness (divby is always float).
+func arithmeticOperandIsFloat(expr *FilterExpression, entityMetadata *metadata.EntityMetadata) bool {
+	if expr == nil {
+		return false
+	}
+	if expr.Left != nil || expr.Right != nil {
+		op := expr.Operator
+		if op == "" && expr.Logical != "" {
+			op = FilterOperator(expr.Logical)
+		}
+		if op == OpDivBy {
+			return true
+		}
+		return arithmeticOperandIsFloat(expr.Left, entityMetadata) || arithmeticOperandIsFloat(expr.Right, entityMetadata)
+	}
+	if expr.Property != "" {
+		return isFloatingProperty(findProperty(expr.Property, entityMetadata))
+	}
+	switch expr.Value.(type) {
+	case float32, float64:
+		return true
+	}
+	return false
+}
+
+// isFloatingProperty reports whether a property is an Edm.Double or Edm.Single.
+func isFloatingProperty(prop *metadata.PropertyMetadata) bool {
+	if prop == nil {
+		return false
+	}
+	if prop.EdmType == "Edm.Double" || prop.EdmType == "Edm.Single" {
+		return true
+	}
+	if prop.Type != nil {
+		switch prop.Type.Kind() {
+		case reflect.Float32, reflect.Float64:
+			return true
+		}
+	}
+	return false
 }
 
 // buildComputeExpressionSQLWithArgs builds SQL for arithmetic expressions while keeping bind args.
@@ -1025,73 +1053,36 @@ func buildComputeExpressionSQLWithArgs(dialect string, expr *FilterExpression, e
 		expr.Right == nil &&
 		expr.Operator != "" &&
 		(expr.Operator != OpEqual || expr.Value != true) {
-		leftSQL, leftArgs := buildComputeExpressionSQLWithArgs(dialect, &FilterExpression{Property: expr.Property}, entityMetadata)
-		rightSQL, rightArgs := buildComputeExpressionSQLWithArgs(dialect, &FilterExpression{Value: expr.Value}, entityMetadata)
+		leftOperand := &FilterExpression{Property: expr.Property}
+		rightOperand := &FilterExpression{Value: expr.Value}
+		leftSQL, leftArgs := buildComputeExpressionSQLWithArgs(dialect, leftOperand, entityMetadata)
+		rightSQL, rightArgs := buildComputeExpressionSQLWithArgs(dialect, rightOperand, entityMetadata)
 		if leftSQL == "" || rightSQL == "" {
 			return "", nil
 		}
 
-		var sqlOp string
-		switch expr.Operator {
-		case OpAdd:
-			sqlOp = "+"
-		case OpSub:
-			sqlOp = "-"
-		case OpMul:
-			sqlOp = "*"
-		case OpDiv:
-			sqlOp = "/"
-		case OpDivBy:
-			switch dialect {
-			case "postgres":
-				return fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			case "mysql", "mariadb":
-				return fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			default:
-				return fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			}
-		case OpMod:
-			return buildModuloSQL(dialect, leftSQL, rightSQL), append(leftArgs, rightArgs...)
-		default:
+		sql := buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(leftOperand, entityMetadata), arithmeticOperandIsFloat(rightOperand, entityMetadata))
+		if sql == "" {
 			return "", nil
 		}
-
-		return fmt.Sprintf("(%s %s %s)", leftSQL, sqlOp, rightSQL), append(leftArgs, rightArgs...)
+		return sql, append(leftArgs, rightArgs...)
 	}
 
 	if expr.Left != nil && expr.Value != nil && expr.Right == nil && expr.Operator != "" {
+		rightOperand := &FilterExpression{Value: expr.Value}
 		leftSQL, leftArgs := buildComputeExpressionSQLWithArgs(dialect, expr.Left, entityMetadata)
-		rightSQL, rightArgs := buildComputeExpressionSQLWithArgs(dialect, &FilterExpression{Value: expr.Value}, entityMetadata)
+		rightSQL, rightArgs := buildComputeExpressionSQLWithArgs(dialect, rightOperand, entityMetadata)
 		if leftSQL == "" || rightSQL == "" {
 			return "", nil
 		}
 
-		var sqlOp string
-		switch expr.Operator {
-		case OpAdd:
-			sqlOp = "+"
-		case OpSub:
-			sqlOp = "-"
-		case OpMul:
-			sqlOp = "*"
-		case OpDiv:
-			sqlOp = "/"
-		case OpDivBy:
-			switch dialect {
-			case "postgres":
-				return fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			case "mysql", "mariadb":
-				return fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			default:
-				return fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			}
-		case OpMod:
-			return buildModuloSQL(dialect, leftSQL, rightSQL), append(leftArgs, rightArgs...)
-		default:
+		sql := buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expr.Left, entityMetadata), arithmeticOperandIsFloat(rightOperand, entityMetadata))
+		if sql == "" {
 			return "", nil
 		}
-
-		return fmt.Sprintf("(%s %s %s)", leftSQL, sqlOp, rightSQL), append(leftArgs, rightArgs...)
+		return sql, append(leftArgs, rightArgs...)
 	}
 
 	if expr.Left != nil && expr.Right != nil && expr.Operator != "" {
@@ -1101,32 +1092,12 @@ func buildComputeExpressionSQLWithArgs(dialect string, expr *FilterExpression, e
 			return "", nil
 		}
 
-		var sqlOp string
-		switch expr.Operator {
-		case OpAdd:
-			sqlOp = "+"
-		case OpSub:
-			sqlOp = "-"
-		case OpMul:
-			sqlOp = "*"
-		case OpDiv:
-			sqlOp = "/"
-		case OpDivBy:
-			switch dialect {
-			case "postgres":
-				return fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			case "mysql", "mariadb":
-				return fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			default:
-				return fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			}
-		case OpMod:
-			return buildModuloSQL(dialect, leftSQL, rightSQL), append(leftArgs, rightArgs...)
-		default:
+		sql := buildArithmeticSQL(dialect, expr.Operator, leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expr.Left, entityMetadata), arithmeticOperandIsFloat(expr.Right, entityMetadata))
+		if sql == "" {
 			return "", nil
 		}
-
-		return fmt.Sprintf("(%s %s %s)", leftSQL, sqlOp, rightSQL), append(leftArgs, rightArgs...)
+		return sql, append(leftArgs, rightArgs...)
 	}
 
 	if expr.Left != nil && expr.Right != nil && expr.Logical != "" {
@@ -1136,32 +1107,12 @@ func buildComputeExpressionSQLWithArgs(dialect string, expr *FilterExpression, e
 			return "", nil
 		}
 
-		var sqlOp string
-		switch expr.Logical {
-		case "add":
-			sqlOp = "+"
-		case "sub":
-			sqlOp = "-"
-		case "mul":
-			sqlOp = "*"
-		case "div":
-			sqlOp = "/"
-		case "divby":
-			switch dialect {
-			case "postgres":
-				return fmt.Sprintf("(CAST(%s AS FLOAT) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			case "mysql", "mariadb":
-				return fmt.Sprintf("(CAST(%s AS DOUBLE) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			default:
-				return fmt.Sprintf("(CAST(%s AS REAL) / %s)", leftSQL, rightSQL), append(leftArgs, rightArgs...)
-			}
-		case "mod":
-			return buildModuloSQL(dialect, leftSQL, rightSQL), append(leftArgs, rightArgs...)
-		default:
+		sql := buildArithmeticSQL(dialect, FilterOperator(expr.Logical), leftSQL, rightSQL,
+			arithmeticOperandIsFloat(expr.Left, entityMetadata), arithmeticOperandIsFloat(expr.Right, entityMetadata))
+		if sql == "" {
 			return "", nil
 		}
-
-		return fmt.Sprintf("(%s %s %s)", leftSQL, sqlOp, rightSQL), append(leftArgs, rightArgs...)
+		return sql, append(leftArgs, rightArgs...)
 	}
 
 	return "", nil

--- a/internal/query/arithmetic_functions_test.go
+++ b/internal/query/arithmetic_functions_test.go
@@ -317,24 +317,26 @@ func TestArithmeticFunctions_SQLGeneration(t *testing.T) {
 			expectedArgsNo: 2,
 		},
 		{
-			name:           "div SQL",
-			filter:         "div(Price, 2) ge 25",
-			expectErr:      false,
-			expectedSQL:    "(price / ?) >= ?",
+			name:      "div SQL",
+			filter:    "div(Price, 2) ge 25",
+			expectErr: false,
+			// Price is Edm.Double, so div performs floating division (cast), and the
+			// divisor is NULLIF-guarded against division by zero.
+			expectedSQL:    "(CAST(price AS REAL) / NULLIF(?, 0)) >= ?",
 			expectedArgsNo: 2,
 		},
 		{
 			name:           "mod SQL with function syntax",
 			filter:         "mod(Price, 2) eq 1",
 			expectErr:      false,
-			expectedSQL:    "(price % ?) = ?",
+			expectedSQL:    "(price % NULLIF(?, 0)) = ?",
 			expectedArgsNo: 2,
 		},
 		{
 			name:           "mod SQL with infix syntax",
 			filter:         "Price mod 2 eq 1",
 			expectErr:      false,
-			expectedSQL:    "(price % ?) = ?",
+			expectedSQL:    "(price % NULLIF(?, 0)) = ?",
 			expectedArgsNo: 2,
 		},
 	}
@@ -428,14 +430,14 @@ func TestArithmeticFunctions_DivBy_SQLGeneration(t *testing.T) {
 			name:           "divby SQL uses CAST for decimal division",
 			filter:         "Price divby 1.5 gt 25",
 			expectErr:      false,
-			expectedSQL:    "(CAST(price AS REAL) / ?) > ?",
+			expectedSQL:    "(CAST(price AS REAL) / NULLIF(?, 0)) > ?",
 			expectedArgsNo: 2,
 		},
 		{
 			name:           "divby infix SQL uses CAST for decimal division",
 			filter:         "Price divby 2 eq 25",
 			expectErr:      false,
-			expectedSQL:    "(CAST(price AS REAL) / ?) = ?",
+			expectedSQL:    "(CAST(price AS REAL) / NULLIF(?, 0)) = ?",
 			expectedArgsNo: 2,
 		},
 	}
@@ -471,7 +473,7 @@ func TestArithmeticFunctions_Mod_SQLServerGeneration(t *testing.T) {
 	}
 
 	sql, args := buildFilterCondition("sqlserver", filterExpr, meta)
-	expectedSQL := "(CAST([price] AS DECIMAL(38, 10)) % CAST(? AS DECIMAL(38, 10))) = ?"
+	expectedSQL := "(CAST([price] AS DECIMAL(38, 10)) % CAST(NULLIF(?, 0) AS DECIMAL(38, 10))) = ?"
 	if sql != expectedSQL {
 		t.Fatalf("Expected SQL: %q, got: %q", expectedSQL, sql)
 	}

--- a/internal/query/divide_by_zero_test.go
+++ b/internal/query/divide_by_zero_test.go
@@ -1,0 +1,68 @@
+package query
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestArithmeticDivideByZeroGuard verifies that every division and modulo
+// divisor is wrapped in NULLIF so that division by zero yields NULL instead of
+// raising a database error on PostgreSQL/SQL Server (SQLite and MySQL already
+// return NULL). See nullIfZero.
+func TestArithmeticDivideByZeroGuard(t *testing.T) {
+	meta := getTestMetadata(t)
+
+	dialects := []string{"sqlite", "postgres", "mysql", "mariadb", "sqlserver"}
+	filters := []string{
+		"Price div 0 gt 0",
+		"Price divby 0 gt 0",
+		"Price mod 0 eq 0",
+		"ID div 0 eq 0",
+		"ID mod 0 eq 0",
+	}
+
+	for _, dialect := range dialects {
+		for _, filter := range filters {
+			t.Run(dialect+"/"+filter, func(t *testing.T) {
+				expr, err := parseFilter(filter, meta, nil, 0)
+				if err != nil {
+					t.Fatalf("parseFilter(%q) error: %v", filter, err)
+				}
+				sql, _ := buildFilterCondition(dialect, expr, meta)
+				if !strings.Contains(sql, "NULLIF(") {
+					t.Errorf("dialect %s filter %q: expected NULLIF-guarded divisor, got %q", dialect, filter, sql)
+				}
+			})
+		}
+	}
+}
+
+// TestArithmeticDivFloatingForDoubleOperand verifies that OData `div` performs
+// IEEE 754 floating division when an operand is Edm.Double (Price), and integer
+// division when both operands are integers (ID). Without the floating cast a
+// database that stores Edm.Double as an exact decimal (e.g. PostgreSQL maps Go
+// float64 to numeric) would compute decimal arithmetic that diverges from the
+// double-precision semantics the type promises.
+func TestArithmeticDivFloatingForDoubleOperand(t *testing.T) {
+	meta := getTestMetadata(t)
+
+	// Price is Edm.Double -> floating division (dividend cast to a float type).
+	expr, err := parseFilter("Price div 3 eq 0", meta, nil, 0)
+	if err != nil {
+		t.Fatalf("parseFilter error: %v", err)
+	}
+	sql, _ := buildFilterCondition("postgres", expr, meta)
+	if !strings.Contains(sql, "CAST(") {
+		t.Errorf("Price div (Edm.Double): expected floating cast, got %q", sql)
+	}
+
+	// ID is an integer -> integer division, no cast.
+	expr, err = parseFilter("ID div 3 eq 0", meta, nil, 0)
+	if err != nil {
+		t.Fatalf("parseFilter error: %v", err)
+	}
+	sql, _ = buildFilterCondition("postgres", expr, meta)
+	if strings.Contains(sql, "CAST(") {
+		t.Errorf("ID div (integer): expected integer division without cast, got %q", sql)
+	}
+}


### PR DESCRIPTION
## Summary
The v1.0.3 OData compliance suite surfaced two `$filter` arithmetic-operator gaps that failed on **PostgreSQL/SQL Server** but passed on SQLite/MySQL:

### 1. Division by zero → 500 (`11.5.1.1_filter_divby_operator`)
`Price divby 0` returned a **500** because PostgreSQL and SQL Server raise a `division by zero` error, whereas SQLite and MySQL return NULL. OData arithmetic follows IEEE 754 (x/0 is ±Infinity/NaN), so the affected rows should simply be excluded from comparisons — never a server error. Every `div`/`divby`/`mod` divisor is now wrapped in `NULLIF(x, 0)`, yielding NULL consistently on all dialects.

### 2. `div` on `Edm.Double` used exact-decimal arithmetic (`5.1.1.5`)
`(Price div 3) mul 3 eq Price` returned the wrong rows on PostgreSQL. `Price` is `Edm.Double`, but GORM maps Go `float64` to PostgreSQL `numeric`, so a bare `/` performed **exact decimal** division instead of the IEEE 754 double arithmetic the type promises. `div` now casts the dividend to a floating type when either operand is `Edm.Double`/`Edm.Single` (integer division is still used when both operands are integers, per OData §5.1.1.6.1).

## Refactor
The four duplicated arithmetic-operator switches in the compute/filter SQL builders are consolidated onto `buildArithmeticSQL`, which now takes operand float-ness and centralizes the `NULLIF` guard and float casting.

## Testing
- New `TestArithmeticDivideByZeroGuard` (all 5 dialects × div/divby/mod) and `TestArithmeticDivFloatingForDoubleOperand` (float cast for Double, integer division preserved for Int).
- Updated existing SQL-generation assertions for the new NULLIF/cast output.
- Verified locally against PostgreSQL 17:
  - `Price divby 0 gt 0` → **200** (was 500), 0 matches (NULL excluded — consistent).
  - `Price mod 0 eq 0` → **200** (was 500).
  - `(Price div 3) mul 3 eq Price` → **6** matches, exactly the IEEE-754 oracle (was 2 under decimal arithmetic).
  - `Quantity div 7 eq 42` → integer division preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)