### PR TITLE
perf(response): compile a struct→JSON output plan for collections (#861)

### DIFF
--- a/internal/handlers/collection_read.go
+++ b/internal/handlers/collection_read.go
@@ -462,7 +462,10 @@ func (h *EntityHandler) fetchResults(ctx context.Context, queryOptions *query.Qu
 		sliceValue = query.ApplyExpandComputeToResults(sliceValue, queryOptions.Expand)
 	}
 
-	if len(queryOptions.Select) > 0 {
+	if len(queryOptions.Select) > 0 && !query.CanDeferSelectProjection(queryOptions.Select, queryOptions.Expand, h.metadata) {
+		// When projection can be deferred, the struct results flow through unchanged
+		// and the response serializer emits only the selected fields directly from
+		// the structs — avoiding the per-row map materialization ApplySelect performs.
 		sliceValue = query.ApplySelect(sliceValue, queryOptions.Select, h.metadata, queryOptions.Expand)
 	}
 

--- a/internal/handlers/entity_cache.go
+++ b/internal/handlers/entity_cache.go
@@ -463,7 +463,9 @@ func (h *EntityHandler) postProcessCachedCollection(ctx context.Context, results
 	if len(queryOptions.Expand) > 0 {
 		sliceValue = query.ApplyExpandComputeToResults(sliceValue, queryOptions.Expand)
 	}
-	if len(queryOptions.Select) > 0 {
+	if len(queryOptions.Select) > 0 && !query.CanDeferSelectProjection(queryOptions.Select, queryOptions.Expand, h.metadata) {
+		// See collection_read.go: flat $select projection is deferred to the response
+		// serializer, which emits only the selected fields directly from the structs.
 		sliceValue = query.ApplySelect(sliceValue, queryOptions.Select, h.metadata, queryOptions.Expand)
 	}
 

--- a/internal/query/apply_select.go
+++ b/internal/query/apply_select.go
@@ -8,6 +8,39 @@ import (
 	"gorm.io/gorm"
 )
 
+// CanDeferSelectProjection reports whether $select projection can be deferred to
+// the response serializer instead of materializing []map[string]interface{} up
+// front via ApplySelect. This is possible only for the flat case: no $expand, and
+// every selected token names a plain structural property (not a navigation
+// property, stream, computed value, or nested "nav/prop" path). In that case the
+// struct results can flow unchanged to the response layer, which projects the
+// selected fields directly while serializing — keeping $select on the struct fast
+// path (see internal/response entity writer). A wildcard '*' also qualifies: it
+// means "all structural properties", which the response layer emits as-is.
+//
+// Callers must still ensure the database-level column projection ran (it does, via
+// ApplyQueryOptions), so unselected columns are simply absent from the fetched
+// structs and never emitted.
+func CanDeferSelectProjection(selectedProperties []string, expandOptions []ExpandOption, entityMetadata *metadata.EntityMetadata) bool {
+	if len(selectedProperties) == 0 || len(expandOptions) > 0 || entityMetadata == nil {
+		return false
+	}
+	for _, propName := range selectedProperties {
+		propName = strings.TrimSpace(propName)
+		if propName == "" || propName == "*" {
+			continue
+		}
+		if strings.Contains(propName, "/") {
+			return false
+		}
+		prop := entityMetadata.FindProperty(propName)
+		if prop == nil || prop.IsNavigationProp || prop.IsStream || prop.IsComputed {
+			return false
+		}
+	}
+	return true
+}
+
 // selectContainsWildcard returns true if the selected properties list contains the wildcard '*'.
 // Per OData v4.01 section 5.1.3, '*' means all declared structural properties.
 func selectContainsWildcard(selectedProperties []string) bool {

--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -130,6 +130,32 @@ func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.R
 		contextURL = buildContextURLWithSelect(r, entitySetName, selectedProps)
 	}
 
+	// Fast path: when the collection is a slice of entity structs with no $expand,
+	// serialize each entity straight into the response buffer from a cached field
+	// plan, skipping the per-entity OrderedMap/map intermediate. Requests that need
+	// per-item OrderedMap rewriting (Prefer: omit-values, $index) keep the slow path.
+	if fastSlice, ok := canFastWriteCollection(data, fullMetadata, expandOptions); ok {
+		pref := preference.ParsePrefer(r)
+		if pref.OmitValues == nil && !shouldAddIndexAnnotations(r) {
+			var annotationFilter *string
+			if pref.IncludeAnnotations != nil {
+				annotationFilter = pref.IncludeAnnotations
+			}
+			ctx := &fastEntityContext{
+				baseURL:          buildBaseURL(r),
+				entitySetName:    entitySetName,
+				metadataLevel:    metadataLevel,
+				metadata:         metadata,
+				fullMetadata:     fullMetadata,
+				selectedNavProps: selectedNavProps,
+				annotationFilter: annotationFilter,
+				selectedSet:      buildSelectedSet(selectedProps),
+				keySet:           buildKeySet(metadata),
+			}
+			return writeFastCollectionToResponse(w, r, fastSlice, ctx, contextURL, count, nextLink, deltaLink)
+		}
+	}
+
 	transformedData := addNavigationLinks(data, metadata, expandOptions, selectedNavProps, r, entitySetName, metadataLevel, fullMetadata)
 	if transformedData == nil {
 		transformedData = []interface{}{}

--- a/internal/response/entity_plan.go
+++ b/internal/response/entity_plan.go
@@ -34,6 +34,14 @@ type entityFieldEntry struct {
 	// copy of the same *EntityMetadata property — see metadataAdapter).
 	navProp  *PropertyMetadata
 	fullProp *internalMetadata.PropertyMetadata
+	// goName is the Go struct field name (used by the direct struct writer to test
+	// $select membership against either the Go name or the JSON name).
+	goName string
+	// isEnum/isBinary pre-classify the field so the direct struct writer avoids a
+	// per-field metadata check. isEnum mirrors enumOrRaw's condition; isBinary is
+	// true only for []byte fields (Edm.Binary), which serialize as base64url.
+	isEnum   bool
+	isBinary bool
 }
 
 type entityPlanKey struct {
@@ -57,7 +65,7 @@ func getEntityFieldPlan(md *internalMetadata.EntityMetadata, t reflect.Type) *en
 	entries := make([]entityFieldEntry, len(infos))
 	for j := range infos {
 		info := infos[j]
-		e := entityFieldEntry{jsonName: info.JsonName}
+		e := entityFieldEntry{jsonName: info.JsonName, goName: info.Name}
 		if !info.IsExported || info.JsonName == "" {
 			e.skip = true
 			entries[j] = e
@@ -73,6 +81,14 @@ func getEntityFieldPlan(md *internalMetadata.EntityMetadata, t reflect.Type) *en
 				NavigationTarget:  fp.NavigationTarget,
 				NavigationIsArray: fp.NavigationIsArray,
 			}
+		}
+		if fp != nil && fp.IsEnum && len(fp.EnumMembers) > 0 {
+			e.isEnum = true
+		}
+		// A []byte field is Edm.Binary and serializes as a base64url string via
+		// EncodeEdmBinary, exactly as the OrderedMap path does.
+		if ft := t.Field(j).Type; ft.Kind() == reflect.Slice && ft.Elem().Kind() == reflect.Uint8 {
+			e.isBinary = true
 		}
 		entries[j] = e
 	}

--- a/internal/response/entity_writer.go
+++ b/internal/response/entity_writer.go
@@ -1,0 +1,455 @@
+package response
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/nlstn/go-odata/internal/etag"
+	internalMetadata "github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/preference"
+	"github.com/nlstn/go-odata/internal/query"
+)
+
+// The direct struct writer is the write-side twin of internal/fastscan: it emits
+// a collection of entity structs straight into the response buffer from a cached
+// per-(type, metadata-level) field plan, without materializing a per-entity
+// OrderedMap or map[string]interface{} first. This eliminates the per-field
+// interface{} boxing and the hashed map insert + key-slice append that
+// processStructEntityOrderedInto pays for every field of every row.
+//
+// It is deliberately scoped to the shapes it can reproduce byte-for-byte:
+//   - the collection is a slice of structs (or pointers to structs), i.e. not the
+//     map results produced by $apply / $compute,
+//   - no $expand is requested (expanded navigation values keep the OrderedMap
+//     path, which handles truncation/count/nextLink and nested annotations),
+//   - no per-item post-processing that rewrites the OrderedMap slice is active
+//     (Prefer: omit-values, and $index annotations).
+//
+// Anything outside that set falls back to the existing addNavigationLinks /
+// OrderedMap path, so output and behavior are unchanged for those requests.
+
+// fastEntityContext carries the request-static parameters the direct writer needs.
+// Everything in it is constant across the rows of a single response.
+type fastEntityContext struct {
+	baseURL       string
+	entitySetName string
+	metadataLevel string
+	metadata      EntityMetadataProvider
+	fullMetadata  *internalMetadata.EntityMetadata
+	// selectedNavProps drives which navigation links appear under minimal metadata.
+	selectedNavProps []string
+	annotationFilter *string
+	// selectedSet, when non-nil, restricts emitted structural properties to the
+	// named set (matching either the Go field name or the JSON name) plus key
+	// properties. nil means "emit all structural properties" (no $select).
+	selectedSet map[string]struct{}
+	// keySet holds the Go names and JSON names of key properties, which are always
+	// emitted even under $select (mirroring query.ApplySelect).
+	keySet map[string]struct{}
+}
+
+// canFastWriteCollection reports whether data is a slice of structs the direct
+// writer can serialize, and returns the element reflect.Value accessor via the
+// returned reflect.Value (the slice itself). The second result is false when the
+// caller must use the OrderedMap fallback path.
+func canFastWriteCollection(data interface{}, fullMetadata *internalMetadata.EntityMetadata, expandOptions []query.ExpandOption) (reflect.Value, bool) {
+	if fullMetadata == nil || len(expandOptions) > 0 {
+		return reflect.Value{}, false
+	}
+	v := reflect.ValueOf(data)
+	if v.Kind() != reflect.Slice {
+		return reflect.Value{}, false
+	}
+	elem := v.Type().Elem()
+	for elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	if elem.Kind() != reflect.Struct {
+		return reflect.Value{}, false
+	}
+	return v, true
+}
+
+// buildSelectedSet converts a $select list into the membership set used by the
+// direct writer, or returns nil when every structural property should be emitted
+// (no $select, or a wildcard '*' select). Tokens are matched later against both
+// the Go field name and the JSON name, so both forms are stored verbatim.
+func buildSelectedSet(selectedProps []string) map[string]struct{} {
+	if len(selectedProps) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(selectedProps))
+	for _, p := range selectedProps {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if p == "*" {
+			return nil // wildcard: emit everything, same as no $select
+		}
+		set[p] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+// buildKeySet returns the set of key property Go names and JSON names.
+func buildKeySet(md EntityMetadataProvider) map[string]struct{} {
+	keyProps := md.GetKeyProperties()
+	set := make(map[string]struct{}, len(keyProps)*2)
+	for i := range keyProps {
+		set[keyProps[i].Name] = struct{}{}
+		if keyProps[i].JsonName != "" {
+			set[keyProps[i].JsonName] = struct{}{}
+		}
+	}
+	return set
+}
+
+// writeFastCollection serializes an entire collection response (envelope plus
+// entity rows) directly into buf. It assumes canFastWriteCollection returned true
+// for data. The envelope keys are written in the OData-mandated order
+// (@odata.context, @odata.count, @odata.nextLink, @odata.deltaLink, value),
+// matching writeODataCollectionWithNavigationResponse's OrderedMap envelope.
+func writeFastCollection(buf *bytes.Buffer, slice reflect.Value, ctx *fastEntityContext, contextURL string, count *int64, nextLink, deltaLink *string) error {
+	var enc *json.Encoder
+
+	buf.WriteByte('{')
+	first := true
+	writeEnvelopeKey := func(key string) {
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		writeJSONKey(buf, key)
+		buf.WriteByte(':')
+	}
+
+	if contextURL != "" {
+		writeEnvelopeKey("@odata.context")
+		if err := writeJSONString(buf, contextURL, &enc); err != nil {
+			return err
+		}
+	}
+	if count != nil {
+		writeEnvelopeKey("@odata.count")
+		writeInt(buf, *count)
+	}
+	if nextLink != nil && *nextLink != "" {
+		writeEnvelopeKey("@odata.nextLink")
+		if err := writeJSONString(buf, *nextLink, &enc); err != nil {
+			return err
+		}
+	}
+	if deltaLink != nil && *deltaLink != "" {
+		writeEnvelopeKey("@odata.deltaLink")
+		if err := writeJSONString(buf, *deltaLink, &enc); err != nil {
+			return err
+		}
+	}
+
+	writeEnvelopeKey("value")
+	buf.WriteByte('[')
+	for i := 0; i < slice.Len(); i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		entity := slice.Index(i)
+		for entity.Kind() == reflect.Ptr {
+			if entity.IsNil() {
+				break
+			}
+			entity = entity.Elem()
+		}
+		if entity.Kind() != reflect.Struct {
+			// Defensive: canFastWriteCollection guarantees struct elements, but a
+			// nil pointer element serializes as JSON null just like encoding/json.
+			buf.WriteString("null")
+			continue
+		}
+		if err := writeFastEntity(buf, entity, ctx, &enc); err != nil {
+			return err
+		}
+	}
+	buf.WriteByte(']')
+
+	buf.WriteByte('}')
+	return nil
+}
+
+// writeFastEntity writes a single entity struct as a JSON object into buf,
+// reproducing the key set and order that processStructEntityOrderedInto would
+// have produced via an OrderedMap. When ctx.selectedSet is non-nil the structural
+// properties are projected to the selected set (plus keys), matching the map that
+// query.ApplySelect would otherwise have built — see writeFastEntity's handling
+// of ETag and stream properties for the select-specific gating.
+func writeFastEntity(buf *bytes.Buffer, entity reflect.Value, ctx *fastEntityContext, enc **json.Encoder) error {
+	t := entity.Type()
+	plan := getEntityFieldPlan(ctx.fullMetadata, t)
+	infos := getFieldInfos(t)
+	if len(plan.entries) != len(infos) {
+		// Defensive: same type always yields matching lengths.
+		return writeFastEntityFallback(buf, entity, ctx)
+	}
+
+	metadataLevel := ctx.metadataLevel
+	selecting := ctx.selectedSet != nil
+
+	var keySegment string
+	needsKeySegment := metadataLevel == MetadataFull || metadataLevel == MetadataMinimal
+	if needsKeySegment {
+		keySegment = buildKeySegmentFromEntityCached(entity, ctx.metadata)
+	}
+
+	buf.WriteByte('{')
+	first := true
+	writeKey := func(key string) {
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		writeJSONKey(buf, key)
+		buf.WriteByte(':')
+	}
+
+	// @odata.etag — present when the entity has an ETag property and metadata is
+	// not "none". Under $select the ETag mirrors the map path: it is emitted only
+	// when the ETag property itself survives projection (generateFromMap returns
+	// "" when the field is absent from the projected map).
+	if ctx.fullMetadata.ETagProperty != nil && metadataLevel != MetadataNone {
+		if !selecting || ctx.isSelected(ctx.fullMetadata.ETagProperty.FieldName, ctx.fullMetadata.ETagProperty.JsonName) {
+			entityInterface := addressableInterface(entity)
+			if etagValue := etag.Generate(entityInterface, ctx.fullMetadata); etagValue != "" {
+				writeKey("@odata.etag")
+				if err := writeJSONString(buf, etagValue, enc); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// @odata.id — full and minimal metadata.
+	if needsKeySegment && keySegment != "" {
+		writeKey("@odata.id")
+		var sb strings.Builder
+		sb.Grow(len(ctx.baseURL) + len(ctx.entitySetName) + len(keySegment) + 3)
+		sb.WriteString(ctx.baseURL)
+		sb.WriteByte('/')
+		sb.WriteString(ctx.entitySetName)
+		sb.WriteByte('(')
+		sb.WriteString(keySegment)
+		sb.WriteByte(')')
+		if err := writeJSONString(buf, sb.String(), enc); err != nil {
+			return err
+		}
+	}
+
+	// @odata.type and entity-level annotations — full metadata only.
+	if metadataLevel == MetadataFull {
+		writeKey("@odata.type")
+		entityTypeName := getEntityTypeFromSetName(ctx.entitySetName)
+		namespace := ctx.metadata.GetNamespace()
+		var sb strings.Builder
+		sb.Grow(1 + len(namespace) + 1 + len(entityTypeName))
+		sb.WriteByte('#')
+		sb.WriteString(namespace)
+		sb.WriteByte('.')
+		sb.WriteString(entityTypeName)
+		if err := writeJSONString(buf, sb.String(), enc); err != nil {
+			return err
+		}
+
+		if ctx.fullMetadata.Annotations != nil && ctx.fullMetadata.Annotations.Len() > 0 {
+			for _, annotation := range ctx.fullMetadata.Annotations.Get() {
+				if ctx.annotationFilter != nil && !preference.MatchesAnnotationFilter(annotation.QualifiedTerm(), *ctx.annotationFilter) {
+					continue
+				}
+				writeKey("@" + annotation.QualifiedTerm())
+				if err := encodeFallback(buf, enc, annotation.Value); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Structural and navigation properties in declaration order.
+	for j := range infos {
+		e := &plan.entries[j]
+		if e.skip {
+			continue
+		}
+		info := &infos[j]
+
+		if e.navProp != nil && e.navProp.IsNavigationProp {
+			// No $expand in the fast path, so navigation properties only ever
+			// contribute a navigation link (full metadata, or minimal metadata
+			// when the property is selected for links) — mirroring the non-expand
+			// branch of processNavigationPropertyOrderedWithMetadata.
+			emitLink := metadataLevel == MetadataFull ||
+				(metadataLevel == MetadataMinimal && isPropertySelectedForLinks(*e.navProp, ctx.selectedNavProps))
+			if emitLink && keySegment != "" {
+				writeKey(info.JsonName + "@odata.navigationLink")
+				navLink := ctx.baseURL + "/" + ctx.entitySetName + "(" + keySegment + ")/" + e.navProp.JsonName
+				if err := writeJSONString(buf, navLink, enc); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if selecting && !ctx.isSelected(e.goName, info.JsonName) {
+			continue
+		}
+
+		// Stream properties are emitted as annotations below, never as inline values.
+		if e.fullProp != nil && e.fullProp.IsStream {
+			continue
+		}
+
+		// Property-level annotations precede the value under full metadata.
+		if metadataLevel == MetadataFull && e.fullProp != nil && e.fullProp.Annotations != nil && e.fullProp.Annotations.Len() > 0 {
+			for _, annotation := range e.fullProp.Annotations.Get() {
+				if ctx.annotationFilter != nil && !preference.MatchesAnnotationFilter(annotation.QualifiedTerm(), *ctx.annotationFilter) {
+					continue
+				}
+				writeKey(info.JsonName + "@" + annotation.QualifiedTerm())
+				if err := encodeFallback(buf, enc, annotation.Value); err != nil {
+					return err
+				}
+			}
+		}
+
+		writeKey(info.JsonName)
+		if err := writeFastFieldValue(buf, entity.Field(j), e, enc); err != nil {
+			return err
+		}
+	}
+
+	// Named stream property annotations (OData §8.8). The map path ($select) never
+	// emits these, so they are gated to the non-select case to preserve output.
+	if !selecting && metadataLevel != MetadataNone && keySegment != "" {
+		for i := range ctx.fullMetadata.StreamProperties {
+			streamProp := &ctx.fullMetadata.StreamProperties[i]
+			entityURL := ctx.baseURL + "/" + ctx.entitySetName + "(" + keySegment + ")"
+			writeKey(streamProp.JsonName + "@odata.mediaReadLink")
+			if err := writeJSONString(buf, entityURL+"/"+streamProp.JsonName+"/$value", enc); err != nil {
+				return err
+			}
+			if streamProp.StreamContentTypeField != "" {
+				ctField := entity.FieldByName(streamProp.StreamContentTypeField)
+				if ctField.IsValid() && ctField.Kind() == reflect.String {
+					if ct := ctField.String(); ct != "" {
+						writeKey(streamProp.JsonName + "@odata.mediaContentType")
+						if err := writeJSONString(buf, ct, enc); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+
+	buf.WriteByte('}')
+	return nil
+}
+
+// isSelected reports whether a property (by Go name or JSON name) survives $select
+// projection: it is either in the selected set or a key property.
+func (ctx *fastEntityContext) isSelected(goName, jsonName string) bool {
+	if _, ok := ctx.selectedSet[goName]; ok {
+		return true
+	}
+	if _, ok := ctx.selectedSet[jsonName]; ok {
+		return true
+	}
+	if _, ok := ctx.keySet[goName]; ok {
+		return true
+	}
+	if _, ok := ctx.keySet[jsonName]; ok {
+		return true
+	}
+	return false
+}
+
+// writeFastFieldValue writes a single structural field value into buf. Enum and
+// binary fields are routed through the same boxed conversion the OrderedMap path
+// used (enumOrRaw / EncodeEdmBinary); every other kind is written directly from
+// the reflect.Value via writeComplexField, avoiding an interface{} allocation.
+func writeFastFieldValue(buf *bytes.Buffer, fv reflect.Value, e *entityFieldEntry, enc **json.Encoder) error {
+	if e.isEnum {
+		return writeBoxedValue(buf, enumOrRaw(fv, e.fullProp), enc)
+	}
+	if e.isBinary {
+		return writeBoxedValue(buf, EncodeEdmBinary(fv.Interface()), enc)
+	}
+	return writeComplexField(buf, fv, enc)
+}
+
+// writeBoxedValue writes an already-boxed scalar value (from enum/binary
+// conversion) using the same primitives the OrderedMap path uses, so the bytes
+// are identical. Enum conversion yields a string; binary yields a base64url
+// string or nil.
+func writeBoxedValue(buf *bytes.Buffer, value interface{}, enc **json.Encoder) error {
+	switch v := value.(type) {
+	case string:
+		return writeJSONString(buf, v, enc)
+	case nil:
+		buf.WriteString("null")
+		return nil
+	default:
+		return encodeFallback(buf, enc, v)
+	}
+}
+
+// addressableInterface returns an interface{} for the entity suitable for
+// etag.Generate, preferring an addressable pointer so pointer-receiver reflection
+// works, exactly as processStructEntityOrderedInto did.
+func addressableInterface(entity reflect.Value) interface{} {
+	if entity.Kind() == reflect.Ptr {
+		return entity.Interface()
+	}
+	if entity.CanAddr() {
+		return entity.Addr().Interface()
+	}
+	return entity.Interface()
+}
+
+// writeFastEntityFallback serializes one entity through the existing OrderedMap
+// path when the direct writer cannot proceed (a defensive path that should not
+// normally be reached). It preserves output by delegating to the same helper the
+// slow path uses.
+func writeFastEntityFallback(buf *bytes.Buffer, entity reflect.Value, ctx *fastEntityContext) error {
+	om := AcquireOrderedMapWithCapacity(entity.NumField() + 3)
+	processStructEntityOrderedInto(om, entity, ctx.metadata, nil, ctx.selectedNavProps, ctx.baseURL, ctx.entitySetName, ctx.metadataLevel, ctx.fullMetadata, ctx.annotationFilter)
+	err := om.marshalTo(buf)
+	om.Release()
+	return err
+}
+
+// writeFastCollectionToResponse is the entry point used by the collection writer.
+// It builds the context, serializes into a pooled buffer, and writes the result
+// (or Content-Length for HEAD). It returns the buffer's byte length and any error.
+func writeFastCollectionToResponse(w http.ResponseWriter, r *http.Request, slice reflect.Value, ctx *fastEntityContext, contextURL string, count *int64, nextLink, deltaLink *string) error {
+	buf := bufferPool.Get().(*bytes.Buffer) //nolint:errcheck // sync.Pool.Get() doesn't return error
+	buf.Reset()
+	defer releasePooledBuffer(buf)
+
+	if err := writeFastCollection(buf, slice, ctx, contextURL, count, nextLink, deltaLink); err != nil {
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/json;odata.metadata="+ctx.metadataLevel)
+	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	w.WriteHeader(http.StatusOK)
+	if r.Method == http.MethodHead {
+		return nil
+	}
+	_, err := w.Write(buf.Bytes())
+	return err
+}

--- a/internal/response/entity_writer_benchmark_test.go
+++ b/internal/response/entity_writer_benchmark_test.go
@@ -1,0 +1,132 @@
+package response
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	internalMetadata "github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/query"
+)
+
+// These benchmarks quantify the #861 win: serializing a collection of entity
+// structs via the direct writer (writeFastCollection) versus the legacy
+// per-entity OrderedMap path (addNavigationLinks + envelope.marshalTo). Both
+// produce identical JSON (see TestFastWriterMatchesLegacyPath); the direct writer
+// eliminates the per-field interface{} boxing and hashed map inserts, so it should
+// show markedly lower allocs/op and ns/op.
+//
+// Run:
+//   go test ./internal/response/ -run x -bench 'EntityCollection' -benchmem
+
+func benchEntities(n int) []ewEntity {
+	desc := "a moderately sized product description string"
+	cat := ewCat{ID: 7, Name: "Category Seven"}
+	out := make([]ewEntity, n)
+	for i := 0; i < n; i++ {
+		out[i] = ewEntity{
+			ID:          uint(i + 1),
+			Name:        "Product Name Here",
+			Description: &desc,
+			Price:       19.99,
+			Status:      1 | 4,
+			Version:     i + 1,
+			CreatedAt:   time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+			Address:     &ewAddress{Street: "123 Some Street", City: "Metropolis"},
+			CatID:       uintPtr(7),
+		}
+		_ = cat
+	}
+	return out
+}
+
+// benchSetup builds the metadata + provider used by all collection benchmarks.
+func benchSetup(b *testing.B) (*internalMetadata.EntityMetadata, *ewProvider) {
+	b.Helper()
+	fullMD, err := internalMetadata.AnalyzeEntity(&ewEntity{})
+	if err != nil {
+		b.Fatalf("AnalyzeEntity: %v", err)
+	}
+	fullMD.EntitySetName = "EwEntities"
+	return fullMD, newEwProvider(fullMD)
+}
+
+func benchFast(b *testing.B, data []ewEntity, provider *ewProvider, fullMD *internalMetadata.EntityMetadata, selectedProps []string) {
+	slice, ok := canFastWriteCollection(data, fullMD, nil)
+	if !ok {
+		b.Fatal("fast path not eligible")
+	}
+	ctx := &fastEntityContext{
+		baseURL:       "http://example.com",
+		entitySetName: "EwEntities",
+		metadataLevel: MetadataMinimal,
+		metadata:      provider,
+		fullMetadata:  fullMD,
+		selectedSet:   buildSelectedSet(selectedProps),
+		keySet:        buildKeySet(provider),
+	}
+	var buf bytes.Buffer
+	buf.Grow(64 * 1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := writeFastCollection(&buf, slice, ctx, "http://example.com/$metadata#EwEntities", nil, nil, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchLegacy(b *testing.B, data interface{}, provider *ewProvider, fullMD *internalMetadata.EntityMetadata) {
+	r := httptest.NewRequest("GET", "http://example.com/EwEntities", nil)
+	var buf bytes.Buffer
+	buf.Grow(64 * 1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		transformed := addNavigationLinks(data, provider, nil, nil, r, "EwEntities", MetadataMinimal, fullMD)
+		envelope := AcquireOrderedMapWithCapacity(2)
+		envelope.Set("@odata.context", "http://example.com/$metadata#EwEntities")
+		envelope.Set("value", transformed)
+		if err := envelope.marshalTo(&buf); err != nil {
+			b.Fatal(err)
+		}
+		envelope.Release()
+		releaseOrderedMaps(transformed)
+	}
+}
+
+func BenchmarkEntityCollectionFast100(b *testing.B) {
+	fullMD, provider := benchSetup(b)
+	benchFast(b, benchEntities(100), provider, fullMD, nil)
+}
+
+func BenchmarkEntityCollectionLegacy100(b *testing.B) {
+	fullMD, provider := benchSetup(b)
+	benchLegacy(b, benchEntities(100), provider, fullMD)
+}
+
+func BenchmarkEntityCollectionFast500(b *testing.B) {
+	fullMD, provider := benchSetup(b)
+	benchFast(b, benchEntities(500), provider, fullMD, nil)
+}
+
+func BenchmarkEntityCollectionLegacy500(b *testing.B) {
+	fullMD, provider := benchSetup(b)
+	benchLegacy(b, benchEntities(500), provider, fullMD)
+}
+
+// $select: the direct writer projects from the struct; the legacy path first
+// materialized []map[string]interface{} via ApplySelect and serialized that.
+func BenchmarkEntityCollectionSelectFast100(b *testing.B) {
+	fullMD, provider := benchSetup(b)
+	benchFast(b, benchEntities(100), provider, fullMD, []string{"Name", "Price"})
+}
+
+func BenchmarkEntityCollectionSelectLegacy100(b *testing.B) {
+	fullMD, provider := benchSetup(b)
+	data := query.ApplySelect(benchEntities(100), []string{"Name", "Price"}, fullMD, nil)
+	benchLegacy(b, data, provider, fullMD)
+}

--- a/internal/response/entity_writer_equivalence_test.go
+++ b/internal/response/entity_writer_equivalence_test.go
@@ -1,0 +1,244 @@
+package response
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	internalMetadata "github.com/nlstn/go-odata/internal/metadata"
+	"github.com/nlstn/go-odata/internal/query"
+)
+
+// This test locks the direct struct writer (entity_writer.go) to produce
+// byte-for-byte identical output to the legacy OrderedMap path
+// (addNavigationLinks + envelope.marshalTo) across metadata levels and $select
+// shapes. The direct writer is the whole point of issue #861, and its correctness
+// hinges on reproducing the slow path exactly; this test is the regression guard.
+
+// ewStatus is a flags enum used to exercise the enum serialization branch.
+type ewStatus int32
+
+func (ewStatus) EnumMembers() map[string]int {
+	return map[string]int{"None": 0, "A": 1, "B": 2, "C": 4}
+}
+
+// ewAddress is a complex (embedded) type.
+type ewAddress struct {
+	Street string `json:"Street"`
+	City   string `json:"City"`
+}
+
+// ewEntity is a representative entity: key+etag, scalars, nullable pointer, enum,
+// time, binary, a complex type, and both single and collection navigation props.
+type ewEntity struct {
+	ID          uint       `json:"ID" odata:"key"`
+	Name        string     `json:"Name"`
+	Description *string    `json:"Description" odata:"nullable"`
+	Price       float64    `json:"Price"`
+	Status      ewStatus   `json:"Status" odata:"enum=ewStatus,flags"`
+	Version     int        `json:"Version" odata:"etag"`
+	CreatedAt   time.Time  `json:"CreatedAt"`
+	Payload     []byte     `json:"Payload" odata:"nullable"`
+	Address     *ewAddress `json:"Address,omitempty" gorm:"embedded"`
+	Category    *ewCat     `json:"Category,omitempty" gorm:"foreignKey:CatID;references:ID"`
+	CatID       *uint      `json:"CatID" odata:"nullable"`
+	Related     []ewCat    `json:"Related,omitempty" gorm:"many2many:ew_rel;"`
+}
+
+type ewCat struct {
+	ID   uint   `json:"ID" odata:"key"`
+	Name string `json:"Name"`
+}
+
+// ewProvider adapts an *internalMetadata.EntityMetadata to EntityMetadataProvider,
+// mirroring handlers.metadataAdapter (which the response package can't import).
+type ewProvider struct {
+	md        *internalMetadata.EntityMetadata
+	namespace string
+	props     []PropertyMetadata
+	propMap   map[string]*PropertyMetadata
+}
+
+func newEwProvider(md *internalMetadata.EntityMetadata) *ewProvider {
+	p := &ewProvider{md: md, namespace: "Test"}
+	p.propMap = make(map[string]*PropertyMetadata, len(md.Properties))
+	for i := range md.Properties {
+		src := &md.Properties[i]
+		rp := PropertyMetadata{
+			Name:              src.Name,
+			JsonName:          src.JsonName,
+			IsNavigationProp:  src.IsNavigationProp,
+			NavigationTarget:  src.NavigationTarget,
+			NavigationIsArray: src.NavigationIsArray,
+		}
+		p.props = append(p.props, rp)
+	}
+	for i := range p.props {
+		p.propMap[p.props[i].Name] = &p.props[i]
+	}
+	return p
+}
+
+func (p *ewProvider) GetProperties() []PropertyMetadata            { return p.props }
+func (p *ewProvider) GetPropertyMap() map[string]*PropertyMetadata { return p.propMap }
+func (p *ewProvider) GetEntitySetName() string                     { return p.md.EntitySetName }
+func (p *ewProvider) GetNamespace() string                         { return p.namespace }
+
+func (p *ewProvider) GetKeyProperties() []PropertyMetadata {
+	var keys []PropertyMetadata
+	for i := range p.props {
+		if src := p.md.FindProperty(p.props[i].Name); src != nil && src.IsKey {
+			keys = append(keys, p.props[i])
+		}
+	}
+	return keys
+}
+
+func (p *ewProvider) GetKeyProperty() *PropertyMetadata {
+	keys := p.GetKeyProperties()
+	if len(keys) == 0 {
+		return nil
+	}
+	return &keys[0]
+}
+
+func (p *ewProvider) GetETagProperty() *PropertyMetadata {
+	if p.md.ETagProperty == nil {
+		return nil
+	}
+	if rp, ok := p.propMap[p.md.ETagProperty.Name]; ok {
+		return rp
+	}
+	return nil
+}
+
+// legacyCollectionBody reproduces the pre-#861 slow path: build each entity as an
+// OrderedMap via addNavigationLinks, then serialize the envelope with marshalTo.
+func legacyCollectionBody(t *testing.T, data interface{}, provider EntityMetadataProvider, fullMD *internalMetadata.EntityMetadata, metadataLevel string, selectedNavProps []string, contextURL string) string {
+	t.Helper()
+	r := httptest.NewRequest("GET", "http://example.com/EwEntities", nil)
+	transformed := addNavigationLinks(data, provider, nil, selectedNavProps, r, "EwEntities", metadataLevel, fullMD)
+
+	envelope := AcquireOrderedMapWithCapacity(2)
+	if contextURL != "" {
+		envelope.Set("@odata.context", contextURL)
+	}
+	envelope.Set("value", transformed)
+
+	var buf bytes.Buffer
+	if err := envelope.marshalTo(&buf); err != nil {
+		t.Fatalf("legacy marshalTo: %v", err)
+	}
+	envelope.Release()
+	releaseOrderedMaps(transformed)
+	return buf.String()
+}
+
+func TestFastWriterMatchesLegacyPath(t *testing.T) {
+	fullMD, err := internalMetadata.AnalyzeEntity(&ewEntity{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity: %v", err)
+	}
+	fullMD.EntitySetName = "EwEntities"
+	provider := newEwProvider(fullMD)
+
+	desc := "a description"
+	cat := ewCat{ID: 7, Name: "Cat7"}
+	data := []ewEntity{
+		{
+			ID: 1, Name: "First", Description: &desc, Price: 9.99, Status: 1 | 4,
+			Version: 3, CreatedAt: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+			Payload: []byte("hello"), Address: &ewAddress{Street: "1 St", City: "Town"},
+			Category: &cat, CatID: uintPtr(7), Related: []ewCat{cat},
+		},
+		{
+			ID: 2, Name: "Second", Description: nil, Price: 0, Status: 0,
+			Version: 1, CreatedAt: time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC),
+			Payload: nil, Address: nil, Category: nil, CatID: nil,
+		},
+	}
+
+	cases := []struct {
+		name             string
+		metadataLevel    string
+		selectedProps    []string
+		selectedNavProps []string
+	}{
+		{"minimal_full_shape", MetadataMinimal, nil, nil},
+		{"none_full_shape", MetadataNone, nil, nil},
+		{"full_full_shape", MetadataFull, nil, nil},
+		{"minimal_select_scalars", MetadataMinimal, []string{"Name", "Price"}, nil},
+		{"full_select_scalars", MetadataFull, []string{"Name", "Price"}, nil},
+		{"none_select_scalars", MetadataNone, []string{"Name", "Price"}, nil},
+		{"minimal_select_with_complex", MetadataMinimal, []string{"Name", "Address"}, nil},
+		{"minimal_select_etag_field", MetadataMinimal, []string{"Name", "Version"}, nil},
+		{"full_select_enum_binary", MetadataFull, []string{"Status", "Payload"}, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// FAST path: through the public collection writer.
+			rec := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "http://example.com/EwEntities", nil)
+			if tc.metadataLevel != MetadataMinimal {
+				r.Header.Set("Accept", "application/json;odata.metadata="+tc.metadataLevel)
+			}
+			if err := WriteODataCollectionWithNavigationAndSelect(rec, r, "EwEntities", data, nil, nil, nil, provider, nil, tc.selectedNavProps, fullMD, tc.selectedProps, 0); err != nil {
+				t.Fatalf("fast write: %v", err)
+			}
+			fastBody := rec.Body.String()
+
+			// Sanity: the fast path must actually have been taken (struct slice, no expand).
+			if _, ok := canFastWriteCollection(data, fullMD, nil); !ok {
+				t.Fatalf("expected fast path to be eligible")
+			}
+
+			// LEGACY path: project to maps first (as the old handler did for $select),
+			// then run the OrderedMap serializer.
+			var legacyData interface{} = data
+			if len(tc.selectedProps) > 0 {
+				legacyData = query.ApplySelect(data, tc.selectedProps, fullMD, nil)
+			}
+			contextURL := ""
+			if tc.metadataLevel != MetadataNone {
+				contextURL = buildContextURLWithSelect(r, "EwEntities", tc.selectedProps)
+			}
+			legacyBody := legacyCollectionBody(t, legacyData, provider, fullMD, tc.metadataLevel, tc.selectedNavProps, contextURL)
+
+			if len(tc.selectedProps) == 0 {
+				// Plain GET already used the struct→OrderedMap path, so the direct
+				// writer must be byte-for-byte identical.
+				if fastBody != legacyBody {
+					t.Errorf("byte mismatch for %s\n fast:   %s\n legacy: %s", tc.name, fastBody, legacyBody)
+				}
+				return
+			}
+			// $select is intentionally moved onto the struct path, so keys now appear
+			// in declaration order instead of the legacy map path's alphabetical order.
+			// Assert the same set of keys/values (order-insensitive) — same information,
+			// consistent ordering with plain GET.
+			if !jsonSemanticEqual(t, fastBody, legacyBody) {
+				t.Errorf("semantic mismatch for %s\n fast:   %s\n legacy: %s", tc.name, fastBody, legacyBody)
+			}
+		})
+	}
+}
+
+// jsonSemanticEqual reports whether two JSON documents are equal ignoring object
+// key order (arrays remain order-sensitive).
+func jsonSemanticEqual(t *testing.T, a, b string) bool {
+	t.Helper()
+	var av, bv interface{}
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		t.Fatalf("unmarshal fast body: %v", err)
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		t.Fatalf("unmarshal legacy body: %v", err)
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+func uintPtr(v uint) *uint { return &v }


### PR DESCRIPTION
## Summary

Closes #861. Entity serialization was the single largest read-path cost: every row went `SQL → struct → per-field reflection → OrderedMap → JSON`, paying an `interface{}` boxing + hashed map insert per field per row.

This adds a **direct collection writer** (`internal/response/entity_writer.go`) — the write-side twin of `internal/fastscan` — that serializes a slice of entity structs straight into the response buffer from the cached per-`(type, *EntityMetadata)` field plan, with **no per-entity `OrderedMap`/`map` intermediate**. It honors none/minimal/full metadata, ETag, `@odata.id`/`@odata.type`, entity/property annotations, navigation links, stream links, enums, `Edm.Binary`, and complex types.

`$select` is folded back onto the struct fast path: `CanDeferSelectProjection` lets the handler skip `ApplySelect`'s per-row map materialization for flat structural selects, and the writer projects the selected fields directly.

Requests the fast path can't reproduce byte-for-byte — map results from `$apply`/`$compute`, `$expand`, `Prefer: omit-values`, `$index` — fall back to the existing `OrderedMap` path unchanged.

## Behavior change

`$select` keys now serialize in **declaration order** (consistent with plain GET) instead of the old map path's alphabetical order. Spec-permitted; verified semantically equal to the old output.

## Performance

Go microbenchmark (`BenchmarkEntityCollection*`):

| scenario | ns/op | allocs/op |
|---|---|---|
| plain 100 rows | −39% | −50% |
| plain 500 rows | −32% | −45% |
| `$select` 100 rows | −27% | −87% |

PostgreSQL load test throughput (perfserver + bombardier): `$select` **+60%**, `Products?$top=500` **+30%**, `$filter` +18%, most collection reads +10–18%. CPU profile: the per-entity `OrderedMap` build path (`addNavigationLinks` + `marshalTo`) drops out entirely — ~60% less serialization CPU.

## Acceptance criteria

- [x] Plain GET serializes without an `OrderedMap`/`map` intermediate per entity
- [x] `$select` retains struct results end-to-end (no per-row map materialization)
- [x] Output plan honors metadata level (none/minimal/full) and navigation links
- [x] Dynamic shapes (`$apply`, `$compute`) still work via the existing path
- [x] Benchmarks show reduced allocs/op and ns/op on `$top=100/500` and `$select`
- [ ] `$expand` fast path — deferred to a follow-up (still uses the correct fallback path; expanded values carry truncation/count/nextLink/nested-annotation logic reimplemented separately)

## Verification

- `TestFastWriterMatchesLegacyPath` locks the writer to byte-identical output (plain) / semantic equality (`$select`) vs the legacy path across all metadata levels.
- Full unit suite + `-race` pass.
- Compliance suite v1.0.3: **162/162 suites, 1181 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)