### PR TITLE
perf(cache): normalize snapshot scalars once, not per-comparison per-request

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -29,11 +29,12 @@ import (
 //   - Manual: call Invalidate() after any write operation to force a refresh on
 //     the next read.
 type EntityCache struct {
-	refreshMu  sync.Mutex // serializes refreshes to prevent a thundering herd
-	snap       atomic.Pointer[Snapshot]
-	ttl        time.Duration
-	entityType reflect.Type
-	keyFn      KeyFunc
+	refreshMu   sync.Mutex // serializes refreshes to prevent a thundering herd
+	snap        atomic.Pointer[Snapshot]
+	ttl         time.Duration
+	entityType  reflect.Type
+	keyFn       KeyFunc
+	normalizeFn NormalizeFunc
 }
 
 // KeyFunc derives the canonical string key of an entity. The argument is a
@@ -42,18 +43,30 @@ type EntityCache struct {
 // that performs key lookups, so that Snapshot.Lookup can find the entity.
 type KeyFunc func(entity reflect.Value) string
 
+// NormalizeFunc precomputes comparison-ready values for one entity, e.g. one
+// slot per filterable/sortable property, indexed however the caller's own
+// property lookup agrees to. It runs once per entity when a snapshot is
+// built (Refresh), not on every comparison of every request, so callers that
+// otherwise re-derive and re-box the same values via reflection on each
+// filter/sort comparison can instead read them straight from the snapshot.
+type NormalizeFunc func(entity reflect.Value) []interface{}
+
 // Snapshot is an immutable view of the cached dataset. It is safe for concurrent
 // reads and is never modified after New/Refresh publishes it.
 type Snapshot struct {
-	entities  reflect.Value  // []T, treated as read-only after construction
-	byKey     map[string]int // canonical key -> index into entities
-	expiresAt time.Time
+	entities   reflect.Value   // []T, treated as read-only after construction
+	byKey      map[string]int  // canonical key -> index into entities
+	normalized [][]interface{} // parallel to entities; nil if no NormalizeFunc was configured
+	expiresAt  time.Time
 }
 
 // New creates a new EntityCache for the given entity type and TTL.
 // entityType should be the non-pointer struct type of the entity. keyFn derives
-// the canonical key used for O(1) key lookups and must not be nil.
-func New(entityType reflect.Type, ttl time.Duration, keyFn KeyFunc) (*EntityCache, error) {
+// the canonical key used for O(1) key lookups and must not be nil. normalizeFn
+// is optional (nil disables precomputed normalization); when set, its output
+// for every entity is precomputed once per Refresh and exposed via
+// Snapshot.Normalized.
+func New(entityType reflect.Type, ttl time.Duration, keyFn KeyFunc, normalizeFn NormalizeFunc) (*EntityCache, error) {
 	if entityType == nil {
 		return nil, fmt.Errorf("entityType must not be nil")
 	}
@@ -65,9 +78,10 @@ func New(entityType reflect.Type, ttl time.Duration, keyFn KeyFunc) (*EntityCach
 	}
 
 	return &EntityCache{
-		ttl:        ttl,
-		entityType: entityType,
-		keyFn:      keyFn,
+		ttl:         ttl,
+		entityType:  entityType,
+		keyFn:       keyFn,
+		normalizeFn: normalizeFn,
 	}, nil
 }
 
@@ -115,14 +129,23 @@ func (c *EntityCache) Refresh(sourceDB *gorm.DB) error {
 
 	entities := entitiesPtr.Elem()
 	byKey := make(map[string]int, entities.Len())
+	var normalized [][]interface{}
+	if c.normalizeFn != nil {
+		normalized = make([][]interface{}, entities.Len())
+	}
 	for i := 0; i < entities.Len(); i++ {
-		byKey[c.keyFn(entities.Index(i))] = i
+		entity := entities.Index(i)
+		byKey[c.keyFn(entity)] = i
+		if c.normalizeFn != nil {
+			normalized[i] = c.normalizeFn(entity)
+		}
 	}
 
 	c.snap.Store(&Snapshot{
-		entities:  entities,
-		byKey:     byKey,
-		expiresAt: time.Now().Add(c.ttl),
+		entities:   entities,
+		byKey:      byKey,
+		normalized: normalized,
+		expiresAt:  time.Now().Add(c.ttl),
 	})
 
 	return nil
@@ -148,4 +171,14 @@ func (s *Snapshot) Lookup(key string) (reflect.Value, bool) {
 		return reflect.Value{}, false
 	}
 	return s.entities.Index(i), true
+}
+
+// Normalized returns the precomputed comparison-ready values for the entity
+// at index i, as produced by the NormalizeFunc passed to New. It returns nil
+// if the cache was created without one.
+func (s *Snapshot) Normalized(i int) []interface{} {
+	if s.normalized == nil {
+		return nil
+	}
+	return s.normalized[i]
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -47,7 +47,7 @@ func newSourceDB(t *testing.T, widgets ...widget) *gorm.DB {
 
 func newWidgetCache(t *testing.T, ttl time.Duration) *EntityCache {
 	t.Helper()
-	c, err := New(reflect.TypeOf(widget{}), ttl, widgetKey)
+	c, err := New(reflect.TypeOf(widget{}), ttl, widgetKey, nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -55,13 +55,13 @@ func newWidgetCache(t *testing.T, ttl time.Duration) *EntityCache {
 }
 
 func TestNewValidation(t *testing.T) {
-	if _, err := New(nil, time.Minute, widgetKey); err == nil {
+	if _, err := New(nil, time.Minute, widgetKey, nil); err == nil {
 		t.Error("expected error for nil entityType")
 	}
-	if _, err := New(reflect.TypeOf(widget{}), 0, widgetKey); err == nil {
+	if _, err := New(reflect.TypeOf(widget{}), 0, widgetKey, nil); err == nil {
 		t.Error("expected error for non-positive ttl")
 	}
-	if _, err := New(reflect.TypeOf(widget{}), time.Minute, nil); err == nil {
+	if _, err := New(reflect.TypeOf(widget{}), time.Minute, nil, nil); err == nil {
 		t.Error("expected error for nil keyFn")
 	}
 }
@@ -102,6 +102,62 @@ func TestRefreshAndLookup(t *testing.T) {
 
 	if _, found := snap.Lookup("99"); found {
 		t.Fatal("did not expect to find widget 99")
+	}
+}
+
+// widgetNormalize precomputes [ID as float64, Name] per widget, mirroring
+// how handlers.EntityCacheNormalizeFunc reduces scalar properties to
+// comparison-ready values once per entity at refresh time.
+func widgetNormalize(v reflect.Value) []interface{} {
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return []interface{}{float64(v.FieldByName("ID").Uint()), v.FieldByName("Name").String()}
+}
+
+func TestNormalizedIsPrecomputedPerEntity(t *testing.T) {
+	db := newSourceDB(t,
+		widget{ID: 1, Name: "a"},
+		widget{ID: 2, Name: "b"},
+	)
+	c, err := New(reflect.TypeOf(widget{}), time.Minute, widgetKey, widgetNormalize)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := c.Refresh(db); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	snap, ok := c.Current()
+	if !ok {
+		t.Fatal("expected a current snapshot")
+	}
+
+	for i := 0; i < snap.Len(); i++ {
+		entity := snap.At(i)
+		norm := snap.Normalized(i)
+		if norm == nil {
+			t.Fatalf("Normalized(%d) = nil, want precomputed values", i)
+		}
+		wantID := float64(entity.FieldByName("ID").Uint())
+		wantName := entity.FieldByName("Name").String()
+		if norm[0] != wantID || norm[1] != wantName {
+			t.Errorf("Normalized(%d) = %v, want [%v %v]", i, norm, wantID, wantName)
+		}
+	}
+}
+
+func TestNormalizedIsNilWithoutNormalizeFunc(t *testing.T) {
+	db := newSourceDB(t, widget{ID: 1, Name: "a"})
+	c := newWidgetCache(t, time.Minute)
+	if err := c.Refresh(db); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	snap, ok := c.Current()
+	if !ok {
+		t.Fatal("expected a current snapshot")
+	}
+	if got := snap.Normalized(0); got != nil {
+		t.Errorf("Normalized(0) = %v, want nil when no NormalizeFunc was configured", got)
 	}
 }
 

--- a/internal/handlers/entity_cache.go
+++ b/internal/handlers/entity_cache.go
@@ -41,6 +41,35 @@ func EntityCacheKeyFunc(entityMeta *metadata.EntityMetadata) cache.KeyFunc {
 	}
 }
 
+// EntityCacheNormalizeFunc returns a cache.NormalizeFunc that precomputes,
+// once per entity when a snapshot is built (or rebuilt on refresh), the
+// comparison-ready value of every scalar property the in-memory filter/sort
+// evaluator can compare (see isCacheComparableType). Each entity's result
+// slice is indexed by that property's position in entityMeta.Properties,
+// matching resolveScalarPropertyIndex, so a filter/sort comparison reads a
+// precomputed value directly out of the snapshot instead of re-deriving and
+// re-boxing it via reflection on every comparison of every request.
+func EntityCacheNormalizeFunc(entityMeta *metadata.EntityMetadata) cache.NormalizeFunc {
+	props := entityMeta.Properties
+	return func(entity reflect.Value) []interface{} {
+		for entity.Kind() == reflect.Ptr {
+			if entity.IsNil() {
+				return nil
+			}
+			entity = entity.Elem()
+		}
+		norm := make([]interface{}, len(props))
+		for i := range props {
+			p := &props[i]
+			if p.IsNavigationProp || p.IsComplexType || p.IsEnum || !isCacheComparableType(p.Type) {
+				continue
+			}
+			norm[i] = normalizeCacheScalar(entityFieldValue(entity, p))
+		}
+		return norm
+	}
+}
+
 // canonicalKeyFromValues builds the canonical key string from a parsed key-value
 // map (keyed by JSON/OData property name, as produced by parseEntityKeyValues).
 // It returns false when a key property is missing from the map.
@@ -118,8 +147,18 @@ func (h *EntityHandler) cacheSnapshot(ctx context.Context) (*cache.Snapshot, boo
 // faithfully. Navigation properties, complex types, enums, and non-scalar Go
 // kinds (time.Time, []byte, …) return false so the query falls back to SQL.
 func (h *EntityHandler) resolveScalarProperty(name string) (*metadata.PropertyMetadata, bool) {
+	_, prop, ok := h.resolveScalarPropertyIndex(name)
+	return prop, ok
+}
+
+// resolveScalarPropertyIndex is resolveScalarProperty's index-returning form.
+// The index is the property's position in h.metadata.Properties, which is
+// also how EntityCacheNormalizeFunc indexes its precomputed values — so
+// filter/sort preparation (done once per query) can resolve a property name
+// once and every subsequent per-entity comparison is a plain slice index.
+func (h *EntityHandler) resolveScalarPropertyIndex(name string) (int, *metadata.PropertyMetadata, bool) {
 	if name == "" || strings.Contains(name, "/") {
-		return nil, false
+		return 0, nil, false
 	}
 	for i := range h.metadata.Properties {
 		p := &h.metadata.Properties[i]
@@ -128,12 +167,12 @@ func (h *EntityHandler) resolveScalarProperty(name string) (*metadata.PropertyMe
 		}
 		if strings.EqualFold(p.JsonName, name) || strings.EqualFold(p.Name, name) {
 			if isCacheComparableType(p.Type) {
-				return p, true
+				return i, p, true
 			}
-			return nil, false
+			return 0, nil, false
 		}
 	}
-	return nil, false
+	return 0, nil, false
 }
 
 // isCacheComparableType reports whether values of t can be compared by the
@@ -157,7 +196,7 @@ func isCacheComparableType(t reflect.Type) bool {
 
 // entityFieldValue returns the value of prop on entity, dereferencing pointers.
 // A nil pointer field yields a nil interface.
-func (h *EntityHandler) entityFieldValue(entity reflect.Value, prop *metadata.PropertyMetadata) interface{} {
+func entityFieldValue(entity reflect.Value, prop *metadata.PropertyMetadata) interface{} {
 	for entity.Kind() == reflect.Ptr {
 		if entity.IsNil() {
 			return nil
@@ -258,57 +297,106 @@ func underlyingKind(t reflect.Type) reflect.Kind {
 	return t.Kind()
 }
 
-// evalEntityFilter evaluates a supported filter expression against a single
-// entity. It assumes filterSupported(expr) already returned true.
-func (h *EntityHandler) evalEntityFilter(entity reflect.Value, expr *query.FilterExpression) bool {
+// preparedFilterNode is a query.FilterExpression with its property lookup and
+// literal value(s) already resolved: the property name search
+// (resolveScalarPropertyIndex) and normalizeCacheScalar(expr.Value) both run
+// once here, in prepareFilter, rather than being repeated for every entity
+// evalPreparedFilter is asked to test. Evaluating an entity against a
+// prepared tree is then plain array indexing and comparisons — no
+// reflection or re-boxing.
+type preparedFilterNode struct {
+	left, right *preparedFilterNode
+	logical     query.LogicalOperator
+	isNot       bool
+
+	// Leaf fields (left == nil && right == nil):
+	propIndex int
+	operator  query.FilterOperator
+	value     interface{}   // normalizeCacheScalar(expr.Value), precomputed once
+	values    []interface{} // OpIn only: each element pre-normalized once
+}
+
+// prepareFilter resolves expr into a preparedFilterNode once per query. It
+// assumes filterSupported(expr) already returned true, so every property and
+// operator here is one evalPreparedFilter can evaluate.
+func (h *EntityHandler) prepareFilter(expr *query.FilterExpression) *preparedFilterNode {
 	if expr == nil {
-		return true
+		return nil
 	}
 
 	if expr.Left != nil && expr.Right != nil {
-		left := h.evalEntityFilter(entity, expr.Left)
-		right := h.evalEntityFilter(entity, expr.Right)
+		return &preparedFilterNode{
+			left:    h.prepareFilter(expr.Left),
+			right:   h.prepareFilter(expr.Right),
+			logical: expr.Logical,
+			isNot:   expr.IsNot,
+		}
+	}
+
+	idx, _, ok := h.resolveScalarPropertyIndex(expr.Property)
+	if !ok {
+		// filterSupported already guarantees this is resolvable; treat an
+		// unexpected miss as "matches nothing" rather than panicking.
+		return &preparedFilterNode{propIndex: -1, operator: expr.Operator, isNot: expr.IsNot}
+	}
+	node := &preparedFilterNode{propIndex: idx, operator: expr.Operator, isNot: expr.IsNot}
+	if expr.Operator == query.OpIn {
+		if values, ok := expr.Value.([]interface{}); ok {
+			node.values = make([]interface{}, len(values))
+			for i, v := range values {
+				node.values[i] = normalizeCacheScalar(v)
+			}
+		}
+		return node
+	}
+	node.value = normalizeCacheScalar(expr.Value)
+	return node
+}
+
+// evalPreparedFilter evaluates a prepared filter tree against one entity's
+// precomputed comparison values (see EntityCacheNormalizeFunc), with no
+// reflection or normalization on the hot path.
+func evalPreparedFilter(norm []interface{}, node *preparedFilterNode) bool {
+	if node == nil {
+		return true
+	}
+
+	if node.left != nil && node.right != nil {
+		left := evalPreparedFilter(norm, node.left)
+		right := evalPreparedFilter(norm, node.right)
 		var result bool
-		switch expr.Logical {
+		switch node.logical {
 		case query.LogicalAnd:
 			result = left && right
 		case query.LogicalOr:
 			result = left || right
 		}
-		if expr.IsNot {
+		if node.isNot {
 			return !result
 		}
 		return result
 	}
 
-	prop, ok := h.resolveScalarProperty(expr.Property)
-	if !ok {
+	if node.propIndex < 0 {
 		return false
 	}
-	left := h.entityFieldValue(entity, prop)
+	left := norm[node.propIndex]
 
-	result := h.evalLeafComparison(left, expr.Operator, expr.Value)
-	if expr.IsNot {
+	var result bool
+	if node.operator == query.OpIn {
+		for _, v := range node.values {
+			if evaluateFilterComparison(left, query.OpEqual, v) {
+				result = true
+				break
+			}
+		}
+	} else {
+		result = evaluateFilterComparison(left, node.operator, node.value)
+	}
+	if node.isNot {
 		return !result
 	}
 	return result
-}
-
-func (h *EntityHandler) evalLeafComparison(left interface{}, op query.FilterOperator, right interface{}) bool {
-	if op == query.OpIn {
-		values, ok := right.([]interface{})
-		if !ok {
-			return false
-		}
-		normLeft := normalizeCacheScalar(left)
-		for _, item := range values {
-			if evaluateFilterComparison(normLeft, query.OpEqual, normalizeCacheScalar(item)) {
-				return true
-			}
-		}
-		return false
-	}
-	return evaluateFilterComparison(normalizeCacheScalar(left), op, normalizeCacheScalar(right))
 }
 
 // snapshotSupportsCollection reports whether a collection query can be served
@@ -363,24 +451,53 @@ func (h *EntityHandler) defaultKeyOrderBy() []query.OrderByItem {
 	return items
 }
 
-// sortEntityValues sorts copies in place by the given $orderby items.
-func (h *EntityHandler) sortEntityValues(values []reflect.Value, orderBy []query.OrderByItem) {
-	if len(orderBy) == 0 || len(values) < 2 {
+// preparedOrderByItem is a query.OrderByItem with its property lookup already
+// resolved, once per query, instead of on every sort comparison.
+type preparedOrderByItem struct {
+	propIndex  int
+	descending bool
+}
+
+// prepareOrderBy resolves orderBy into preparedOrderByItems once per query.
+// Items whose property can't be resolved are skipped, matching
+// resolveScalarProperty's contract (snapshotSupportsCollection already
+// guarantees every item here is resolvable).
+func (h *EntityHandler) prepareOrderBy(orderBy []query.OrderByItem) []preparedOrderByItem {
+	prepared := make([]preparedOrderByItem, 0, len(orderBy))
+	for _, item := range orderBy {
+		idx, _, ok := h.resolveScalarPropertyIndex(item.Property)
+		if !ok {
+			continue
+		}
+		prepared = append(prepared, preparedOrderByItem{propIndex: idx, descending: item.Descending})
+	}
+	return prepared
+}
+
+// snapshotMatch pairs a mutable copy of one matching entity (mutable because
+// downstream $expand populates navigation fields on it) with its precomputed
+// comparison values, shared directly from the snapshot: sorting never needs
+// to re-derive or re-normalize anything from the entity itself.
+type snapshotMatch struct {
+	entity reflect.Value
+	norm   []interface{}
+}
+
+// sortMatches sorts matches in place by the given prepared $orderby items,
+// comparing precomputed values instead of re-deriving them from the entity.
+func sortMatches(matches []snapshotMatch, orderBy []preparedOrderByItem) {
+	if len(orderBy) == 0 || len(matches) < 2 {
 		return
 	}
-	sort.SliceStable(values, func(i, j int) bool {
+	sort.SliceStable(matches, func(i, j int) bool {
 		for _, item := range orderBy {
-			prop, ok := h.resolveScalarProperty(item.Property)
-			if !ok {
-				continue
-			}
-			lv := h.entityFieldValue(values[i], prop)
-			rv := h.entityFieldValue(values[j], prop)
-			cmp := compareMapValues(normalizeCacheScalar(lv), lv != nil, normalizeCacheScalar(rv), rv != nil)
+			lv := matches[i].norm[item.propIndex]
+			rv := matches[j].norm[item.propIndex]
+			cmp := compareMapValues(lv, lv != nil, rv, rv != nil)
 			if cmp == 0 {
 				continue
 			}
-			if item.Descending {
+			if item.descending {
 				return cmp > 0
 			}
 			return cmp < 0
@@ -393,18 +510,20 @@ func (h *EntityHandler) sortEntityValues(values []reflect.Value, orderBy []query
 // returning a *[]T (matching the pointer-to-slice shape the SQL path produces)
 // so downstream $expand/$select post-processing is identical.
 func (h *EntityHandler) queryCollectionSnapshot(snap *cache.Snapshot, queryOptions, modifiedOptions *query.QueryOptions) interface{} {
-	filter := queryOptions.Filter
+	prepared := h.prepareFilter(queryOptions.Filter)
 
-	matches := make([]reflect.Value, 0)
+	matches := make([]snapshotMatch, 0)
 	for i := 0; i < snap.Len(); i++ {
-		entity := snap.At(i)
-		if filter == nil || h.evalEntityFilter(entity, filter) {
+		norm := snap.Normalized(i)
+		if prepared == nil || evalPreparedFilter(norm, prepared) {
+			entity := snap.At(i)
 			// Copy the struct out of the snapshot's backing array so that
 			// downstream $expand (which populates navigation fields) never
-			// mutates the shared, immutable snapshot.
+			// mutates the shared, immutable snapshot. norm is read-only and
+			// safe to share as-is.
 			cp := reflect.New(h.metadata.EntityType).Elem()
 			cp.Set(entity)
-			matches = append(matches, cp)
+			matches = append(matches, snapshotMatch{entity: cp, norm: norm})
 		}
 	}
 
@@ -412,7 +531,7 @@ func (h *EntityHandler) queryCollectionSnapshot(snap *cache.Snapshot, queryOptio
 	if len(orderBy) == 0 {
 		orderBy = h.defaultKeyOrderBy()
 	}
-	h.sortEntityValues(matches, orderBy)
+	sortMatches(matches, h.prepareOrderBy(orderBy))
 
 	// Apply $skip then $top (modifiedOptions.Top is already top+1 so the caller
 	// can detect whether a next page exists).
@@ -439,8 +558,8 @@ func (h *EntityHandler) queryCollectionSnapshot(snap *cache.Snapshot, queryOptio
 
 	sliceType := reflect.SliceOf(h.metadata.EntityType)
 	out := reflect.MakeSlice(sliceType, len(matches), len(matches))
-	for i, e := range matches {
-		out.Index(i).Set(e)
+	for i, m := range matches {
+		out.Index(i).Set(m.entity)
 	}
 	resultsPtr := reflect.New(sliceType)
 	resultsPtr.Elem().Set(out)
@@ -477,9 +596,10 @@ func (h *EntityHandler) countSnapshot(snap *cache.Snapshot, filter *query.Filter
 	if filter == nil {
 		return int64(snap.Len())
 	}
+	prepared := h.prepareFilter(filter)
 	var count int64
 	for i := 0; i < snap.Len(); i++ {
-		if h.evalEntityFilter(snap.At(i), filter) {
+		if evalPreparedFilter(snap.Normalized(i), prepared) {
 			count++
 		}
 	}

--- a/odata.go
+++ b/odata.go
@@ -1128,7 +1128,7 @@ func (s *Service) configureEntityCache(entityMeta *metadata.EntityMetadata, hand
 		ttl = 5 * time.Minute
 	}
 
-	entityCache, err := cache.New(entityMeta.EntityType, ttl, handlers.EntityCacheKeyFunc(entityMeta))
+	entityCache, err := cache.New(entityMeta.EntityType, ttl, handlers.EntityCacheKeyFunc(entityMeta), handlers.EntityCacheNormalizeFunc(entityMeta))
 	if err != nil {
 		return fmt.Errorf("failed to create entity cache for '%s': %w", entityMeta.EntitySetName, err)
 	}

--- a/test/cache_snapshot_test.go
+++ b/test/cache_snapshot_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 // TestCacheSnapshot_FallbackForUnsupportedFilter verifies that a query using a
@@ -135,6 +137,122 @@ func TestCacheSnapshot_CountFromCache(t *testing.T) {
 	}
 	if n, _ := count.(float64); n != 2 {
 		t.Fatalf("expected count 2, got %v", count)
+	}
+}
+
+// TestCacheSnapshot_AndOrFilterFromCache verifies a nested AND/OR filter is
+// evaluated correctly from the in-memory snapshot's prepared filter tree.
+func TestCacheSnapshot_AndOrFilterFromCache(t *testing.T) {
+	_, service := setupCacheTestService(t, odata.EntityCacheConfig{
+		Level: odata.CacheLevelFull,
+		TTL:   time.Minute,
+	})
+
+	// (ID eq 1 or ID eq 3) and Name ne 'Clothing' -> only Electronics (ID 1).
+	req := httptest.NewRequest(http.MethodGet, "/CachedCategories?$filter=(ID%20eq%201%20or%20ID%20eq%203)%20and%20Name%20ne%20'Clothing'", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	values := decodeValues(t, w)
+	if len(values) != 1 {
+		t.Fatalf("expected 1 entity, got %d: %v", len(values), values)
+	}
+	if name, _ := values[0].(map[string]interface{})["Name"].(string); name != "Electronics" {
+		t.Fatalf("expected Electronics, got %q", name)
+	}
+}
+
+// TestCacheSnapshot_NotFilterFromCache verifies a negated leaf comparison is
+// evaluated correctly from the in-memory snapshot's prepared filter tree.
+func TestCacheSnapshot_NotFilterFromCache(t *testing.T) {
+	_, service := setupCacheTestService(t, odata.EntityCacheConfig{
+		Level: odata.CacheLevelFull,
+		TTL:   time.Minute,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/CachedCategories?$filter=not%20(Name%20eq%20'Books')&$orderby=Name", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	values := decodeValues(t, w)
+	if len(values) != 2 {
+		t.Fatalf("expected 2 entities, got %d: %v", len(values), values)
+	}
+	got := make([]string, len(values))
+	for i, v := range values {
+		got[i], _ = v.(map[string]interface{})["Name"].(string)
+	}
+	want := []string{"Clothing", "Electronics"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("not filter: expected %v, got %v", want, got)
+		}
+	}
+}
+
+// CachedRanking has a deliberately duplicated Group value so multi-key
+// $orderby exercises the tie-breaking second key (see sortMatches).
+type CachedRanking struct {
+	ID    uint   `json:"ID" gorm:"primaryKey" odata:"key"`
+	Group string `json:"Group"`
+	Score int    `json:"Score"`
+}
+
+// TestCacheSnapshot_MultiKeyOrderByTieBreak verifies that $orderby with more
+// than one property breaks ties using the later keys, from the in-memory
+// snapshot's precomputed, prepared orderby.
+func TestCacheSnapshot_MultiKeyOrderByTieBreak(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+	if err := db.AutoMigrate(&CachedRanking{}); err != nil {
+		t.Fatalf("failed to migrate database: %v", err)
+	}
+	rankings := []CachedRanking{
+		{ID: 1, Group: "A", Score: 10},
+		{ID: 2, Group: "A", Score: 30},
+		{ID: 3, Group: "B", Score: 20},
+	}
+	if err := db.Create(&rankings).Error; err != nil {
+		t.Fatalf("failed to seed data: %v", err)
+	}
+
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+	if err := service.RegisterEntity(&CachedRanking{}, odata.EntityCacheConfig{
+		Level: odata.CacheLevelFull,
+		TTL:   time.Minute,
+	}); err != nil {
+		t.Fatalf("failed to register entity: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/CachedRankings?$orderby=Group%20asc,Score%20desc", nil)
+	w := httptest.NewRecorder()
+	service.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	values := decodeValues(t, w)
+	if len(values) != 3 {
+		t.Fatalf("expected 3 entities, got %d: %v", len(values), values)
+	}
+	gotIDs := make([]float64, len(values))
+	for i, v := range values {
+		gotIDs[i], _ = v.(map[string]interface{})["ID"].(float64)
+	}
+	// Group A first (asc), Score 30 before 10 within group A (desc), then Group B.
+	want := []float64{2, 1, 3}
+	for i := range want {
+		if gotIDs[i] != want[i] {
+			t.Fatalf("multi-key orderby: expected IDs %v, got %v", want, gotIDs)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The lock-free entity-cache snapshot's in-memory filter/sort re-extracted and re-normalized every scalar property via reflection on every comparison of every entity on every request:
- `normalizeCacheScalar` boxes each reduced value into `interface{}` — the #1 app-code allocator in the `CachedFeatureFlags` profile cited in the issue.
- `resolveScalarProperty` linearly re-scanned the property list for every leaf of the filter tree, for every entity.

None of this depends on the request — the snapshot is immutable between rebuilds — so it's precomputed once instead:

- `cache.EntityCache`/`Snapshot` gain an optional `NormalizeFunc`, run once per entity when a snapshot is (re)built (`Refresh`), whose output is stored alongside each entity and exposed via `Snapshot.Normalized(i)`.
- `handlers.EntityCacheNormalizeFunc` builds that function from entity metadata, indexed by each property's position in `entityMetadata.Properties` (matching the new `resolveScalarPropertyIndex`).
- Filter and orderby are each "prepared" once per query (`prepareFilter`/`prepareOrderBy`): property name lookup and literal-value normalization happen once, producing a small tree/list of resolved indices. Evaluating an entity is then plain slice indexing and comparisons (`evalPreparedFilter`/`sortMatches`) — no reflection or boxing on the per-entity/per-comparison path.

Filter/sort results are unchanged, and the conservative DB fallback for filters/sorts the in-memory evaluator doesn't support (`filterSupported`) is untouched.

## Test plan
- [x] `internal/cache`: new `TestNormalizedIsPrecomputedPerEntity` / `TestNormalizedIsNilWithoutNormalizeFunc` cover the new `NormalizeFunc`/`Normalized` API.
- [x] `test/cache_snapshot_test.go`: new `TestCacheSnapshot_AndOrFilterFromCache`, `TestCacheSnapshot_NotFilterFromCache`, `TestCacheSnapshot_MultiKeyOrderByTieBreak` exercise the prepared-filter tree (AND/OR/NOT nesting) and prepared-orderby tie-breaking specifically through the cache path.
- [x] Existing cache integration tests (filter, `in`, orderby desc, count, concurrent reads, invalidation, TTL) all still pass unchanged.
- [x] `go test ./... -race` (affected packages) and full suite pass.
- [x] `golangci-lint run` on touched packages shows no new findings.

Fixes #866