### PR TITLE
perf(response): trim per-row serialization hotspots (#861)

### DIFF
--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -81,12 +81,68 @@ func encodeHex16(dst []byte, v uint64) {
 	dst[18] = hexTable[v&0xf]
 }
 
+// appendHex16 appends v as 16 lowercase hex characters to dst.
+func appendHex16(dst []byte, v uint64) []byte {
+	return append(dst,
+		hexTable[(v>>60)&0xf], hexTable[(v>>56)&0xf], hexTable[(v>>52)&0xf], hexTable[(v>>48)&0xf],
+		hexTable[(v>>44)&0xf], hexTable[(v>>40)&0xf], hexTable[(v>>36)&0xf], hexTable[(v>>32)&0xf],
+		hexTable[(v>>28)&0xf], hexTable[(v>>24)&0xf], hexTable[(v>>20)&0xf], hexTable[(v>>16)&0xf],
+		hexTable[(v>>12)&0xf], hexTable[(v>>8)&0xf], hexTable[(v>>4)&0xf], hexTable[v&0xf],
+	)
+}
+
 // Generate creates an ETag value for an entity based on its ETag property
 // Returns an empty string if no ETag property is defined
 // Uses xxhash64 for fast non-cryptographic hashing (ETag doesn't need cryptographic strength)
 func Generate(entity interface{}, meta *metadata.EntityMetadata) string {
-	if meta.ETagProperty == nil {
+	hash, ok := etagHash(entity, meta)
+	if !ok {
 		return ""
+	}
+
+	// Get pre-allocated buffer from pool (pre-filled with W/"..." framing)
+	bufPtr := etagBufferPool.Get().(*[]byte) //nolint:errcheck // sync.Pool.Get() doesn't return error
+	buf := *bufPtr
+
+	// Encode hash directly into buffer (zero allocation hex encoding)
+	encodeHex16(buf, hash)
+
+	// Create result string (single allocation)
+	result := string(buf)
+
+	// Return buffer to pool
+	etagBufferPool.Put(bufPtr)
+
+	return result
+}
+
+// AppendJSON appends the JSON-encoded ETag string (e.g. `"W/\"0123456789abcdef\""`)
+// to dst and returns the extended slice with true. It returns (dst, false),
+// writing nothing, when the entity has no resolvable ETag — matching Generate
+// returning "". Emitting the pre-escaped JSON form directly lets response
+// serializers write the ETag straight into their output buffer, avoiding both
+// Generate's per-entity result string allocation and a second JSON-escaping pass
+// (the ETag value always contains quotes, so it would otherwise route through the
+// reflection encoder).
+func AppendJSON(dst []byte, entity interface{}, meta *metadata.EntityMetadata) ([]byte, bool) {
+	hash, ok := etagHash(entity, meta)
+	if !ok {
+		return dst, false
+	}
+	// JSON encoding of the ETag value W/"<hex>": the inner double quotes are
+	// backslash-escaped, matching encoding/json's output for that string.
+	dst = append(dst, '"', 'W', '/', '\\', '"')
+	dst = appendHex16(dst, hash)
+	dst = append(dst, '\\', '"', '"')
+	return dst, true
+}
+
+// etagHash resolves the entity's ETag property value and returns its xxhash64,
+// or (0, false) when no ETag property is defined or the field cannot be resolved.
+// It is the shared core of Generate and AppendJSON.
+func etagHash(entity interface{}, meta *metadata.EntityMetadata) (uint64, bool) {
+	if meta.ETagProperty == nil {
+		return 0, false
 	}
 
 	// Get the entity value
@@ -97,18 +153,18 @@ func Generate(entity interface{}, meta *metadata.EntityMetadata) string {
 
 	// Handle map entities (from $select operations)
 	if entityValue.Kind() == reflect.Map {
-		return generateFromMap(entity, meta)
+		return etagHashFromMap(entity, meta)
 	}
 
 	// Use cached field index instead of FieldByName
 	idx, found := getFieldIndex(entityValue.Type(), meta.ETagProperty.FieldName)
 	if !found {
-		return ""
+		return 0, false
 	}
 
 	fieldValue := entityValue.Field(idx)
 	if !fieldValue.IsValid() {
-		return ""
+		return 0, false
 	}
 
 	// Convert the field value to a string for hashing
@@ -141,31 +197,15 @@ func Generate(entity interface{}, meta *metadata.EntityMetadata) string {
 		etagSource = fmt.Sprintf("%v", fieldValue.Interface())
 	}
 
-	// Generate xxhash64 of the ETag source (much faster than SHA256)
-	hash := xxhash.Sum64String(etagSource)
-
-	// Get pre-allocated buffer from pool
-	bufPtr := etagBufferPool.Get().(*[]byte) //nolint:errcheck // sync.Pool.Get() doesn't return error
-	buf := *bufPtr
-
-	// Encode hash directly into buffer (zero allocation hex encoding)
-	encodeHex16(buf, hash)
-
-	// Create result string (single allocation)
-	result := string(buf)
-
-	// Return buffer to pool
-	etagBufferPool.Put(bufPtr)
-
-	return result
+	return xxhash.Sum64String(etagSource), true
 }
 
-// generateFromMap generates an ETag from a map entity (from $select operations)
-// Uses xxhash64 for fast hashing with zero-allocation hex encoding
-func generateFromMap(entity interface{}, meta *metadata.EntityMetadata) string {
+// etagHashFromMap resolves the ETag property from a map entity (from $select
+// operations) and returns its xxhash64, or (0, false) when it cannot be resolved.
+func etagHashFromMap(entity interface{}, meta *metadata.EntityMetadata) (uint64, bool) {
 	entityMap, ok := entity.(map[string]interface{})
 	if !ok {
-		return ""
+		return 0, false
 	}
 
 	// Try to get the ETag field value using JsonName first, then FieldName
@@ -183,7 +223,7 @@ func generateFromMap(entity interface{}, meta *metadata.EntityMetadata) string {
 	}
 
 	if !found || fieldValue == nil {
-		return ""
+		return 0, false
 	}
 
 	// Convert the field value to a string for hashing
@@ -221,23 +261,7 @@ func generateFromMap(entity interface{}, meta *metadata.EntityMetadata) string {
 		etagSource = fmt.Sprintf("%v", v)
 	}
 
-	// Generate xxhash64 of the ETag source (much faster than SHA256)
-	hash := xxhash.Sum64String(etagSource)
-
-	// Get pre-allocated buffer from pool
-	bufPtr := etagBufferPool.Get().(*[]byte) //nolint:errcheck // sync.Pool.Get() doesn't return error
-	buf := *bufPtr
-
-	// Encode hash directly into buffer (zero allocation hex encoding)
-	encodeHex16(buf, hash)
-
-	// Create result string (single allocation)
-	result := string(buf)
-
-	// Return buffer to pool
-	etagBufferPool.Put(bufPtr)
-
-	return result
+	return xxhash.Sum64String(etagSource), true
 }
 
 // Parse extracts the ETag value from a quoted ETag string

--- a/internal/etag/etag_test.go
+++ b/internal/etag/etag_test.go
@@ -1,6 +1,7 @@
 package etag
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -543,6 +544,83 @@ func TestNoneMatch_List(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("NoneMatch(%q, %q) = %v, want %v\nDescription: %s",
 					tt.ifNoneMatch, tt.currentETag, got, tt.want, tt.description)
+			}
+		})
+	}
+}
+
+// TestAppendJSONMatchesGenerate locks AppendJSON to the JSON string encoding of
+// Generate: for any entity with an ETag, AppendJSON must emit exactly what
+// encoding/json would produce for Generate's string, and it must report false
+// (writing nothing) exactly when Generate returns "".
+func TestAppendJSONMatchesGenerate(t *testing.T) {
+	cases := []struct {
+		name   string
+		entity interface{}
+		meta   *metadata.EntityMetadata
+	}{
+		{
+			name:   "int etag",
+			entity: TestEntity{ID: 1, Version: 5},
+			meta:   &metadata.EntityMetadata{ETagProperty: &metadata.PropertyMetadata{FieldName: "Version", IsETag: true}},
+		},
+		{
+			name:   "string etag",
+			entity: TestEntity{Name: "Test"},
+			meta:   &metadata.EntityMetadata{ETagProperty: &metadata.PropertyMetadata{FieldName: "Name", IsETag: true}},
+		},
+		{
+			name:   "time etag",
+			entity: TestEntity{LastModified: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)},
+			meta:   &metadata.EntityMetadata{ETagProperty: &metadata.PropertyMetadata{FieldName: "LastModified", IsETag: true}},
+		},
+		{
+			name:   "no etag property",
+			entity: TestEntity{ID: 1},
+			meta:   &metadata.EntityMetadata{},
+		},
+		{
+			name:   "etag field missing",
+			entity: TestEntity{ID: 1},
+			meta:   &metadata.EntityMetadata{ETagProperty: &metadata.PropertyMetadata{FieldName: "Nonexistent", IsETag: true}},
+		},
+		{
+			name:   "map etag present",
+			entity: map[string]interface{}{"Version": 5},
+			meta:   &metadata.EntityMetadata{ETagProperty: &metadata.PropertyMetadata{FieldName: "Version", JsonName: "Version", IsETag: true}},
+		},
+		{
+			name:   "map etag absent",
+			entity: map[string]interface{}{"ID": 1},
+			meta:   &metadata.EntityMetadata{ETagProperty: &metadata.PropertyMetadata{FieldName: "Version", JsonName: "Version", IsETag: true}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := Generate(tc.entity, tc.meta)
+			got, ok := AppendJSON(nil, tc.entity, tc.meta)
+
+			if want == "" {
+				if ok {
+					t.Fatalf("AppendJSON reported ok=true but Generate returned empty; got %q", got)
+				}
+				if len(got) != 0 {
+					t.Fatalf("AppendJSON wrote %q when Generate returned empty", got)
+				}
+				return
+			}
+
+			if !ok {
+				t.Fatalf("AppendJSON reported ok=false but Generate returned %q", want)
+			}
+			// AppendJSON must equal the JSON string encoding of the Generate value.
+			wantJSON, err := json.Marshal(want)
+			if err != nil {
+				t.Fatalf("marshal want: %v", err)
+			}
+			if string(got) != string(wantJSON) {
+				t.Errorf("AppendJSON = %s, want %s", got, wantJSON)
 			}
 		})
 	}

--- a/internal/response/entity_plan.go
+++ b/internal/response/entity_plan.go
@@ -42,6 +42,12 @@ type entityFieldEntry struct {
 	// true only for []byte fields (Edm.Binary), which serialize as base64url.
 	isEnum   bool
 	isBinary bool
+	// quotedKey is the pre-rendered JSON object key including quotes and the colon,
+	// e.g. `"Name":`. The direct writer emits it with a single buf.Write instead of
+	// re-quoting and re-scanning the (static) key for escapes on every row. It is
+	// nil when the JSON name would need escaping, in which case the writer falls
+	// back to writeJSONKey; escaping is checked once here, at plan-build time.
+	quotedKey []byte
 }
 
 type entityPlanKey struct {
@@ -89,6 +95,12 @@ func getEntityFieldPlan(md *internalMetadata.EntityMetadata, t reflect.Type) *en
 		// EncodeEdmBinary, exactly as the OrderedMap path does.
 		if ft := t.Field(j).Type; ft.Kind() == reflect.Slice && ft.Elem().Kind() == reflect.Uint8 {
 			e.isBinary = true
+		}
+		// Pre-render the JSON key (`"name":`) once, skipping the per-row re-quote and
+		// escape scan. Left nil when the name would need escaping (rare for struct
+		// tags), so the writer falls back to writeJSONKey for exact output.
+		if !needsEscaping(info.JsonName) {
+			e.quotedKey = append(append(append(make([]byte, 0, len(info.JsonName)+3), '"'), info.JsonName...), '"', ':')
 		}
 		entries[j] = e
 	}

--- a/internal/response/entity_writer.go
+++ b/internal/response/entity_writer.go
@@ -216,27 +216,33 @@ func writeFastEntity(buf *bytes.Buffer, entity reflect.Value, ctx *fastEntityCon
 
 	buf.WriteByte('{')
 	first := true
-	writeKey := func(key string) {
+	comma := func() {
 		if !first {
 			buf.WriteByte(',')
 		}
 		first = false
+	}
+	writeKey := func(key string) {
+		comma()
 		writeJSONKey(buf, key)
 		buf.WriteByte(':')
 	}
 
 	// @odata.etag — present when the entity has an ETag property and metadata is
 	// not "none". Under $select the ETag mirrors the map path: it is emitted only
-	// when the ETag property itself survives projection (generateFromMap returns
-	// "" when the field is absent from the projected map).
+	// when the ETag property itself survives projection (AppendJSON reports false
+	// when the field is absent from the projected map). AppendJSON writes the
+	// escaped value straight into the buffer, avoiding a per-entity string
+	// allocation and JSON-escaping pass; if there is no ETag we roll back the key.
 	if ctx.fullMetadata.ETagProperty != nil && metadataLevel != MetadataNone {
 		if !selecting || ctx.isSelected(ctx.fullMetadata.ETagProperty.FieldName, ctx.fullMetadata.ETagProperty.JsonName) {
-			entityInterface := addressableInterface(entity)
-			if etagValue := etag.Generate(entityInterface, ctx.fullMetadata); etagValue != "" {
-				writeKey("@odata.etag")
-				if err := writeJSONString(buf, etagValue, enc); err != nil {
-					return err
-				}
+			mark, wasFirst := buf.Len(), first
+			writeKey("@odata.etag")
+			if out, ok := etag.AppendJSON(buf.AvailableBuffer(), addressableInterface(entity), ctx.fullMetadata); ok {
+				buf.Write(out)
+			} else {
+				buf.Truncate(mark)
+				first = wasFirst
 			}
 		}
 	}
@@ -341,7 +347,14 @@ func writeFastEntity(buf *bytes.Buffer, entity reflect.Value, ctx *fastEntityCon
 			}
 		}
 
-		writeKey(info.JsonName)
+		// Emit the pre-rendered key when available (the common case), else fall back
+		// to the escaping-aware writer for names that need escaping.
+		if e.quotedKey != nil {
+			comma()
+			buf.Write(e.quotedKey)
+		} else {
+			writeKey(info.JsonName)
+		}
 		if err := writeFastFieldValue(buf, entity.Field(j), e, enc); err != nil {
 			return err
 		}

--- a/internal/response/ordered_map.go
+++ b/internal/response/ordered_map.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"unicode/utf8"
 )
 
 // bufferPool is a sync.Pool for reusing bytes.Buffer instances
@@ -459,10 +458,12 @@ func writeUint(buf *bytes.Buffer, v uint64) {
 	buf.Write(b[i:])
 }
 
-// writeFloat writes a float64 to the buffer
+// writeFloat writes a float64 to the buffer using the same formatting as
+// strconv.FormatFloat(v, 'f', -1, 64), but appends into a stack buffer instead of
+// allocating an intermediate string per call.
 func writeFloat(buf *bytes.Buffer, v float64) {
-	// Use strconv for proper float formatting
-	buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+	var tmp [32]byte
+	buf.Write(strconv.AppendFloat(tmp[:0], v, 'f', -1, 64))
 }
 
 // writeJSONKey writes a JSON object key (quoted string) to buf, escaping only
@@ -493,21 +494,16 @@ func writeJSONString(buf *bytes.Buffer, s string, enc **json.Encoder) error {
 	return nil
 }
 
-// needsEscaping checks if a string needs JSON escaping
-// Returns true if the string contains characters that need escaping
+// needsEscaping reports whether a string needs JSON escaping — i.e. contains a
+// control character (< 0x20), a double quote, or a backslash. A plain byte scan
+// suffices: every byte of a multi-byte UTF-8 sequence is >= 0x80, so none can
+// equal a character that requires escaping, and such bytes are valid as-is inside
+// a JSON string. This avoids decoding runes just to skip them.
 func needsEscaping(s string) bool {
-	for i := 0; i < len(s); {
-		c := s[i]
-		if c < 0x20 || c == '"' || c == '\\' {
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c < 0x20 || c == '"' || c == '\\' {
 			return true
 		}
-		if c < utf8.RuneSelf {
-			i++
-			continue
-		}
-		// Multi-byte UTF-8 characters are safe
-		_, size := utf8.DecodeRuneInString(s[i:])
-		i += size
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

Follow-up tuning to the collection output-plan writer (#863/#864), driven by a fresh CPU + allocation profile of the merged code under PostgreSQL load. Two things stood out:
- `needsEscaping` was the **single largest app-code self-time function** (~1.4% of all CPU), and `-peek` showed ~half of it came from `writeJSONKey` re-scanning *static* keys on every row.
- Per-row **ETag and float string allocations** dominated the writer's heap churn.

Changes:
- **Pre-render each field's JSON key** (`"Name":`) once in the cached field plan; emit with a single `buf.Write` instead of re-quoting + re-escape-scanning the static key per row. Falls back to `writeJSONKey` when a name would need escaping (checked once, at plan-build time).
- **`needsEscaping` → plain byte scan.** Every byte of a multi-byte UTF-8 sequence is ≥ 0x80, so none can be an escape-requiring char and all are valid raw in a JSON string — the per-char rune decode was unnecessary.
- **`writeFloat` → `strconv.AppendFloat`** into a stack buffer, removing a string allocation per float field per row.
- **`etag.AppendJSON`** writes the pre-escaped JSON form (`"W/\"…\""`) straight into the response buffer; the fast writer uses it instead of `Generate` + `writeJSONString`, dropping a per-entity string allocation and a reflection-encoder escaping pass. `Generate` and `AppendJSON` now share an `etagHash` core, so `Generate`'s output is unchanged.

## Performance

`BenchmarkEntityCollection*` (100 / 500 rows):

| benchmark | ns/op | allocs/op |
|---|---|---|
| Fast100 | 74.4µs → **54.9µs** (−26%) | 803 → **602** (−25%) |
| Fast500 | 380µs → **281µs** (−26%) | 4803 → **3802** (−21%) |
| ExpandFast100 | 86.4µs → **64.7µs** (−25%) | 803 → **603** (−25%) |

The ~200 removed allocs per 100 rows are exactly the per-entity ETag + float strings.

## Correctness

Output is unchanged:
- `TestFastWriterMatchesLegacyPath` / `…Expand` still assert byte-identical output vs the legacy path.
- New `TestAppendJSONMatchesGenerate` locks `AppendJSON` to the JSON encoding of `Generate` (struct/int/string/time/map + absent-ETag cases).
- `TestNeedsEscaping` (incl. unicode/emoji) still passes.
- Full unit suite + `-race` and the compliance suite (162/162) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)