### PR TITLE
perf(query): resolve $expand relationship constraints once at registration

### DIFF
--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -115,6 +115,13 @@ type PropertyMetadata struct {
 	Nullable     *bool  // Explicit nullable override (nil means use default behavior)
 	// Referential constraints for navigation properties
 	ReferentialConstraints map[string]string // Maps dependent property to principal property
+	// GormReferenceConstraints holds the belongs-to/has-one/has-many
+	// referential constraint(s) resolved from GORM's own relationship schema,
+	// for the common case where the gorm tag doesn't spell out
+	// foreignKey/references explicitly (so ReferentialConstraints is empty).
+	// Resolved once here, at metadata-analysis time, instead of re-parsing
+	// the GORM schema on every $expand request.
+	GormReferenceConstraints []GormReferenceConstraint
 	// Search properties
 	IsSearchable     bool    // True if this property should be considered in $search
 	SearchFuzziness  int     // Fuzziness level for search (default 1, meaning exact match)
@@ -579,6 +586,14 @@ func analyzeNavigationProperty(property *PropertyMetadata, field reflect.StructF
 			// Extract referential constraints from GORM tags (only for foreignKey/references)
 			if strings.Contains(gormTag, "foreignKey") || strings.Contains(gormTag, "references") {
 				property.ReferentialConstraints = extractReferentialConstraints(gormTag)
+			}
+
+			// The tag may not fully spell out the constraint (e.g. "references:"
+			// without "foreignKey:"), or may be absent for a convention-based
+			// relationship GORM itself still resolves by name. Ask GORM's own
+			// relationship schema once, here, so $expand doesn't need to.
+			if len(property.ReferentialConstraints) == 0 {
+				property.GormReferenceConstraints = resolveGormReferenceConstraints(property, ownerType)
 			}
 		} else if strings.Contains(gormTag, "embedded") {
 			// It's a complex type (embedded struct without foreign keys)
@@ -1679,6 +1694,78 @@ func getColumnNameFromProperty(prop *PropertyMetadata) string {
 	return toSnakeCase(prop.Name)
 }
 
+// gormSchemaCache backs GORM's own schema.Parse cache across every call in
+// this package, so a Go type's relationships are parsed once (the first time
+// any of its navigation properties needs them) rather than once per call.
+// GORM keys its cache by model type, so a single shared map is safe to reuse
+// across unrelated entities and self-referential relationships alike.
+var gormSchemaCache sync.Map
+
+// parsedGormSchema parses ownerType with GORM's own schema parser, reusing
+// gormSchemaCache instead of a throwaway cache store so repeated lookups for
+// the same type (e.g. multiple navigation properties on one entity) don't
+// reparse the schema.
+func parsedGormSchema(ownerType reflect.Type) (*gormschema.Schema, error) {
+	for ownerType.Kind() == reflect.Ptr {
+		ownerType = ownerType.Elem()
+	}
+	if ownerType.Kind() != reflect.Struct {
+		return nil, nil
+	}
+	return gormschema.Parse(reflect.New(ownerType).Interface(), &gormSchemaCache, gormschema.NamingStrategy{})
+}
+
+// GormReferenceConstraint is a single dependent/principal property pair
+// (with the dependent's resolved DB column) describing how a child row
+// references its parent, resolved from GORM's relationship schema.
+type GormReferenceConstraint struct {
+	DependentProperty string
+	DependentColumn   string
+	PrincipalProperty string
+}
+
+// resolveGormReferenceConstraints resolves a belongs-to/has-one/has-many
+// navigation property's referential constraint(s) from GORM's own
+// relationship schema — used when the gorm tag doesn't spell out
+// foreignKey/references explicitly, so extractReferentialConstraints found
+// nothing. This mirrors GORM's own relationship resolution (including its
+// naming conventions) rather than re-implementing it, and runs once here at
+// metadata-analysis time instead of on every $expand request.
+func resolveGormReferenceConstraints(property *PropertyMetadata, ownerType reflect.Type) []GormReferenceConstraint {
+	if property == nil || ownerType == nil || property.IsManyToMany {
+		return nil
+	}
+	sch, err := parsedGormSchema(ownerType)
+	if err != nil || sch == nil {
+		return nil
+	}
+	rel := sch.Relationships.Relations[property.FieldName]
+	if rel == nil {
+		return nil
+	}
+
+	constraints := make([]GormReferenceConstraint, 0, len(rel.References))
+	for _, ref := range rel.References {
+		if ref == nil || ref.PrimaryKey == nil || ref.ForeignKey == nil {
+			continue
+		}
+		constraint := GormReferenceConstraint{}
+		if ref.OwnPrimaryKey {
+			// has-one / has-many: target.ForeignKey = parent.PrimaryKey
+			constraint.DependentProperty = ref.ForeignKey.Name
+			constraint.DependentColumn = ref.ForeignKey.DBName
+			constraint.PrincipalProperty = ref.PrimaryKey.Name
+		} else {
+			// belongs-to: target.PrimaryKey = parent.ForeignKey
+			constraint.DependentProperty = ref.PrimaryKey.Name
+			constraint.DependentColumn = ref.PrimaryKey.DBName
+			constraint.PrincipalProperty = ref.ForeignKey.Name
+		}
+		constraints = append(constraints, constraint)
+	}
+	return constraints
+}
+
 // getForeignKeyColumnName computes the foreign key column name for a navigation property
 // This respects GORM foreignKey: tags and falls back to <navigation_property_name>_id convention
 // resolveManyToManyJoinInfo resolves the join/bridge table name and its foreign key
@@ -1697,14 +1784,8 @@ func resolveManyToManyJoinInfo(property *PropertyMetadata, ownerType reflect.Typ
 	if property == nil || ownerType == nil {
 		return
 	}
-	for ownerType.Kind() == reflect.Ptr {
-		ownerType = ownerType.Elem()
-	}
-	if ownerType.Kind() != reflect.Struct {
-		return
-	}
 
-	sch, err := gormschema.Parse(reflect.New(ownerType).Interface(), &sync.Map{}, gormschema.NamingStrategy{})
+	sch, err := parsedGormSchema(ownerType)
 	if err != nil || sch == nil {
 		return
 	}

--- a/internal/metadata/analyzer_test.go
+++ b/internal/metadata/analyzer_test.go
@@ -536,6 +536,67 @@ func TestNavigationPropertyWithReferentialConstraints(t *testing.T) {
 	}
 }
 
+// TestNavigationPropertyResolvesGormReferenceConstraintsOnceAtAnalysisTime
+// covers a gorm tag that names "references:" without "foreignKey:", so
+// extractReferentialConstraints (which requires foreignKey to be non-empty)
+// leaves ReferentialConstraints empty even though the field is a navigation
+// property. GORM itself still resolves the relationship (defaulting the
+// foreign key to the owner-type-name+ID convention), so
+// GormReferenceConstraints should be populated from GORM's own schema —
+// resolved here, once, at analysis time rather than by $expand per request.
+func TestNavigationPropertyResolvesGormReferenceConstraintsOnceAtAnalysisTime(t *testing.T) {
+	type User struct {
+		ID   int    `json:"id" odata:"key"`
+		Name string `json:"name"`
+	}
+
+	type Order struct {
+		ID         int   `json:"id" odata:"key"`
+		CustomerID int   `json:"customerId"`
+		Customer   *User `json:"customer" gorm:"references:ID"`
+	}
+
+	meta, err := AnalyzeEntity(Order{})
+	if err != nil {
+		t.Fatalf("AnalyzeEntity() error = %v", err)
+	}
+
+	var customerProp *PropertyMetadata
+	for i, prop := range meta.Properties {
+		if prop.Name == "Customer" {
+			customerProp = &meta.Properties[i]
+			break
+		}
+	}
+	if customerProp == nil {
+		t.Fatal("Customer navigation property not found")
+	}
+	if !customerProp.IsNavigationProp {
+		t.Fatal("Customer should be a navigation property")
+	}
+	if len(customerProp.ReferentialConstraints) != 0 {
+		t.Fatalf("expected tag-based ReferentialConstraints to stay empty (no foreignKey: in tag), got %v", customerProp.ReferentialConstraints)
+	}
+	if len(customerProp.GormReferenceConstraints) == 0 {
+		t.Fatal("expected GormReferenceConstraints to be resolved from GORM's own schema")
+	}
+
+	// Belongs-to: Order.CustomerID (principal, read off the parent Order row)
+	// references User.ID (dependent, matched against the target User table).
+	found := false
+	for _, c := range customerProp.GormReferenceConstraints {
+		if c.DependentProperty == "ID" && c.PrincipalProperty == "CustomerID" {
+			found = true
+			if c.DependentColumn != "id" {
+				t.Errorf("DependentColumn = %q, want %q", c.DependentColumn, "id")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected an ID -> CustomerID constraint, got %+v", customerProp.GormReferenceConstraints)
+	}
+}
+
 func TestAutoDetectNullability(t *testing.T) {
 	type TestEntity struct {
 		ID                int     `json:"id" odata:"key"`

--- a/internal/query/expand_per_parent.go
+++ b/internal/query/expand_per_parent.go
@@ -5,12 +5,10 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/nlstn/go-odata/internal/fastscan"
 	"github.com/nlstn/go-odata/internal/metadata"
 	"gorm.io/gorm"
-	gormschema "gorm.io/gorm/schema"
 )
 
 // ApplyPerParentExpand applies $expand options with $top/$skip for collection navigation properties per parent.
@@ -227,55 +225,24 @@ func resolveParentReferenceProperty(navProp *metadata.PropertyMetadata, entityMe
 		return expandCompositeConstraints(navProp.ReferentialConstraints, entityMetadata, targetMetadata)
 	}
 
-	// GORM's relationship schema is the source of truth for relationship
-	// direction when tags do not describe enough information. Most navigation
-	// fields expose foreignKey/references, however, and resolving those against
-	// our already-built metadata avoids reparsing GORM schema on every request.
-	if constraints := gormRelationshipConstraints(navProp, entityMetadata); len(constraints) > 0 {
+	// GormReferenceConstraints is resolved once, at metadata-analysis time,
+	// from GORM's own relationship schema for the case where the gorm tag
+	// doesn't fully describe the constraint (see
+	// metadata.resolveGormReferenceConstraints). Using it here means $expand
+	// never needs to parse the GORM schema itself.
+	if len(navProp.GormReferenceConstraints) > 0 {
+		constraints := make([]parentReferenceConstraint, 0, len(navProp.GormReferenceConstraints))
+		for _, c := range navProp.GormReferenceConstraints {
+			constraints = append(constraints, parentReferenceConstraint{
+				dependentProperty: c.DependentProperty,
+				dependentColumn:   c.DependentColumn,
+				principalProperty: c.PrincipalProperty,
+			})
+		}
 		return constraints
 	}
 
 	return fallbackReferenceConstraints(navProp, entityMetadata, targetMetadata)
-}
-
-func gormRelationshipConstraints(navProp *metadata.PropertyMetadata, entityMetadata *metadata.EntityMetadata) []parentReferenceConstraint {
-	ownerType := entityMetadata.EntityType
-	for ownerType.Kind() == reflect.Ptr {
-		ownerType = ownerType.Elem()
-	}
-	if ownerType.Kind() != reflect.Struct || navProp.IsManyToMany {
-		return nil
-	}
-
-	sch, err := gormschema.Parse(reflect.New(ownerType).Interface(), &sync.Map{}, gormschema.NamingStrategy{})
-	if err != nil || sch == nil {
-		return nil
-	}
-	rel := sch.Relationships.Relations[navProp.FieldName]
-	if rel == nil {
-		return nil
-	}
-
-	constraints := make([]parentReferenceConstraint, 0, len(rel.References))
-	for _, ref := range rel.References {
-		if ref == nil || ref.PrimaryKey == nil || ref.ForeignKey == nil {
-			continue
-		}
-		constraint := parentReferenceConstraint{}
-		if ref.OwnPrimaryKey {
-			// has-one / has-many: target.ForeignKey = parent.PrimaryKey
-			constraint.dependentProperty = ref.ForeignKey.Name
-			constraint.dependentColumn = ref.ForeignKey.DBName
-			constraint.principalProperty = ref.PrimaryKey.Name
-		} else {
-			// belongs-to: target.PrimaryKey = parent.ForeignKey
-			constraint.dependentProperty = ref.PrimaryKey.Name
-			constraint.dependentColumn = ref.PrimaryKey.DBName
-			constraint.principalProperty = ref.ForeignKey.Name
-		}
-		constraints = append(constraints, constraint)
-	}
-	return constraints
 }
 
 func expandCompositeConstraints(constraints map[string]string, entityMetadata *metadata.EntityMetadata, targetMetadata *metadata.EntityMetadata) []parentReferenceConstraint {

--- a/internal/query/expand_per_parent_test.go
+++ b/internal/query/expand_per_parent_test.go
@@ -23,6 +23,20 @@ type perParentTag struct {
 	ID uint `gorm:"primaryKey" odata:"key"`
 }
 
+type perParentCustomer struct {
+	ID uint `gorm:"primaryKey" odata:"key"`
+}
+
+// perParentOrder's Customer tag names "references:" without "foreignKey:", so
+// extractReferentialConstraints leaves ReferentialConstraints empty and
+// resolution falls to GormReferenceConstraints (see analyzer.go), resolved
+// from GORM's own relationship schema at metadata-analysis time.
+type perParentOrder struct {
+	ID         uint `gorm:"primaryKey" odata:"key"`
+	CustomerID uint
+	Customer   *perParentCustomer `gorm:"references:ID"`
+}
+
 type perParentProduct struct {
 	ID   uint           `gorm:"primaryKey" odata:"key"`
 	Tags []perParentTag `gorm:"many2many:per_parent_product_tags"`
@@ -111,5 +125,52 @@ func TestApplyPerParentExpandLoadsManyToManyRelationships(t *testing.T) {
 	}
 	if got := len(products[0].Tags); got != 2 {
 		t.Fatalf("Tags length = %d, want 2", got)
+	}
+}
+
+func TestApplyPerParentExpandUsesGormReferenceConstraintsWithoutForeignKeyTag(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&perParentOrder{}, &perParentCustomer{}); err != nil {
+		t.Fatal(err)
+	}
+	db.Create(&perParentCustomer{ID: 1})
+	db.Create(&perParentOrder{ID: 1, CustomerID: 1})
+
+	orderMeta, err := metadata.AnalyzeEntity(perParentOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	customerMeta, err := metadata.AnalyzeEntity(perParentCustomer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := map[string]*metadata.EntityMetadata{
+		orderMeta.EntitySetName:    orderMeta,
+		customerMeta.EntitySetName: customerMeta,
+	}
+	orderMeta.SetEntitiesRegistry(registry)
+	customerMeta.SetEntitiesRegistry(registry)
+
+	customerProp := orderMeta.FindProperty("Customer")
+	if customerProp == nil {
+		t.Fatal("Customer navigation property not found")
+	}
+	if len(customerProp.ReferentialConstraints) != 0 {
+		t.Fatalf("expected tag-based ReferentialConstraints to stay empty, got %v", customerProp.ReferentialConstraints)
+	}
+	if len(customerProp.GormReferenceConstraints) == 0 {
+		t.Fatal("expected GormReferenceConstraints to be resolved from GORM's schema")
+	}
+
+	var orders []perParentOrder
+	db.Find(&orders)
+	if err := ApplyPerParentExpand(db, &orders, []ExpandOption{{NavigationProperty: "Customer"}}, orderMeta); err != nil {
+		t.Fatal(err)
+	}
+	if orders[0].Customer == nil || orders[0].Customer.ID != 1 {
+		t.Fatalf("Customer = %#v, want customer 1", orders[0].Customer)
 	}
 }


### PR DESCRIPTION
## Summary

Every `$expand` request re-parsed the owning entity's full GORM schema (`gormschema.Parse`) whenever a navigation property's referential constraint couldn't be fully derived from its gorm tag alone (e.g. a tag naming `references:` without `foreignKey:`, relying on GORM's own naming-convention resolution). The call passed a throwaway `&sync.Map{}` cache store, so GORM's own internal schema cache never actually cached anything across requests.

This moves that resolution to metadata-analysis time (entity registration), where it belongs:

- `analyzeNavigationProperty` now resolves the constraint from GORM's relationship schema once, via a new shared, cached `parsedGormSchema` helper, and stores the result on `PropertyMetadata.GormReferenceConstraints`.
- `$expand`'s `resolveParentReferenceProperty` reads that precomputed field directly instead of calling `gormschema.Parse` on the request path.
- `resolveManyToManyJoinInfo` (which had the identical throwaway-cache pattern for many-to-many join-table resolution) now reuses the same shared cache too.

Existing `$expand` behavior (has-many, belongs-to, many-to-many, nested) is unchanged — the constraint values are computed with the exact same logic as before, just relocated and cached.

## Test plan
- [x] `TestNavigationPropertyResolvesGormReferenceConstraintsOnceAtAnalysisTime` (new, `internal/metadata`): a `references:`-only tag (no `foreignKey:`) resolves `GormReferenceConstraints` from GORM's schema at analysis time.
- [x] `TestApplyPerParentExpandUsesGormReferenceConstraintsWithoutForeignKeyTag` (new, `internal/query`): end-to-end `$expand` load using that same tag pattern returns the correct related entity.
- [x] Existing `TestApplyPerParentExpandLoadsDirectRelationships` / `TestApplyPerParentExpandLoadsManyToManyRelationships` still pass, confirming has-many/belongs-to/many-to-many `$expand` is unchanged.
- [x] `go test ./... -race` (affected packages) and full suite pass.
- [x] `golangci-lint run` on touched packages shows no new findings.

Fixes #862