### PR TITLE
fix(fastscan): make plan poisoning per-column with a retry window

### DIFF
--- a/internal/fastscan/fastscan.go
+++ b/internal/fastscan/fastscan.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"database/sql"
 	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -56,10 +58,92 @@ type plan struct {
 	// destinations slice and every sql.Null* buffer, so concurrent queries
 	// never share mutable scan state.
 	bindings sync.Pool
-	// disabled is set when a scan produced an error that GORM's richer value
-	// conversion might have handled; every later query for this schema then
-	// uses the fallback instead of failing the same way again.
-	disabled atomic.Bool
+	// poisoned tracks, per DB column name, the time a scan of that column
+	// last produced an error that GORM's richer value conversion might have
+	// handled. A query that touches a currently-poisoned column falls back
+	// to GORM instead of risking the same failure; other columns on the same
+	// schema keep using the fast path. Entries expire after poisonRetryWindow
+	// so a transient bad value (or a value that no longer occurs) doesn't
+	// poison the column forever.
+	poisoned sync.Map // db column name -> time.Time
+	// poisonCount is a best-effort (may lag a just-expired entry) count of
+	// entries in poisoned, used to skip the poison check entirely in the
+	// common case where nothing is poisoned.
+	poisonCount atomic.Int32
+}
+
+// poisonRetryWindow bounds how long a column stays poisoned before it is
+// given another chance. Keeping this short means a truly incompatible column
+// (e.g. legacy TEXT in an INTEGER column, or a driver without parseTime) is
+// quickly re-poisoned at negligible cost, while a transient bad value doesn't
+// forfeit the fast path for the life of the process. Variable (not const) so
+// tests can shrink it instead of sleeping tens of seconds.
+var poisonRetryWindow = 30 * time.Second
+
+// isPoisoned reports whether column is currently poisoned, lazily expiring
+// (and uncounting) the entry once poisonRetryWindow has elapsed.
+func (p *plan) isPoisoned(column string) bool {
+	v, ok := p.poisoned.Load(column)
+	if !ok {
+		return false
+	}
+	at, ok := v.(time.Time)
+	if !ok || time.Since(at) > poisonRetryWindow {
+		if p.poisoned.CompareAndDelete(column, v) {
+			p.poisonCount.Add(-1)
+		}
+		return false
+	}
+	return true
+}
+
+// anyPoisoned reports whether any of columns is currently poisoned.
+func (p *plan) anyPoisoned(columns []string) bool {
+	if p.poisonCount.Load() <= 0 {
+		return false
+	}
+	for _, c := range columns {
+		if p.isPoisoned(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// poisonColumn marks column as poisoned as of now, extending its poisoned
+// window if it was already poisoned.
+func (p *plan) poisonColumn(column string) {
+	if _, loaded := p.poisoned.Swap(column, time.Now()); !loaded {
+		p.poisonCount.Add(1)
+	}
+}
+
+// poisonAll marks every column in the schema as poisoned. It is the
+// conservative fallback used when a scan error can't be attributed to a
+// specific column, matching the previous whole-plan-disable behavior.
+func (p *plan) poisonAll() {
+	for name := range p.fields {
+		p.poisonColumn(name)
+	}
+}
+
+// scanErrorColumnIndexRe matches the column index that database/sql's
+// (*Rows).Scan embeds in conversion errors, e.g. `sql: Scan error on column
+// index 1, name "amount": converting driver.Value type string ...`. This
+// format has been stable in the standard library for many Go releases; if it
+// ever changes, recordScanFailure falls back to poisoning every column.
+var scanErrorColumnIndexRe = regexp.MustCompile(`column index (\d+)`)
+
+// recordScanFailure poisons the column responsible for a scan error, or
+// every column in the schema if the offending one can't be identified.
+func (p *plan) recordScanFailure(err error, columns []string) {
+	if m := scanErrorColumnIndexRe.FindStringSubmatch(err.Error()); m != nil {
+		if idx, convErr := strconv.Atoi(m[1]); convErr == nil && idx >= 0 && idx < len(columns) {
+			p.poisonColumn(columns[idx])
+			return
+		}
+	}
+	p.poisonAll()
 }
 
 var (
@@ -105,7 +189,7 @@ func Find(db *gorm.DB, dest interface{}) error {
 		return tx.Find(dest).Error
 	}
 	p := planFor(sch)
-	if p == nil || p.disabled.Load() || !eligibleStatement(tx.Statement, sch) {
+	if p == nil || !eligibleStatement(tx.Statement, sch) || p.likelyTouchesPoisoned(tx.Statement, sch) {
 		return tx.Find(dest).Error
 	}
 
@@ -113,21 +197,39 @@ func Find(db *gorm.DB, dest interface{}) error {
 	if err != nil {
 		return err
 	}
+	columns, err := rows.Columns()
+	if err != nil {
+		if closeErr := rows.Close(); closeErr != nil {
+			return closeErr
+		}
+		return err
+	}
+	if p.anyPoisoned(columns) {
+		// A column this query touches failed to scan recently enough that it
+		// is still poisoned; don't waste a scan attempt repeating a failure
+		// we already know about. Execute resets the statement's SQL after
+		// Rows, so Find rebuilds it cleanly.
+		if closeErr := rows.Close(); closeErr != nil {
+			return closeErr
+		}
+		return tx.Find(dest).Error
+	}
 
-	result, err := scanRows(tx.Statement.Context, rows, p, sliceVal, elemType)
+	result, err := scanRows(tx.Statement.Context, rows, p, sliceVal, elemType, columns)
 	closeErr := rows.Close()
 	if err != nil {
 		if scanErr, ok := err.(*rowScanError); ok {
 			// A row failed to scan. If the context is gone this is just
 			// cancellation; otherwise the plan mis-handled a driver value that
-			// GORM's conversions might accept. Disable the plan for this
-			// schema and re-run the query through GORM, which either succeeds
-			// or reports its own (equivalent) error. Execute resets the
-			// statement's SQL after Rows, so Find rebuilds it cleanly.
+			// GORM's conversions might accept. Poison the offending column (or
+			// every column, if it can't be identified) and re-run the query
+			// through GORM, which either succeeds or reports its own
+			// (equivalent) error. Execute resets the statement's SQL after
+			// Rows, so Find rebuilds it cleanly.
 			if ctxErr := contextErr(tx.Statement.Context); ctxErr != nil {
 				return scanErr.err
 			}
-			p.disabled.Store(true)
+			p.recordScanFailure(scanErr.err, columns)
 			return tx.Find(dest).Error
 		}
 		return err
@@ -175,7 +277,7 @@ func First(db *gorm.DB, dest interface{}) error {
 		return tx.First(dest).Error
 	}
 	p := planFor(sch)
-	if p == nil || p.disabled.Load() || !eligibleStatement(tx.Statement, sch) {
+	if p == nil || !eligibleStatement(tx.Statement, sch) || p.likelyTouchesPoisoned(tx.Statement, sch) {
 		return tx.First(dest).Error
 	}
 
@@ -194,19 +296,37 @@ func First(db *gorm.DB, dest interface{}) error {
 	if err != nil {
 		return err
 	}
-	found, err := scanFirstRow(tx.Statement.Context, rows, p, destVal.Elem())
+	columns, err := rows.Columns()
+	if err != nil {
+		if closeErr := rows.Close(); closeErr != nil {
+			return closeErr
+		}
+		return err
+	}
+	if p.anyPoisoned(columns) {
+		// A column this query touches failed to scan recently enough that it
+		// is still poisoned; don't waste a scan attempt repeating a failure
+		// we already know about.
+		if closeErr := rows.Close(); closeErr != nil {
+			return closeErr
+		}
+		return tx.First(dest).Error
+	}
+
+	found, err := scanFirstRow(tx.Statement.Context, rows, p, destVal.Elem(), columns)
 	closeErr := rows.Close()
 	if err != nil {
 		if scanErr, ok := err.(*rowScanError); ok {
 			// A row failed to scan. If the context is gone this is just
 			// cancellation; otherwise the plan mis-handled a driver value that
-			// GORM's conversions might accept. Disable the plan for this schema
-			// and re-run through GORM, which either succeeds or reports its own
-			// (equivalent) error.
+			// GORM's conversions might accept. Poison the offending column (or
+			// every column, if it can't be identified) and re-run through
+			// GORM, which either succeeds or reports its own (equivalent)
+			// error.
 			if ctxErr := contextErr(tx.Statement.Context); ctxErr != nil {
 				return scanErr.err
 			}
-			p.disabled.Store(true)
+			p.recordScanFailure(scanErr.err, columns)
 			return tx.First(dest).Error
 		}
 		return err
@@ -237,6 +357,32 @@ func planFor(sch *schema.Schema) *plan {
 		return p
 	}
 	return nil
+}
+
+// likelyTouchesPoisoned reports whether executing stmt against sch could
+// touch a currently-poisoned column, without running the query. This lets
+// Find/First skip straight to the GORM fallback — as the old whole-plan
+// disable did — when nothing would survive the fast path anyway, instead of
+// paying for a query that anyPoisoned would just reject afterward.
+func (p *plan) likelyTouchesPoisoned(stmt *gorm.Statement, sch *schema.Schema) bool {
+	if p.poisonCount.Load() <= 0 {
+		return false
+	}
+	if len(stmt.Selects) == 0 {
+		// No explicit selection: GORM selects every schema column, so a
+		// poisoned column (there is at least one) is definitely included.
+		return true
+	}
+	for _, sel := range stmt.Selects {
+		dbName := sel
+		if field, ok := sch.FieldsByName[sel]; ok {
+			dbName = field.DBName
+		}
+		if p.isPoisoned(dbName) {
+			return true
+		}
+	}
+	return false
 }
 
 func buildPlan(sch *schema.Schema) *plan {
@@ -466,13 +612,9 @@ func (p *plan) releaseBindingSet(b *bindingSet) {
 	p.bindings.Put(b)
 }
 
-func scanRows(ctx context.Context, rows *sql.Rows, p *plan, slice reflect.Value, elemType reflect.Type) (reflect.Value, error) {
+func scanRows(ctx context.Context, rows *sql.Rows, p *plan, slice reflect.Value, elemType reflect.Type, columns []string) (reflect.Value, error) {
 	if ctx == nil {
 		ctx = context.Background()
-	}
-	columns, err := rows.Columns()
-	if err != nil {
-		return reflect.Value{}, err
 	}
 
 	bindings := p.acquireBindingSet(columns)
@@ -505,13 +647,9 @@ func scanRows(ctx context.Context, rows *sql.Rows, p *plan, slice reflect.Value,
 // scanFirstRow scans at most one row into elem (an addressable struct value),
 // reporting whether a row was present. It mirrors gorm.First: the query already
 // carries LIMIT 1, so only the leading row is consumed.
-func scanFirstRow(ctx context.Context, rows *sql.Rows, p *plan, elem reflect.Value) (bool, error) {
+func scanFirstRow(ctx context.Context, rows *sql.Rows, p *plan, elem reflect.Value, columns []string) (bool, error) {
 	if ctx == nil {
 		ctx = context.Background()
-	}
-	columns, err := rows.Columns()
-	if err != nil {
-		return false, err
 	}
 
 	bindings := p.acquireBindingSet(columns)

--- a/internal/fastscan/fastscan_test.go
+++ b/internal/fastscan/fastscan_test.go
@@ -527,21 +527,38 @@ func TestFirstNonStructDestFallsBack(t *testing.T) {
 	}
 }
 
-func TestScanErrorPoisonsPlanAndFallsBack(t *testing.T) {
+// gadgetPlan runs a fresh Find against the gadgets table (created by the
+// caller) so the schema gets parsed and its plan built, then returns the plan.
+func gadgetPlan(t *testing.T, db *gorm.DB) *plan {
+	t.Helper()
+	stmt := db.Session(&gorm.Session{}).Model(&Gadget{}).Statement
+	if parseErr := stmt.Parse(&Gadget{}); parseErr != nil {
+		t.Fatalf("parse: %v", parseErr)
+	}
+	p := planFor(stmt.Schema)
+	if p == nil {
+		t.Fatal("expected an eligible plan for Gadget")
+	}
+	return p
+}
+
+type Gadget struct {
+	ID     uint `gorm:"primaryKey"`
+	Amount int
+	Name   string
+}
+
+func TestScanErrorPoisonsColumnAndFallsBack(t *testing.T) {
 	db := openDB(t)
-	if err := db.Exec("CREATE TABLE gadgets (id integer primary key, amount integer)").Error; err != nil {
+	if err := db.Exec("CREATE TABLE gadgets (id integer primary key, amount integer, name text)").Error; err != nil {
 		t.Fatalf("create table: %v", err)
 	}
 	// SQLite's flexible typing lets TEXT live in an INTEGER column. The fast
 	// path's sql.NullInt64 rejects it; GORM Find reports its own conversion
-	// error. Either way the caller sees an error, and the plan is disabled.
-	if err := db.Exec("INSERT INTO gadgets (id, amount) VALUES (1, 'not-a-number')").Error; err != nil {
+	// error. Either way the caller sees an error, and only the offending
+	// column ("amount") is poisoned.
+	if err := db.Exec("INSERT INTO gadgets (id, amount, name) VALUES (1, 'not-a-number', 'widget')").Error; err != nil {
 		t.Fatalf("insert: %v", err)
-	}
-
-	type Gadget struct {
-		ID     uint `gorm:"primaryKey"`
-		Amount int
 	}
 
 	var results []Gadget
@@ -553,16 +570,102 @@ func TestScanErrorPoisonsPlanAndFallsBack(t *testing.T) {
 		t.Logf("conversion error: %v", err)
 	}
 
+	p := gadgetPlan(t, db)
+	if !p.isPoisoned("amount") {
+		t.Error("amount column was not poisoned after a scan error")
+	}
+	if p.isPoisoned("id") || p.isPoisoned("name") {
+		t.Error("poisoning a scan error should not affect unrelated columns")
+	}
+
+	// A query that doesn't touch the poisoned column should still take the
+	// fast path and succeed.
+	var partial []Gadget
+	if err := Find(db.Table("gadgets").Model(&Gadget{}).Select("id", "name"), &partial); err != nil {
+		t.Fatalf("Find selecting only healthy columns: %v", err)
+	}
+	if len(partial) != 1 || partial[0].Name != "widget" {
+		t.Fatalf("unexpected result for healthy-column select: %+v", partial)
+	}
+
+	// A query that doesn't restrict columns still includes the poisoned one.
+	// It should skip straight to the GORM fallback (not attempt — and fail —
+	// the fast scan again) and surface GORM's own equivalent conversion error.
+	var full []Gadget
+	if err := Find(db.Table("gadgets").Model(&Gadget{}), &full); err == nil {
+		t.Fatal("expected the fallback to surface GORM's own conversion error for the still-poisoned column")
+	}
+}
+
+func TestPoisonExpiresAfterRetryWindow(t *testing.T) {
+	original := poisonRetryWindow
+	poisonRetryWindow = 10 * time.Millisecond
+	defer func() { poisonRetryWindow = original }()
+
+	db := openDB(t)
+	if err := db.Exec("CREATE TABLE gadgets (id integer primary key, amount integer, name text)").Error; err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	p := gadgetPlan(t, db)
+	p.poisonColumn("amount")
+	if !p.isPoisoned("amount") {
+		t.Fatal("expected amount to be poisoned immediately after poisoning")
+	}
+	if p.poisonCount.Load() != 1 {
+		t.Fatalf("poisonCount = %d, want 1", p.poisonCount.Load())
+	}
+
+	time.Sleep(2 * poisonRetryWindow)
+	if p.isPoisoned("amount") {
+		t.Error("expected amount to no longer be poisoned after the retry window elapsed")
+	}
+	if p.poisonCount.Load() != 0 {
+		t.Errorf("poisonCount = %d, want 0 after expiry", p.poisonCount.Load())
+	}
+}
+
+func TestRecordScanFailureFallsBackToPoisonAllForUnrecognizedError(t *testing.T) {
+	db := openDB(t)
+	if err := db.Exec("CREATE TABLE gadgets (id integer primary key, amount integer, name text)").Error; err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	p := gadgetPlan(t, db)
+
+	p.recordScanFailure(errors.New("some unrelated driver failure"), []string{"id", "amount", "name"})
+
+	for _, col := range []string{"id", "amount", "name"} {
+		if !p.isPoisoned(col) {
+			t.Errorf("expected column %q to be poisoned when the error can't be attributed to one column", col)
+		}
+	}
+}
+
+func TestLikelyTouchesPoisoned(t *testing.T) {
+	db := openDB(t)
+	if err := db.Exec("CREATE TABLE gadgets (id integer primary key, amount integer, name text)").Error; err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	p := gadgetPlan(t, db)
+	p.poisonColumn("amount")
+
 	stmt := db.Session(&gorm.Session{}).Model(&Gadget{}).Statement
 	if parseErr := stmt.Parse(&Gadget{}); parseErr != nil {
 		t.Fatalf("parse: %v", parseErr)
 	}
-	p := planFor(stmt.Schema)
-	if p == nil {
-		t.Fatal("expected an eligible plan for Gadget")
+
+	if !p.likelyTouchesPoisoned(stmt, stmt.Schema) {
+		t.Error("a query with no explicit Select should be treated as touching the poisoned column")
 	}
-	if !p.disabled.Load() {
-		t.Error("plan was not disabled after a scan error")
+
+	stmt.Selects = []string{"ID", "Name"}
+	if p.likelyTouchesPoisoned(stmt, stmt.Schema) {
+		t.Error("an explicit select excluding the poisoned column should not be flagged")
+	}
+
+	stmt.Selects = []string{"ID", "Amount"}
+	if !p.likelyTouchesPoisoned(stmt, stmt.Schema) {
+		t.Error("an explicit select including the poisoned column should be flagged")
 	}
 }
 


### PR DESCRIPTION
## Summary

A single scan error used to disable the whole fastscan plan for a schema permanently — one odd driver value (e.g. legacy TEXT in an INTEGER column, or a MySQL setup without `parseTime`) forfeited the fast path for the whole entity set for the life of the process.

This makes poisoning more precise, combining both options proposed in the issue:

- **Per-column poisoning**: on a scan error, identify the offending column from database/sql's `"Scan error on column index N"` wrapper and poison only that column. Queries whose `$select` doesn't touch the poisoned column keep using the fast path. If the offending column can't be identified, fall back to poisoning every column (same as the old whole-plan-disable, but still subject to the retry window below).
- **Retry-after-window**: a poisoned column expires after 30s, so a transient bad value — or one that no longer occurs — doesn't forfeit the fast path forever.

To avoid paying for two query executions on every request once something is poisoned, `Find`/`First` first do a cheap pre-check (`likelyTouchesPoisoned`) using the statement's explicit `Select` list — if there's no explicit selection (the common case), any active poison is assumed to be touched, matching the old behavior of skipping straight to the GORM fallback before ever running the query.

The worst-case invariant from #834 is unchanged: a query that still hits a poisoned column falls back to `db.Find`/`db.First`, exactly as before.

## Test plan
- [x] `TestScanErrorPoisonsColumnAndFallsBack` (replaces `TestScanErrorPoisonsPlanAndFallsBack`): a scan error poisons only the offending column; a `$select` excluding it still succeeds via the fast path; a full select still falls back and surfaces GORM's own equivalent error.
- [x] `TestPoisonExpiresAfterRetryWindow`: a poisoned column stops being poisoned after the window elapses.
- [x] `TestRecordScanFailureFallsBackToPoisonAllForUnrecognizedError`: an error that doesn't match the expected wrapper format poisons every column, conservatively.
- [x] `TestLikelyTouchesPoisoned`: the pre-query check correctly distinguishes explicit selects that do/don't touch a poisoned column, and treats no-selection queries as touching any active poison.
- [x] `go test ./internal/fastscan/... -race` and full suite (`go test ./...`) pass.
- [x] `golangci-lint run internal/fastscan/...` clean.

Fixes #839