### PR TITLE
fix(complianceserver): serialize reseeds to prevent concurrent-drop deadlock

### DIFF
--- a/cmd/complianceserver/reseed.go
+++ b/cmd/complianceserver/reseed.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,10 +13,22 @@ import (
 	"gorm.io/gorm"
 )
 
+// seedMu serializes seedDatabase so its destructive drop/migrate/seed sequence
+// can never run concurrently with itself. The compliance suite runs suites in
+// parallel and each triggers a Reseed at setup; two overlapping reseeds
+// otherwise deadlock on PostgreSQL (one dropping "Products" while the other
+// inserts/re-adds its foreign key) and produce FK/duplicate-key errors. The
+// HTTP reseedGate also guards this at the request layer, but this mutex makes
+// the invariant hold regardless of how the reseed is invoked.
+var seedMu sync.Mutex
+
 // seedDatabase initializes the database with sample data
 // This function drops and recreates all tables to ensure a clean state
 // It handles both initial setup and reseeding operations
 func seedDatabase(db *gorm.DB) error {
+	seedMu.Lock()
+	defer seedMu.Unlock()
+
 	// Get the database dialect name to determine the database type
 	dialectName := db.Name()
 

--- a/cmd/complianceserver/reseed_concurrency_test.go
+++ b/cmd/complianceserver/reseed_concurrency_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// TestSeedDatabaseConcurrent verifies that concurrent reseeds are serialized and
+// never corrupt the schema. The compliance suite runs suites in parallel, each
+// issuing a Reseed at setup; without serialization two overlapping drop/migrate/
+// seed sequences deadlock and raise foreign-key / duplicate-key errors (observed
+// on PostgreSQL). seedMu must make every seedDatabase call run to completion
+// before the next begins.
+func TestSeedDatabaseConcurrent(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "concurrent.db")
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := seedDatabase(db); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent seedDatabase failed: %v", err)
+	}
+
+	// The final state must be exactly one clean seed (7 products), proving the
+	// reseeds serialized rather than interleaving partial writes.
+	var products int64
+	if err := db.Table("Products").Count(&products).Error; err != nil {
+		t.Fatalf("count products: %v", err)
+	}
+	if products != 7 {
+		t.Errorf("expected 7 products after serialized reseeds, got %d", products)
+	}
+}


### PR DESCRIPTION
## Summary
PostgreSQL compliance runs were **intermittently** failing at suite setup (e.g. `11.4.11_head_requests`) — a pre-existing flake independent of the v1.0.3 bump. The compliance server logs show the root cause:

```
ERROR: deadlock detected
  Process A: DROP TABLE IF EXISTS "Products" CASCADE
  Process B: INSERT INTO "Products" ...
ERROR: insert or update on table "Products" violates foreign key constraint "fk_Categories_products"
  ALTER TABLE "Products" ADD CONSTRAINT "fk_Categories_products" ...
ERROR: duplicate key value violates unique constraint "ProductDescriptions_pkey"
```

The compliance suite runs suites in **parallel**, and each triggers a `Reseed` at setup. Two `seedDatabase` drop/migrate/seed sequences could therefore run concurrently — one dropping `Products` while another re-added its foreign key and re-inserted the seed rows — deadlocking and corrupting the reseed. PostgreSQL surfaces this; the other databases happened not to.

## Fix
Guard `seedDatabase` with a process-level `sync.Mutex` so its destructive drop/migrate/seed sequence always runs to completion before the next begins, regardless of how the reseed is invoked. The HTTP `reseedGate` still guards the request layer; this makes the serialization invariant hold unconditionally.

## Testing
- New `TestSeedDatabaseConcurrent` runs 8 concurrent `seedDatabase` calls under `-race` and asserts all succeed with exactly one clean seed (7 products) — no interleaving.
- Full compliance-server test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)