### PR TITLE
perf(fastscan): cut two per-row allocations in the scan destination path

### DIFF
--- a/internal/fastscan/fastscan.go
+++ b/internal/fastscan/fastscan.go
@@ -215,7 +215,7 @@ func Find(db *gorm.DB, dest interface{}) error {
 		return tx.Find(dest).Error
 	}
 
-	result, err := scanRows(tx.Statement.Context, rows, p, sliceVal, elemType, columns)
+	result, err := scanRows(tx.Statement.Context, rows, p, sliceVal, columns)
 	closeErr := rows.Close()
 	if err != nil {
 		if scanErr, ok := err.(*rowScanError); ok {
@@ -612,7 +612,7 @@ func (p *plan) releaseBindingSet(b *bindingSet) {
 	p.bindings.Put(b)
 }
 
-func scanRows(ctx context.Context, rows *sql.Rows, p *plan, slice reflect.Value, elemType reflect.Type, columns []string) (reflect.Value, error) {
+func scanRows(ctx context.Context, rows *sql.Rows, p *plan, slice reflect.Value, columns []string) (reflect.Value, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -630,18 +630,34 @@ func scanRows(ctx context.Context, rows *sql.Rows, p *plan, slice reflect.Value,
 		result = result.Slice(0, 0)
 	}
 
-	zero := reflect.Zero(elemType)
+	// reflect.Append re-derives a new slice-header allocation on every call
+	// (see reflect.Value.extendSlice), even when the backing array already
+	// has room — a real per-row allocation when called once per row. Track
+	// length/capacity as plain ints instead and grow explicitly, in the rare
+	// case it's needed, so the common pre-sized-by-the-caller case (the
+	// collection handler always passes a slice capped to $top) never calls
+	// into reflect's slice-growth machinery at all.
+	full := result.Slice(0, result.Cap())
+	count := 0
 	for rows.Next() {
-		result = reflect.Append(result, zero)
-		elem := result.Index(result.Len() - 1)
-		if err := scanRowInto(ctx, rows, bindings, elem); err != nil {
+		if count == full.Len() {
+			newCap := full.Cap() * 2
+			if newCap == 0 {
+				newCap = 8
+			}
+			grown := reflect.MakeSlice(slice.Type(), newCap, newCap)
+			reflect.Copy(grown, full.Slice(0, count))
+			full = grown
+		}
+		if err := scanRowInto(ctx, rows, bindings, full.Index(count)); err != nil {
 			return reflect.Value{}, err
 		}
+		count++
 	}
 	if err := rows.Err(); err != nil {
 		return reflect.Value{}, err
 	}
-	return result, nil
+	return full.Slice(0, count), nil
 }
 
 // scanFirstRow scans at most one row into elem (an addressable struct value),
@@ -700,7 +716,13 @@ func scanRowInto(ctx context.Context, rows *sql.Rows, bindings *bindingSet, elem
 			}
 		case scanTime:
 			if b.timeBuf.Valid {
-				b.field.ReflectValueOf(ctx, elem).Set(reflect.ValueOf(b.timeBuf.Time))
+				// reflect.ValueOf(b.timeBuf.Time) would box the time.Time
+				// value itself, allocating a heap copy to satisfy the
+				// interface conversion. Boxing a *time.Time instead is
+				// allocation-free (a pointer fits directly in an interface
+				// value), and .Elem() gives Set an indirect Value backed by
+				// that same memory, which it copies out immediately.
+				b.field.ReflectValueOf(ctx, elem).Set(reflect.ValueOf(&b.timeBuf.Time).Elem())
 			}
 		}
 	}

--- a/internal/fastscan/fastscan_test.go
+++ b/internal/fastscan/fastscan_test.go
@@ -250,6 +250,41 @@ func TestFindReusesPresizedSlice(t *testing.T) {
 	}
 }
 
+// TestFindGrowsPastInitialCapacity seeds more rows than the destination
+// slice's initial capacity, forcing scanRows's manual grow path (doubling
+// the backing array) to run more than once, and checks every row still
+// lands in the right place afterward.
+func TestFindGrowsPastInitialCapacity(t *testing.T) {
+	db := openDB(t)
+	if err := db.AutoMigrate(&Widget{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	const n = 50
+	widgets := make([]Widget, 0, n)
+	for i := 0; i < n; i++ {
+		widgets = append(widgets, Widget{Name: fmt.Sprintf("widget-%d", i)})
+	}
+	if err := db.Create(&widgets).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// A capacity of 1 forces several doublings (1 -> 2 -> 4 -> ... -> 64)
+	// before all n rows fit.
+	results := make([]Widget, 0, 1)
+	if err := Find(db.Order("id"), &results); err != nil {
+		t.Fatalf("fastscan.Find: %v", err)
+	}
+	if len(results) != n {
+		t.Fatalf("expected %d widgets, got %d", n, len(results))
+	}
+	for i, w := range results {
+		want := fmt.Sprintf("widget-%d", i)
+		if w.Name != want {
+			t.Fatalf("result[%d].Name = %q, want %q", i, w.Name, want)
+		}
+	}
+}
+
 func TestFindConcurrentUsesIndependentBindingSets(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:fastscan_concurrent?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Discard})
 	if err != nil {


### PR DESCRIPTION
## Summary

Profiled `internal/fastscan.Find` (`BenchmarkFastscanFind`, 100-row page over a 7-field struct) with `pprof -alloc_objects` and found two allocations attributable to fastscan's own code, both paid once per row instead of once per query — matching the issue's request to audit `scanRowInto` for "remaining per-row `reflect.New`/`Interface()` allocations" before attempting the riskier result-slice pooling:

- **`scanRowInto`** set `time.Time` fields via `reflect.ValueOf(b.timeBuf.Time).Set(...)`, which boxes the `time.Time` *value* — an unavoidable heap copy to satisfy the interface conversion, paid once per time field per row. `reflect.ValueOf(&b.timeBuf.Time).Elem()` boxes a `*time.Time` instead (pointers don't need boxing to become an `interface{}`) and gives `Set` an indirect `Value` backed by the same memory — no allocation.
- **`scanRows`** grew the result slice via `reflect.Append` once per row. `reflect.Value.extendSlice` (which `Append` calls internally) unconditionally allocates a new slice-header struct on *every* call, even when the backing array already has room — so a query whose destination is already sized correctly (the common case: the collection handler always passes a slice capped to `$top`) still paid one allocation per row just from calling `Append` in a loop. Tracking length/capacity as plain ints and growing explicitly (doubling, via `MakeSlice`+`Copy`) only when actually needed turns this into O(1) reflect calls for the pre-sized case, and O(log n) for the rare case a query returns more rows than the destination's initial capacity.

## Results

`BenchmarkFastscanFind` (100-row page, `BenchProduct`: 7 fields incl. 2 `time.Time`):

| | before | after |
|---|---|---|
| allocs/op | 1472 | **1174** (‑20%) |
| B/op | 47840 | **40669** (‑15%) |
| ns/op | 93073 | 83253 |

`BenchmarkFastscanFirst` drops from 85 to 83 allocs/op (2 fewer `time.Time` fields).

The remaining allocations are intrinsic to the `mattn/go-sqlite3` driver (`nextSyncLocked`, `_Cfunc_GoStringN`) and `database/sql`'s own value conversion — confirmed via `pprof`, not something fastscan's scan path controls.

## Scope note

Pooling the result slice/struct backing array itself (option 1 in the issue) is the riskier change — it needs a clear ownership handoff with the response-write path (structs must never be retained past the response write) — and the issue explicitly says to start with the contained fix and measure first. This PR is that contained fix; result-slice pooling is left as a follow-up if further gains are still wanted after measuring against this baseline.

## Test plan
- [x] `TestFindGrowsPastInitialCapacity` (new): seeds more rows than the destination's initial capacity, forcing the manual grow path to double more than once, and verifies every row lands correctly.
- [x] Existing fastscan tests (`TestFindMatchesGorm`, `TestFindReusesPresizedSlice`, `TestFindEmptyResultIsNonNil`, `TestFindConcurrentUsesIndependentBindingSets`, poisoning tests, etc.) all still pass unchanged.
- [x] `go test ./internal/fastscan/... -race` and full suite pass.
- [x] `golangci-lint run internal/fastscan/...` clean.
- [x] Before/after `pprof -alloc_objects` confirms both target allocation sites are eliminated.

Fixes #867