### PR TITLE
perf(response): extend the struct output plan to $expand (#861)

### DIFF
--- a/internal/response/collection.go
+++ b/internal/response/collection.go
@@ -130,11 +130,12 @@ func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.R
 		contextURL = buildContextURLWithSelect(r, entitySetName, selectedProps)
 	}
 
-	// Fast path: when the collection is a slice of entity structs with no $expand,
-	// serialize each entity straight into the response buffer from a cached field
-	// plan, skipping the per-entity OrderedMap/map intermediate. Requests that need
-	// per-item OrderedMap rewriting (Prefer: omit-values, $index) keep the slow path.
-	if fastSlice, ok := canFastWriteCollection(data, fullMetadata, expandOptions); ok {
+	// Fast path: when the collection is a slice of entity structs, serialize each
+	// entity straight into the response buffer from a cached field plan, skipping
+	// the per-entity OrderedMap/map intermediate. Expanded navigation properties are
+	// handled inline. Requests that need per-item OrderedMap rewriting (Prefer:
+	// omit-values, $index) keep the slow path.
+	if fastSlice, ok := canFastWriteCollection(data, fullMetadata); ok {
 		pref := preference.ParsePrefer(r)
 		if pref.OmitValues == nil && !shouldAddIndexAnnotations(r) {
 			var annotationFilter *string
@@ -148,6 +149,7 @@ func writeODataCollectionWithNavigationResponse(w http.ResponseWriter, r *http.R
 				metadata:         metadata,
 				fullMetadata:     fullMetadata,
 				selectedNavProps: selectedNavProps,
+				expandOptions:    expandOptions,
 				annotationFilter: annotationFilter,
 				selectedSet:      buildSelectedSet(selectedProps),
 				keySet:           buildKeySet(metadata),

--- a/internal/response/entity_writer.go
+++ b/internal/response/entity_writer.go
@@ -42,6 +42,10 @@ type fastEntityContext struct {
 	fullMetadata  *internalMetadata.EntityMetadata
 	// selectedNavProps drives which navigation links appear under minimal metadata.
 	selectedNavProps []string
+	// expandOptions holds the $expand tree. Expanded navigation properties emit
+	// their (possibly nested-transformed) value plus @odata.count/@odata.nextLink;
+	// unexpanded ones fall back to navigation-link behavior.
+	expandOptions    []query.ExpandOption
 	annotationFilter *string
 	// selectedSet, when non-nil, restricts emitted structural properties to the
 	// named set (matching either the Go field name or the JSON name) plus key
@@ -53,11 +57,14 @@ type fastEntityContext struct {
 }
 
 // canFastWriteCollection reports whether data is a slice of structs the direct
-// writer can serialize, and returns the element reflect.Value accessor via the
-// returned reflect.Value (the slice itself). The second result is false when the
-// caller must use the OrderedMap fallback path.
-func canFastWriteCollection(data interface{}, fullMetadata *internalMetadata.EntityMetadata, expandOptions []query.ExpandOption) (reflect.Value, bool) {
-	if fullMetadata == nil || len(expandOptions) > 0 {
+// writer can serialize, and returns the slice reflect.Value. The second result is
+// false when the caller must use the OrderedMap fallback path. $expand is handled
+// by the fast path (expanded values are emitted via the shared JSON path), so
+// $expand requests whose results remain structs stay on the fast path; only when
+// an upstream stage converted the results to maps (e.g. $expand combined with a
+// projecting $select) does the element check below route them to the fallback.
+func canFastWriteCollection(data interface{}, fullMetadata *internalMetadata.EntityMetadata) (reflect.Value, bool) {
+	if fullMetadata == nil {
 		return reflect.Value{}, false
 	}
 	v := reflect.ValueOf(data)
@@ -287,10 +294,19 @@ func writeFastEntity(buf *bytes.Buffer, entity reflect.Value, ctx *fastEntityCon
 		info := &infos[j]
 
 		if e.navProp != nil && e.navProp.IsNavigationProp {
-			// No $expand in the fast path, so navigation properties only ever
-			// contribute a navigation link (full metadata, or minimal metadata
-			// when the property is selected for links) — mirroring the non-expand
-			// branch of processNavigationPropertyOrderedWithMetadata.
+			// Expanded navigation property: emit its value (with nested
+			// $select/$expand/$ref/$count already applied by ApplyExpandOptionToValue)
+			// plus @odata.count and @odata.nextLink, mirroring the expand branch of
+			// processNavigationPropertyOrderedWithMetadata.
+			if expandOpt := query.FindExpandOption(ctx.expandOptions, e.navProp.Name, e.navProp.JsonName); expandOpt != nil {
+				if err := ctx.writeExpandedNavigation(buf, entity.Field(j), e.navProp, info.JsonName, expandOpt, keySegment, writeKey, enc); err != nil {
+					return err
+				}
+				continue
+			}
+			// Unexpanded navigation property: a navigation link only (full metadata,
+			// or minimal metadata when the property is selected for links) — mirroring
+			// the non-expand branch of processNavigationPropertyOrderedWithMetadata.
 			emitLink := metadataLevel == MetadataFull ||
 				(metadataLevel == MetadataMinimal && isPropertySelectedForLinks(*e.navProp, ctx.selectedNavProps))
 			if emitLink && keySegment != "" {
@@ -357,6 +373,42 @@ func writeFastEntity(buf *bytes.Buffer, entity reflect.Value, ctx *fastEntityCon
 
 	buf.WriteByte('}')
 	return nil
+}
+
+// writeExpandedNavigation writes an expanded navigation property: its @odata.count
+// (when $count was requested), its @odata.nextLink (when a $top-limited collection
+// was truncated), and its value. It reproduces the expand branch of
+// processNavigationPropertyOrderedWithMetadata exactly, including the key order
+// (count, nextLink, value). The value — with nested $select/$expand/$ref/$count
+// already applied by ApplyExpandOptionToValue — is serialized through encodeFallback,
+// which yields the same bytes the OrderedMap path's marshalTo produces for it.
+func (ctx *fastEntityContext) writeExpandedNavigation(buf *bytes.Buffer, fieldValue reflect.Value, navProp *PropertyMetadata, jsonName string, expandOpt *query.ExpandOption, keySegment string, writeKey func(string), enc **json.Encoder) error {
+	truncated := false
+	if expandOpt.Top != nil && navProp.NavigationIsArray {
+		fieldValue, truncated = TruncateExpandedCollectionToTop(fieldValue, *expandOpt.Top)
+	}
+
+	updatedValue := fieldValue.Interface()
+	var count *int
+	if targetMetadata, err := ctx.fullMetadata.ResolveNavigationTarget(navProp.Name); err == nil {
+		updatedValue, count = ApplyExpandOptionToValue(updatedValue, expandOpt, targetMetadata)
+	}
+
+	if count != nil {
+		writeKey(jsonName + "@odata.count")
+		writeInt(buf, int64(*count))
+	}
+
+	if truncated && keySegment != "" {
+		writeKey(jsonName + "@odata.nextLink")
+		nextLink := BuildExpandedCollectionNextLink(ctx.baseURL, ctx.entitySetName, keySegment, jsonName, expandOpt)
+		if err := writeJSONString(buf, nextLink, enc); err != nil {
+			return err
+		}
+	}
+
+	writeKey(jsonName)
+	return encodeFallback(buf, enc, updatedValue)
 }
 
 // isSelected reports whether a property (by Go name or JSON name) survives $select

--- a/internal/response/entity_writer_benchmark_test.go
+++ b/internal/response/entity_writer_benchmark_test.go
@@ -53,7 +53,7 @@ func benchSetup(b *testing.B) (*internalMetadata.EntityMetadata, *ewProvider) {
 }
 
 func benchFast(b *testing.B, data []ewEntity, provider *ewProvider, fullMD *internalMetadata.EntityMetadata, selectedProps []string) {
-	slice, ok := canFastWriteCollection(data, fullMD, nil)
+	slice, ok := canFastWriteCollection(data, fullMD)
 	if !ok {
 		b.Fatal("fast path not eligible")
 	}
@@ -129,4 +129,84 @@ func BenchmarkEntityCollectionSelectLegacy100(b *testing.B) {
 	fullMD, provider := benchSetup(b)
 	data := query.ApplySelect(benchEntities(100), []string{"Name", "Price"}, fullMD, nil)
 	benchLegacy(b, data, provider, fullMD)
+}
+
+// benchSetupExpand builds metadata with the navigation target registered so
+// ResolveNavigationTarget works during $expand serialization.
+func benchSetupExpand(b *testing.B) (*internalMetadata.EntityMetadata, *ewProvider) {
+	b.Helper()
+	fullMD, provider := benchSetup(b)
+	catMD, err := internalMetadata.AnalyzeEntity(&ewCat{})
+	if err != nil {
+		b.Fatalf("AnalyzeEntity ewCat: %v", err)
+	}
+	catMD.EntitySetName = "EwCats"
+	fullMD.SetEntitiesRegistry(map[string]*internalMetadata.EntityMetadata{
+		fullMD.EntityName: fullMD,
+		catMD.EntityName:  catMD,
+	})
+	return fullMD, provider
+}
+
+func benchEntitiesExpanded(n int) []ewEntity {
+	out := benchEntities(n)
+	c := ewCat{ID: 7, Name: "Category Seven"}
+	for i := range out {
+		out[i].Category = &c
+	}
+	return out
+}
+
+// $expand: the parent entity stays on the direct writer; the expanded value is
+// serialized through the shared JSON path (as the legacy path also does).
+func BenchmarkEntityCollectionExpandFast100(b *testing.B) {
+	fullMD, provider := benchSetupExpand(b)
+	data := benchEntitiesExpanded(100)
+	expand := []query.ExpandOption{{NavigationProperty: "Category"}}
+	slice, ok := canFastWriteCollection(data, fullMD)
+	if !ok {
+		b.Fatal("fast path not eligible")
+	}
+	ctx := &fastEntityContext{
+		baseURL:       "http://example.com",
+		entitySetName: "EwEntities",
+		metadataLevel: MetadataMinimal,
+		metadata:      provider,
+		fullMetadata:  fullMD,
+		expandOptions: expand,
+		keySet:        buildKeySet(provider),
+	}
+	var buf bytes.Buffer
+	buf.Grow(64 * 1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := writeFastCollection(&buf, slice, ctx, "http://example.com/$metadata#EwEntities", nil, nil, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEntityCollectionExpandLegacy100(b *testing.B) {
+	fullMD, provider := benchSetupExpand(b)
+	data := benchEntitiesExpanded(100)
+	expand := []query.ExpandOption{{NavigationProperty: "Category"}}
+	r := httptest.NewRequest("GET", "http://example.com/EwEntities", nil)
+	var buf bytes.Buffer
+	buf.Grow(64 * 1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		transformed := addNavigationLinks(data, provider, expand, nil, r, "EwEntities", MetadataMinimal, fullMD)
+		envelope := AcquireOrderedMapWithCapacity(2)
+		envelope.Set("@odata.context", "http://example.com/$metadata#EwEntities")
+		envelope.Set("value", transformed)
+		if err := envelope.marshalTo(&buf); err != nil {
+			b.Fatal(err)
+		}
+		envelope.Release()
+		releaseOrderedMaps(transformed)
+	}
 }

--- a/internal/response/entity_writer_equivalence_test.go
+++ b/internal/response/entity_writer_equivalence_test.go
@@ -192,7 +192,7 @@ func TestFastWriterMatchesLegacyPath(t *testing.T) {
 			fastBody := rec.Body.String()
 
 			// Sanity: the fast path must actually have been taken (struct slice, no expand).
-			if _, ok := canFastWriteCollection(data, fullMD, nil); !ok {
+			if _, ok := canFastWriteCollection(data, fullMD); !ok {
 				t.Fatalf("expected fast path to be eligible")
 			}
 
@@ -222,6 +222,99 @@ func TestFastWriterMatchesLegacyPath(t *testing.T) {
 			// consistent ordering with plain GET.
 			if !jsonSemanticEqual(t, fastBody, legacyBody) {
 				t.Errorf("semantic mismatch for %s\n fast:   %s\n legacy: %s", tc.name, fastBody, legacyBody)
+			}
+		})
+	}
+}
+
+// TestFastWriterMatchesLegacyPathExpand locks the $expand fast path to byte-for-byte
+// identical output vs the legacy OrderedMap path. Both serialize expanded values in
+// declaration order (the legacy expand path also goes struct→OrderedMap), so the
+// output must match exactly — including @odata.count and @odata.nextLink placement.
+func TestFastWriterMatchesLegacyPathExpand(t *testing.T) {
+	fullMD, err := internalMetadata.AnalyzeEntity(&ewEntity{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity ewEntity: %v", err)
+	}
+	fullMD.EntitySetName = "EwEntities"
+	catMD, err := internalMetadata.AnalyzeEntity(&ewCat{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity ewCat: %v", err)
+	}
+	catMD.EntitySetName = "EwCats"
+	// Register the navigation target so ResolveNavigationTarget (and thus nested
+	// $select/$expand/$count) works, matching a real service.
+	fullMD.SetEntitiesRegistry(map[string]*internalMetadata.EntityMetadata{
+		fullMD.EntityName: fullMD,
+		catMD.EntityName:  catMD,
+	})
+	provider := newEwProvider(fullMD)
+
+	desc := "a description"
+	c1 := ewCat{ID: 7, Name: "Cat7"}
+	c2 := ewCat{ID: 8, Name: "Cat8"}
+	data := []ewEntity{
+		{
+			ID: 1, Name: "First", Description: &desc, Price: 9.99, Status: 1 | 4,
+			Version: 3, CreatedAt: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+			Category: &c1, CatID: uintPtr(7), Related: []ewCat{c1, c2},
+		},
+		{
+			ID: 2, Name: "Second", Price: 0, Status: 0, Version: 1,
+			CreatedAt: time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC),
+			Category:  nil, CatID: nil, Related: nil,
+		},
+	}
+
+	one := 1
+	cases := []struct {
+		name          string
+		metadataLevel string
+		expand        []query.ExpandOption
+	}{
+		{"minimal_expand_single", MetadataMinimal, []query.ExpandOption{{NavigationProperty: "Category"}}},
+		{"full_expand_single", MetadataFull, []query.ExpandOption{{NavigationProperty: "Category"}}},
+		{"minimal_expand_collection", MetadataMinimal, []query.ExpandOption{{NavigationProperty: "Related"}}},
+		{"minimal_expand_collection_count", MetadataMinimal, []query.ExpandOption{{NavigationProperty: "Related", Count: true}}},
+		{"minimal_expand_collection_top", MetadataMinimal, []query.ExpandOption{{NavigationProperty: "Related", Top: &one}}},
+		{"minimal_expand_nested_select", MetadataMinimal, []query.ExpandOption{{NavigationProperty: "Related", Select: []string{"Name"}}}},
+		{"full_expand_collection", MetadataFull, []query.ExpandOption{{NavigationProperty: "Related"}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := canFastWriteCollection(data, fullMD); !ok {
+				t.Fatalf("expected fast path to be eligible")
+			}
+
+			rec := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "http://example.com/EwEntities", nil)
+			if tc.metadataLevel != MetadataMinimal {
+				r.Header.Set("Accept", "application/json;odata.metadata="+tc.metadataLevel)
+			}
+			if err := WriteODataCollectionWithNavigationAndSelect(rec, r, "EwEntities", data, nil, nil, nil, provider, tc.expand, nil, fullMD, nil, 0); err != nil {
+				t.Fatalf("fast write: %v", err)
+			}
+			fastBody := rec.Body.String()
+
+			// LEGACY path with the same $expand options.
+			lr := httptest.NewRequest("GET", "http://example.com/EwEntities", nil)
+			transformed := addNavigationLinks(data, provider, tc.expand, nil, lr, "EwEntities", tc.metadataLevel, fullMD)
+			envelope := AcquireOrderedMapWithCapacity(2)
+			if tc.metadataLevel != MetadataNone {
+				envelope.Set("@odata.context", buildContextURLWithSelect(lr, "EwEntities", nil))
+			}
+			envelope.Set("value", transformed)
+			var buf bytes.Buffer
+			if err := envelope.marshalTo(&buf); err != nil {
+				t.Fatalf("legacy marshalTo: %v", err)
+			}
+			envelope.Release()
+			releaseOrderedMaps(transformed)
+			legacyBody := buf.String()
+
+			if fastBody != legacyBody {
+				t.Errorf("byte mismatch for %s\n fast:   %s\n legacy: %s", tc.name, fastBody, legacyBody)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Follow-up to #863. That PR added the direct struct→JSON collection writer but deliberately left `$expand` on the OrderedMap fallback path. This PR extends the fast writer to handle `$expand`, so the **parent entity's fields stay on the reflection-free path** instead of building a per-entity `OrderedMap`.

For each expanded navigation property the writer reproduces the expand branch of `processNavigationPropertyOrderedWithMetadata` exactly:
- `$top` truncation → `@odata.nextLink`
- `@odata.count`
- the value (with nested `$select`/`$expand`/`$ref`/`$count` applied via `ApplyExpandOptionToValue`), emitted in the same key order

The expanded value is serialized through the shared JSON path (`encodeFallback`), which is byte-identical to what `marshalTo` produced for it — so only the parent's scalar/complex fields change how they're written. `$expand` combined with a projecting `$select` still converts to maps upstream and uses the fallback path unchanged.

## Performance

`BenchmarkEntityCollectionExpand*` (Products-like parent + single expand, 100 rows): **−32% ns/op, −50% allocs/op** (125µs → 85µs, 1607 → 803 allocs).

## Verification

- `TestFastWriterMatchesLegacyPathExpand` locks byte-identical output vs the legacy path across single/collection expands, nested `$select`, `$top` truncation, and `$count`.
- Full unit suite + `-race` pass.
- Compliance suite v1.0.3: **162/162 suites, 0 failures**.

Completes the last unchecked box from #861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)