### PR TITLE
fix(lint): resolve findings surfaced by newer golangci-lint

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -192,7 +192,7 @@ func buildKeyValuesFromEntity(entityMetadata *metadata.EntityMetadata, entity in
 	}
 
 	value := reflect.ValueOf(entity)
-	if value.Kind() == reflect.Ptr {
+	if value.Kind() == reflect.Pointer {
 		if value.IsNil() {
 			return nil
 		}
@@ -208,7 +208,7 @@ func buildKeyValuesFromEntity(entityMetadata *metadata.EntityMetadata, entity in
 		if !field.IsValid() {
 			continue
 		}
-		if field.Kind() == reflect.Ptr && field.IsNil() {
+		if field.Kind() == reflect.Pointer && field.IsNil() {
 			keyValues[keyProp.JsonName] = nil
 			continue
 		}

--- a/internal/handlers/batch_test.go
+++ b/internal/handlers/batch_test.go
@@ -333,7 +333,7 @@ Content-Type: application/json
 	// Verify products exist
 	var products []BatchTestProduct
 	db.Find(&products)
-	names := []string{}
+	names := make([]string, 0, len(products))
 	for _, p := range products {
 		names = append(names, p.Name)
 	}

--- a/internal/handlers/binary_request.go
+++ b/internal/handlers/binary_request.go
@@ -43,7 +43,7 @@ func isBinaryFieldType(t reflect.Type) bool {
 	if t == nil {
 		return false
 	}
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8

--- a/internal/handlers/metadata_xml.go
+++ b/internal/handlers/metadata_xml.go
@@ -87,9 +87,9 @@ func (h *MetadataHandler) buildMetadataDocument(model metadataModel, ver version
 	usedVocabularies := model.collectUsedVocabularies()
 	vocabularyAliases := metadata.VocabularyAliasMap()
 
-	builder.WriteString(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+	fmt.Fprintf(&builder, `<?xml version="1.0" encoding="UTF-8"?>
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="%s">
-`, ver.String()))
+`, ver.String())
 
 	// Add Reference elements for used vocabularies
 	for _, ns := range usedVocabularies {
@@ -100,15 +100,15 @@ func (h *MetadataHandler) buildMetadataDocument(model metadataModel, ver version
 			alias = parts[len(parts)-1]
 		}
 		uri := vocabularyURI(ns)
-		builder.WriteString(fmt.Sprintf(`  <edmx:Reference Uri="%s">
+		fmt.Fprintf(&builder, `  <edmx:Reference Uri="%s">
     <edmx:Include Namespace="%s" Alias="%s" />
   </edmx:Reference>
-`, uri, ns, alias))
+`, uri, ns, alias)
 	}
 
-	builder.WriteString(fmt.Sprintf(`  <edmx:DataServices>
+	fmt.Fprintf(&builder, `  <edmx:DataServices>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="%s">
-`, model.namespace))
+`, model.namespace)
 
 	builder.WriteString(h.buildEnumTypes(model))
 	builder.WriteString(h.buildTypeDefinitions(model))

--- a/internal/query/apply_filter.go
+++ b/internal/query/apply_filter.go
@@ -1462,7 +1462,9 @@ func buildFunctionSQL(dialect string, op FilterOperator, columnName string, valu
 				rightArgs = []interface{}{secondArg}
 			}
 
-			allArgs := append(leftArgs, rightArgs...)
+			allArgs := make([]interface{}, 0, len(leftArgs)+len(rightArgs))
+			allArgs = append(allArgs, leftArgs...)
+			allArgs = append(allArgs, rightArgs...)
 			if dialect == "postgres" {
 				return fmt.Sprintf("(%s || %s)", leftSQL, rightSQL), allArgs
 			}


### PR DESCRIPTION
## Summary
Fixes the 8 pre-existing lint findings surfaced by a newer local golangci-lint that current CI does not yet report:

- govet `inline` (use `reflect.Pointer` instead of the deprecated `reflect.Ptr`): `internal/handlers/auth.go:195`, `:211`, `internal/handlers/binary_request.go:46`
- `prealloc`: `internal/handlers/batch_test.go` (`names`), `internal/query/apply_filter.go` (concat arg slice)
- staticcheck `QF1012` (`fmt.Fprintf(...)` instead of `builder.WriteString(fmt.Sprintf(...))`): `internal/handlers/metadata_xml.go` (3 sites)

All mechanical, no behavior change.

Fixes #840

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `golangci-lint run` confirms all 8 originally-listed findings are resolved