### PR TITLE
perf(response): negotiate content format once per request

### DIFF
--- a/http_runtime.go
+++ b/http_runtime.go
@@ -30,6 +30,12 @@ func (s *Service) serveHTTP(w http.ResponseWriter, r *http.Request, allowAsync b
 		r = r.WithContext(ctx)
 	}
 
+	// Negotiate content format once per request and cache the result on the
+	// context. The $format query parameter and Accept header are immutable for
+	// the request, so the response layer reuses this decision instead of
+	// re-parsing the raw query string on every helper call.
+	r = r.WithContext(response.WithNegotiation(r.Context(), r))
+
 	// Strip base path from incoming request path
 	if basePath != "" && strings.HasPrefix(r.URL.Path, basePath) {
 		newPath := strings.TrimPrefix(r.URL.Path, basePath)

--- a/internal/response/atom.go
+++ b/internal/response/atom.go
@@ -22,13 +22,17 @@ const (
 // IsAtomFormat returns true if the request asks for Atom/XML format via
 // $format=atom, $format=application/atom+xml, or Accept: application/atom+xml.
 func IsAtomFormat(r *http.Request) bool {
-	format := getFormatParameter(r)
+	return getNegotiation(r).isAtom
+}
+
+// isAtomFrom resolves the Atom/JSON decision from the already parsed $format
+// value and Accept header.
+func isAtomFrom(format, accept string) bool {
 	if format != "" {
 		parts := strings.Split(format, ";")
 		baseFormat := strings.TrimSpace(parts[0])
 		return baseFormat == "atom" || baseFormat == "application/atom+xml"
 	}
-	accept := r.Header.Get("Accept")
 	if accept == "" {
 		return false
 	}

--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -243,15 +243,7 @@ func WriteODataDeltaResponse(w http.ResponseWriter, r *http.Request, entitySetNa
 
 // shouldAddIndexAnnotations checks if the $index query parameter is present in the request
 func shouldAddIndexAnnotations(r *http.Request) bool {
-	queryParams := query.ParseRawQuery(r.URL.RawQuery)
-	_, prefixedExists := queryParams["$index"]
-	if prefixedExists {
-		return true
-	}
-
-	queryParams = query.NormalizeQueryParams(queryParams)
-	_, normalizedExists := queryParams["$index"]
-	return normalizedExists
+	return getNegotiation(r).hasIndex
 }
 
 // addIndexAnnotations adds @odata.index annotations to collection items.

--- a/internal/response/format_helpers.go
+++ b/internal/response/format_helpers.go
@@ -88,14 +88,18 @@ func validateMetadataValue(value string) error {
 // Returns an error if an invalid metadata value is specified.
 // Valid values are: "minimal", "full", "none"
 func ValidateODataMetadata(r *http.Request) error {
-	format := getFormatParameter(r)
+	return getNegotiation(r).metadataErr
+}
+
+// validateMetadataFrom validates the odata.metadata parameter using the already
+// parsed $format value and Accept header.
+func validateMetadataFrom(format, accept string) error {
 	if format != "" {
 		if err := validateMetadataInFormat(format); err != nil {
 			return err
 		}
 	}
 
-	accept := r.Header.Get("Accept")
 	if accept != "" {
 		if err := validateMetadataInAccept(accept); err != nil {
 			return err
@@ -108,12 +112,16 @@ func ValidateODataMetadata(r *http.Request) error {
 // GetODataMetadataLevel extracts the odata.metadata parameter value from the request
 // Returns "minimal" (default), "full", or "none" based on Accept header or $format parameter
 func GetODataMetadataLevel(r *http.Request) string {
-	format := getFormatParameter(r)
+	return getNegotiation(r).metadataLevel
+}
+
+// metadataLevelFrom resolves the metadata level from the already parsed $format
+// value and Accept header.
+func metadataLevelFrom(format, accept string) string {
 	if format != "" {
 		return extractMetadataFromFormat(format)
 	}
 
-	accept := r.Header.Get("Accept")
 	if accept != "" {
 		return extractMetadataFromAccept(accept)
 	}
@@ -124,14 +132,18 @@ func GetODataMetadataLevel(r *http.Request) string {
 // GetIEEE754Compatible extracts IEEE754Compatible format parameter value from
 // $format or Accept. Returns false when unspecified.
 func GetIEEE754Compatible(r *http.Request) bool {
-	format := getFormatParameter(r)
+	return getNegotiation(r).ieee754
+}
+
+// ieee754From resolves IEEE754Compatible from the already parsed $format value
+// and Accept header.
+func ieee754From(format, accept string) bool {
 	if format != "" {
 		if value, ok := extractIEEE754FromMediaType(format); ok {
 			return value
 		}
 	}
 
-	accept := r.Header.Get("Accept")
 	if accept != "" {
 		parts := strings.Split(accept, ",")
 		for _, part := range parts {
@@ -157,22 +169,11 @@ func GetIEEE754Compatible(r *http.Request) bool {
 
 // BuildJSONContentType builds the OData JSON Content-Type value from request format negotiation.
 func BuildJSONContentType(r *http.Request) string {
-	metadataLevel := GetODataMetadataLevel(r)
-	if GetIEEE754Compatible(r) {
-		return fmt.Sprintf("application/json;odata.metadata=%s;IEEE754Compatible=true", metadataLevel)
+	n := getNegotiation(r)
+	if n.ieee754 {
+		return fmt.Sprintf("application/json;odata.metadata=%s;IEEE754Compatible=true", n.metadataLevel)
 	}
-	return fmt.Sprintf("application/json;odata.metadata=%s", metadataLevel)
-}
-
-func getFormatParameter(r *http.Request) string {
-	queryParams := oquery.ParseRawQuery(r.URL.RawQuery)
-
-	queryParams = oquery.NormalizeQueryParams(queryParams)
-
-	if format := queryParams.Get("$format"); format != "" {
-		return format
-	}
-	return ""
+	return fmt.Sprintf("application/json;odata.metadata=%s", n.metadataLevel)
 }
 
 func validateMetadataInFormat(format string) error {
@@ -298,7 +299,12 @@ func extractIEEE754FromParts(parts []string) (bool, bool) {
 // IsAcceptableFormat checks if the requested format via Accept header or $format is supported
 // Returns true if the format is acceptable (JSON, Atom/XML, or wildcard), false otherwise
 func IsAcceptableFormat(r *http.Request) bool {
-	format := getFormatParameter(r)
+	return getNegotiation(r).acceptable
+}
+
+// isAcceptableFrom resolves format acceptability from the already parsed $format
+// value and Accept header.
+func isAcceptableFrom(format, accept string) bool {
 	if format != "" {
 		parts := strings.Split(format, ";")
 		baseFormat := strings.TrimSpace(parts[0])
@@ -306,7 +312,6 @@ func IsAcceptableFormat(r *http.Request) bool {
 			baseFormat == "atom" || baseFormat == "application/atom+xml"
 	}
 
-	accept := r.Header.Get("Accept")
 	if accept == "" {
 		return true
 	}

--- a/internal/response/metadata_level_test.go
+++ b/internal/response/metadata_level_test.go
@@ -338,7 +338,8 @@ func TestBuildJSONContentType(t *testing.T) {
 	}
 }
 
-// TestGetFormatParameter tests the getFormatParameter helper function
+// TestGetFormatParameter tests the $format extraction performed by
+// parseQueryNegotiation.
 func TestGetFormatParameter(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -405,9 +406,9 @@ func TestGetFormatParameter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/test?"+tt.rawQuery, nil)
-			got := getFormatParameter(req)
+			got, _ := parseQueryNegotiation(req.URL.RawQuery)
 			if got != tt.expected {
-				t.Errorf("getFormatParameter(%q) = %q, want %q",
+				t.Errorf("parseQueryNegotiation(%q) format = %q, want %q",
 					tt.rawQuery, got, tt.expected)
 			}
 		})

--- a/internal/response/negotiation.go
+++ b/internal/response/negotiation.go
@@ -1,0 +1,83 @@
+package response
+
+import (
+	"context"
+	"net/http"
+
+	oquery "github.com/nlstn/go-odata/internal/query"
+)
+
+// negotiationContextKey is the context key under which a *negotiation computed
+// once at the start of a request is stored.
+const negotiationContextKey ContextKey = "odata.negotiation"
+
+// negotiation holds the result of content negotiation for a single request.
+//
+// Metadata level, format acceptability, the Atom/JSON decision, IEEE754
+// compatibility and the presence of $index all derive solely from the request's
+// $format query parameter and Accept header, both of which are immutable for the
+// lifetime of a request. Computing them once and reusing the result avoids
+// re-parsing the raw query string (two url.Values allocations plus percent
+// decoding) on each of the four to eight negotiation helper calls per request.
+type negotiation struct {
+	metadataLevel string
+	isAtom        bool
+	acceptable    bool
+	ieee754       bool
+	hasIndex      bool
+	metadataErr   error
+}
+
+// computeNegotiation performs all format/Accept parsing for a request exactly
+// once. The raw query string is parsed a single time to derive both the $format
+// value and the presence of $index, and that result is threaded through the
+// per-field helpers instead of each of them re-parsing the query.
+func computeNegotiation(r *http.Request) *negotiation {
+	format, hasIndex := parseQueryNegotiation(r.URL.RawQuery)
+	accept := r.Header.Get("Accept")
+
+	n := &negotiation{
+		metadataLevel: metadataLevelFrom(format, accept),
+		isAtom:        isAtomFrom(format, accept),
+		acceptable:    isAcceptableFrom(format, accept),
+		ieee754:       ieee754From(format, accept),
+		hasIndex:      hasIndex,
+		metadataErr:   validateMetadataFrom(format, accept),
+	}
+	return n
+}
+
+// parseQueryNegotiation parses the raw query string once and reports the $format
+// value (empty when absent) and whether the $index system query option is
+// present in either its prefixed or normalized form.
+func parseQueryNegotiation(rawQuery string) (format string, hasIndex bool) {
+	raw := oquery.ParseRawQuery(rawQuery)
+	if _, ok := raw["$index"]; ok {
+		hasIndex = true
+	}
+
+	normalized := oquery.NormalizeQueryParams(raw)
+	if !hasIndex {
+		_, hasIndex = normalized["$index"]
+	}
+
+	return normalized.Get("$format"), hasIndex
+}
+
+// WithNegotiation computes the request's content negotiation once and returns a
+// context carrying the result. Call it at the start of request handling so that
+// the response helpers reuse the cached decision instead of re-parsing.
+func WithNegotiation(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, negotiationContextKey, computeNegotiation(r))
+}
+
+// getNegotiation returns the negotiation cached on the request context, computing
+// it on demand (without caching) when absent. The fallback keeps direct callers
+// of the exported helpers — tests and alternate entry points that never went
+// through WithNegotiation — correct.
+func getNegotiation(r *http.Request) *negotiation {
+	if n, ok := r.Context().Value(negotiationContextKey).(*negotiation); ok {
+		return n
+	}
+	return computeNegotiation(r)
+}

--- a/internal/response/negotiation_bench_test.go
+++ b/internal/response/negotiation_bench_test.go
@@ -1,0 +1,59 @@
+package response
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// benchNegotiationSequence mirrors the negotiation helper calls a single
+// collection response performs: acceptability, atom check, metadata level,
+// content type and the $index check.
+func benchNegotiationSequence(r *http.Request) {
+	_ = IsAcceptableFormat(r)
+	_ = IsAtomFormat(r)
+	_ = GetODataMetadataLevel(r)
+	_ = BuildJSONContentType(r)
+	_ = shouldAddIndexAnnotations(r)
+}
+
+// BenchmarkNegotiationFallback measures the cost when every helper recomputes
+// the negotiation from the raw query and Accept header (pre-change behavior).
+func BenchmarkNegotiationFallback(b *testing.B) {
+	req := httptest.NewRequest(http.MethodGet, "/Products?$top=100&$filter=Price%20gt%20500", nil)
+	req.Header.Set("Accept", "application/json")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchNegotiationSequence(req)
+	}
+}
+
+// BenchmarkNegotiationCached measures the cost when the negotiation is computed
+// once at the entry point and cached on the request context (post-change).
+func BenchmarkNegotiationCached(b *testing.B) {
+	req := httptest.NewRequest(http.MethodGet, "/Products?$top=100&$filter=Price%20gt%20500", nil)
+	req.Header.Set("Accept", "application/json")
+	req = req.WithContext(WithNegotiation(req.Context(), req))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchNegotiationSequence(req)
+	}
+}
+
+// BenchmarkNegotiationCachedWithInjection includes the one-time WithNegotiation
+// cost per request, giving the true per-request comparison against the fallback.
+func BenchmarkNegotiationCachedWithInjection(b *testing.B) {
+	req := httptest.NewRequest(http.MethodGet, "/Products?$top=100&$filter=Price%20gt%20500", nil)
+	req.Header.Set("Accept", "application/json")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cr := req.WithContext(WithNegotiation(req.Context(), req))
+		benchNegotiationSequence(cr)
+	}
+}

--- a/internal/response/negotiation_test.go
+++ b/internal/response/negotiation_test.go
@@ -1,0 +1,80 @@
+package response
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNegotiationCacheMatchesFallback verifies that the negotiation cached on the
+// request context produces exactly the same results as computing it on demand,
+// so injecting it at the entry point never changes observable behavior.
+func TestNegotiationCacheMatchesFallback(t *testing.T) {
+	cases := []struct {
+		name   string
+		rawURL string
+		accept string
+	}{
+		{"plain json", "/Products?$top=100", "application/json"},
+		{"metadata full via accept", "/Products", "application/json;odata.metadata=full"},
+		{"metadata none via format", "/Products?$format=application/json;odata.metadata=none", ""},
+		{"ieee754 via accept", "/Products", "application/json;IEEE754Compatible=true"},
+		{"atom via format", "/Products?$format=atom", ""},
+		{"atom via accept", "/Products", "application/atom+xml"},
+		{"xml unacceptable", "/Products", "application/xml"},
+		{"index present", "/Products?$index=true", "application/json"},
+		{"no accept no format", "/Products", ""},
+		{"invalid metadata", "/Products?$format=application/json;odata.metadata=bogus", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fallback path: no negotiation on the context.
+			plain := httptest.NewRequest(http.MethodGet, tc.rawURL, nil)
+			if tc.accept != "" {
+				plain.Header.Set("Accept", tc.accept)
+			}
+
+			// Cached path: negotiation injected on the context.
+			cached := httptest.NewRequest(http.MethodGet, tc.rawURL, nil)
+			if tc.accept != "" {
+				cached.Header.Set("Accept", tc.accept)
+			}
+			cached = cached.WithContext(WithNegotiation(cached.Context(), cached))
+
+			assertSame := func(label string, a, b any) {
+				t.Helper()
+				if a != b {
+					t.Errorf("%s: cached=%v fallback=%v", label, a, b)
+				}
+			}
+
+			assertSame("metadataLevel", GetODataMetadataLevel(cached), GetODataMetadataLevel(plain))
+			assertSame("isAtom", IsAtomFormat(cached), IsAtomFormat(plain))
+			assertSame("acceptable", IsAcceptableFormat(cached), IsAcceptableFormat(plain))
+			assertSame("ieee754", GetIEEE754Compatible(cached), GetIEEE754Compatible(plain))
+			assertSame("contentType", BuildJSONContentType(cached), BuildJSONContentType(plain))
+			assertSame("index", shouldAddIndexAnnotations(cached), shouldAddIndexAnnotations(plain))
+
+			cachedErr := ValidateODataMetadata(cached)
+			plainErr := ValidateODataMetadata(plain)
+			if (cachedErr == nil) != (plainErr == nil) {
+				t.Errorf("metadataErr mismatch: cached=%v fallback=%v", cachedErr, plainErr)
+			}
+		})
+	}
+}
+
+// TestNegotiationComputedOnce verifies that once a negotiation is cached on the
+// context, repeated helper calls reuse the same instance rather than recomputing.
+func TestNegotiationComputedOnce(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/Products?$top=100", nil)
+	req.Header.Set("Accept", "application/json")
+	req = req.WithContext(WithNegotiation(req.Context(), req))
+
+	first := getNegotiation(req)
+	second := getNegotiation(req)
+	if first != second {
+		t.Fatalf("expected the cached negotiation to be reused, got distinct instances")
+	}
+}


### PR DESCRIPTION
## Summary

Content negotiation (metadata level, `$format` acceptability, the Atom/JSON
decision, `IEEE754Compatible`, and the presence of `$index`) derives entirely
from the request's `$format` query parameter and `Accept` header — both
immutable for the lifetime of a request. Yet the response layer re-derived them
on every helper call, and each derivation re-parsed the raw query string via
`getFormatParameter` → `ParseRawQuery` + `NormalizeQueryParams` (two `url.Values`
allocations plus percent-decoding).

A single `GET` collection response funnels through this 4–8 times:
`ValidateODataMetadata` (entry), then `IsAcceptableFormat`, `IsAtomFormat`,
`GetODataMetadataLevel`, `BuildJSONContentType`, and `shouldAddIndexAnnotations`
(which parsed the query *twice* on its own). This showed up in the PostgreSQL
load-test allocation profile as `NormalizeQueryParams` being one of the larger
single sources of allocation churn on the hot read path.

This PR computes the negotiation **once per request** and caches it on the
request context, following the existing `BasePathContextKey` pattern. The
exported helpers now read the cached decision, with a compute-on-demand fallback
so direct callers (tests, alternate entry points that never went through the
runtime) stay correct.

## Changes

- New `internal/response/negotiation.go`: a `negotiation` struct plus
  `WithNegotiation` (compute + cache) and `getNegotiation` (read cache, else
  compute). The raw query string is parsed exactly once to derive both `$format`
  and `$index`.
- `ValidateODataMetadata`, `GetODataMetadataLevel`, `GetIEEE754Compatible`,
  `IsAcceptableFormat`, `IsAtomFormat`, `BuildJSONContentType` and
  `shouldAddIndexAnnotations` now read the cached negotiation. Their parsing
  logic was refactored into shared `(format, accept)`-taking helpers with no
  behavior change.
- `http_runtime.go` injects the negotiation once, right after base-path handling.
- Removed the now-redundant `getFormatParameter` and `hasIndexParam` helpers.

No public API signatures change; `WithNegotiation` is the only new exported
symbol. Behavior is unchanged — a table test asserts the cached and fallback
paths produce identical results across format/Accept/metadata/atom/index cases.

## Measured impact

**Microbenchmark** (`BenchmarkNegotiation*`, the helper sequence one response
performs, `-count=6`, deterministic):

| | ns/op | allocs/op | B/op |
|---|---|---|---|
| recompute every call (old behavior) | 5277 | 107 | 5749 |
| compute once + cached reads (this PR) | 1257 | 24 | 1249 |
| cached reads only | 122 | 2 | 64 |

~76% less time and ~78% fewer allocations in the negotiation portion of each
request.

**Server-side, PostgreSQL, identical fixed 200k-request workload**
(`/Products?$filter=Price gt 500&$top=100`, cumulative `alloc_space`): total
allocations dropped **24.17 GB → 23.20 GB (−4.0%, ~4.8 KB/request)**, and the
raw-query-parsing hot spots fell sharply —

| symbol | before | after |
|---|---|---|
| `query.NormalizeQueryParams` | 590 MB | 248 MB (−58%) |
| `query.ParseRawQuery` | 538 MB | 178 MB (−67%) |
| `getFormatParameter` (aggregate) | 706 MB | removed — all negotiation parsing now sums to ~178 MB in `computeNegotiation` |

End-to-end throughput on a fully CPU-saturated 16-thread test box moved within
run-to-run noise (the bottleneck there is the DB round-trip, row serialization,
and shared-core contention, not negotiation) — no regressions across the load
suite. The value is the reduced allocation/GC pressure, which matters most under
sustained load and on core-constrained deployments.

## Testing

- `go test ./...` — all packages pass
- `gofmt`, `go vet`, `golangci-lint` — clean
- New `TestNegotiationCacheMatchesFallback` / `TestNegotiationComputedOnce`


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
