### PR TITLE
Allow MS PowerQuery to function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,10 +54,4 @@ linters:
           - errcheck
         path: "internal/observability/(metrics|noop)\\.go"
         text: "meter\\.(Float64Histogram|Int64Counter|Int64Histogram)"
-      - linters:
-          - staticcheck
-        test: "SA1008"
-        path:
-          - internal/handlers/helpers_test.go
-          - internal/response/error_response_test.go
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,3 +54,10 @@ linters:
           - errcheck
         path: "internal/observability/(metrics|noop)\\.go"
         text: "meter\\.(Float64Histogram|Int64Counter|Int64Histogram)"
+      - linters:
+          - staticcheck
+        test: "SA1008"
+        path:
+          - internal/handlers/helpers_test.go
+          - internal/response/error_response_test.go
+

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -119,6 +119,14 @@ func SetODataHeader(w http.ResponseWriter, key, value string) {
 	w.Header()[key] = []string{value}
 }
 
+func GetODataHeader(w http.ResponseWriter, key string) (string, error) {
+	val := w.Header()[key]
+	if len(val) == 0 {
+		return "", fmt.Errorf("key '%s' does not exist in headers", key)
+	}
+	return val[0], nil
+}
+
 func isCaseInsensitiveSystemQueryParsingEnabled(r *http.Request) bool {
 	// This service implements OData 4.01 request syntax. OData-MaxVersion
 	// negotiates the response representation; it does not restrict which URL

--- a/internal/handlers/helpers_test.go
+++ b/internal/handlers/helpers_test.go
@@ -23,10 +23,12 @@ func TestSetODataHeader(t *testing.T) {
 
 	// Verify header was set - use direct map access since OData headers have non-canonical keys
 	// OData spec requires exact "OData-Version" capitalization which is non-canonical in Go
-	header := w.Header()
-	values := header["OData-Version"] //nolint:staticcheck // OData headers require non-canonical keys
-	if len(values) == 0 || values[0] != "4.01" {
-		t.Errorf("Expected OData-Version header to be 4.01, got %v", values)
+	value, err := GetODataHeader(w, "OData-Version")
+	if err != nil {
+		t.Error(err)
+	}
+	if value != "4.01" {
+		t.Errorf("Expected OData-Version header to be 4.01, got %v", value)
 	}
 }
 
@@ -66,12 +68,12 @@ func TestSetODataVersionHeaderForRequest(t *testing.T) {
 			req = req.WithContext(version.WithVersion(req.Context(), negotiatedVersion))
 			response.SetODataVersionHeaderFromRequest(w, req)
 
-			value := w.Header()["OData-Version"]
-			if value[0] == "" {
+			value, err := GetODataHeader(w, "OData-Version")
+			if err != nil {
 				t.Error("Expected OData-Version header to be set")
 				return
 			}
-			if value[0] != tt.expectedVersion {
+			if value != tt.expectedVersion {
 				t.Errorf("Expected OData-Version %s, got %s", tt.expectedVersion, value)
 			}
 		})

--- a/internal/handlers/helpers_test.go
+++ b/internal/handlers/helpers_test.go
@@ -66,13 +66,12 @@ func TestSetODataVersionHeaderForRequest(t *testing.T) {
 			req = req.WithContext(version.WithVersion(req.Context(), negotiatedVersion))
 			response.SetODataVersionHeaderFromRequest(w, req)
 
-			// Check for the header - use Get() since Set() was used
-			value := w.Header().Get("OData-Version")
-			if value == "" {
+			value := w.Header()["OData-Version"]
+			if value[0] == "" {
 				t.Error("Expected OData-Version header to be set")
 				return
 			}
-			if value != tt.expectedVersion {
+			if value[0] != tt.expectedVersion {
 				t.Errorf("Expected OData-Version %s, got %s", tt.expectedVersion, value)
 			}
 		})

--- a/internal/handlers/metadata_facets_test.go
+++ b/internal/handlers/metadata_facets_test.go
@@ -289,17 +289,17 @@ func TestMetadataWithReferentialConstraintsJSON(t *testing.T) {
 
 func TestEdmTypeMapping(t *testing.T) {
 	type TypeMappingEntity struct {
-		ID            int              `json:"id" odata:"key"`
-		CreatedAt     time.Time        `json:"createdAt"`
-		CreatedAtPtr  *time.Time       `json:"createdAtPtr"`
-		IntField      int              `json:"intField"`
-		Int64Field    int64            `json:"int64Field"`
-		Float64Field  float64          `json:"float64Field"`
-		StringField   string           `json:"stringField"`
-		BoolField     bool             `json:"boolField"`
-		BinaryContent []byte           `json:"binaryContent"`
-		RawField      json.RawMessage  `json:"rawField"`
-		AnyField      interface{}      `json:"anyField"`
+		ID            int             `json:"id" odata:"key"`
+		CreatedAt     time.Time       `json:"createdAt"`
+		CreatedAtPtr  *time.Time      `json:"createdAtPtr"`
+		IntField      int             `json:"intField"`
+		Int64Field    int64           `json:"int64Field"`
+		Float64Field  float64         `json:"float64Field"`
+		StringField   string          `json:"stringField"`
+		BoolField     bool            `json:"boolField"`
+		BinaryContent []byte          `json:"binaryContent"`
+		RawField      json.RawMessage `json:"rawField"`
+		AnyField      interface{}     `json:"anyField"`
 	}
 
 	entityMeta, err := metadata.AnalyzeEntity(TypeMappingEntity{})

--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -102,9 +102,9 @@ type PropertyMetadata struct {
 	JoinTableForeignKey       string
 	JoinTableReferencesColumn string
 	NavigationIsArray         bool // True for collection navigation properties
-	NavigationContainsTarget  bool   // True if this is a containment navigation property (ContainsTarget="true")
-	IsETag                    bool   // True if this property should be used for ETag generation
-	IsComplexType             bool   // True if this property is a complex type (embedded struct)
+	NavigationContainsTarget  bool // True if this is a containment navigation property (ContainsTarget="true")
+	IsETag                    bool // True if this property should be used for ETag generation
+	IsComplexType             bool // True if this property is a complex type (embedded struct)
 	EmbeddedPrefix            string
 	ComplexTypeFields         map[string]*PropertyMetadata
 	// Facets

--- a/internal/query/has_function_test.go
+++ b/internal/query/has_function_test.go
@@ -128,10 +128,10 @@ func TestHasEnumValueLiteral(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		filter        string
-		wantValue     int64
-		wantErr       bool
+		name      string
+		filter    string
+		wantValue int64
+		wantErr   bool
 	}{
 		{
 			name:      "qualified enum literal with has infix",
@@ -197,10 +197,10 @@ func TestHasEnumValueLiteralSQL(t *testing.T) {
 	// Status values: InStock=1, OnSale=2, Discontinued=4, Featured=8
 	products := []Product{
 		{ID: 1, Name: "Normal", Status: 1},        // InStock
-		{ID: 2, Name: "Sale", Status: 3},           // InStock|OnSale
-		{ID: 3, Name: "Featured", Status: 9},       // InStock|Featured
-		{ID: 4, Name: "FeaturedSale", Status: 11},  // InStock|OnSale|Featured
-		{ID: 5, Name: "Discontinued", Status: 4},   // Discontinued
+		{ID: 2, Name: "Sale", Status: 3},          // InStock|OnSale
+		{ID: 3, Name: "Featured", Status: 9},      // InStock|Featured
+		{ID: 4, Name: "FeaturedSale", Status: 11}, // InStock|OnSale|Featured
+		{ID: 5, Name: "Discontinued", Status: 4},  // Discontinued
 	}
 	if err := db.Create(&products).Error; err != nil {
 		t.Fatalf("seed: %v", err)

--- a/internal/query/search_expression_test.go
+++ b/internal/query/search_expression_test.go
@@ -202,16 +202,16 @@ func TestToFTS34Query(t *testing.T) {
 
 func TestSearchExprNode_containsNot(t *testing.T) {
 	tests := []struct {
-		query    string
-		want     bool
+		query string
+		want  bool
 	}{
 		{"laptop", false},
 		{"laptop AND wireless", false},
 		{"laptop OR phone", false},
 		{"NOT laptop", true},
-		{"laptop NOT wireless", true},  // implicit AND with NOT right child
-		{"Mouse NOT Wireless", true},   // issue #732 case 1
-		{"NOT Laptop", true},           // issue #732 case 2
+		{"laptop NOT wireless", true}, // implicit AND with NOT right child
+		{"Mouse NOT Wireless", true},  // issue #732 case 1
+		{"NOT Laptop", true},          // issue #732 case 2
 	}
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {

--- a/internal/response/atom.go
+++ b/internal/response/atom.go
@@ -39,6 +39,12 @@ func isAtomFrom(format, accept string) bool {
 	for _, part := range strings.Split(accept, ",") {
 		part = strings.TrimSpace(part)
 		subparts := strings.Split(part, ";")
+
+		// we check json first, because powerquery wants us to provide that if it asks for it.
+		// the order of these IF-statements is critical
+		if strings.TrimSpace(subparts[0]) == "application/json" {
+			return false
+		}
 		if strings.TrimSpace(subparts[0]) == "application/atom+xml" {
 			return true
 		}

--- a/internal/response/error_response_test.go
+++ b/internal/response/error_response_test.go
@@ -36,8 +36,8 @@ func TestWriteError_BasicError(t *testing.T) {
 	}
 
 	// Verify OData-Version header
-	odataVersion := w.Header().Get("OData-Version")
-	if odataVersion != "4.01" {
+	odataVersion := w.Header()["OData-Version"]
+	if odataVersion[0] != "4.01" {
 		t.Errorf("OData-Version = %v, want 4.01", odataVersion)
 	}
 
@@ -429,8 +429,8 @@ func TestWriteError_RespectsVersionNegotiation_40(t *testing.T) {
 	}
 
 	// Verify OData-Version header matches negotiated version
-	odataVersion := w.Header().Get("OData-Version")
-	if odataVersion != "4.0" {
+	odataVersion := w.Header()["OData-Version"]
+	if odataVersion[0] != "4.0" {
 		t.Errorf("OData-Version = %v, want 4.0", odataVersion)
 	}
 }
@@ -452,8 +452,8 @@ func TestWriteError_RespectsVersionNegotiation_401(t *testing.T) {
 	}
 
 	// Verify OData-Version header matches negotiated version
-	odataVersion := w.Header().Get("OData-Version")
-	if odataVersion != "4.01" {
+	odataVersion := w.Header()["OData-Version"]
+	if odataVersion[0] != "4.01" {
 		t.Errorf("OData-Version = %v, want 4.01", odataVersion)
 	}
 }
@@ -480,8 +480,8 @@ func TestWriteODataError_RespectsVersionNegotiation(t *testing.T) {
 	}
 
 	// Verify OData-Version header matches negotiated version
-	odataVersion := w.Header().Get("OData-Version")
-	if odataVersion != "4.0" {
+	odataVersion := w.Header()["OData-Version"]
+	if odataVersion[0] != "4.0" {
 		t.Errorf("OData-Version = %v, want 4.0", odataVersion)
 	}
 }

--- a/internal/response/error_response_test.go
+++ b/internal/response/error_response_test.go
@@ -36,8 +36,11 @@ func TestWriteError_BasicError(t *testing.T) {
 	}
 
 	// Verify OData-Version header
-	odataVersion := w.Header()["OData-Version"]
-	if odataVersion[0] != "4.01" {
+	odataVersion, err := GetODataVersionHeaderFromRequest(w, "OData-Version")
+	if err != nil {
+		t.Error(err)
+	}
+	if odataVersion != "4.01" {
 		t.Errorf("OData-Version = %v, want 4.01", odataVersion)
 	}
 
@@ -429,8 +432,11 @@ func TestWriteError_RespectsVersionNegotiation_40(t *testing.T) {
 	}
 
 	// Verify OData-Version header matches negotiated version
-	odataVersion := w.Header()["OData-Version"]
-	if odataVersion[0] != "4.0" {
+	odataVersion, err := GetODataVersionHeaderFromRequest(w, "OData-Version")
+	if err != nil {
+		t.Error(err)
+	}
+	if odataVersion != "4.0" {
 		t.Errorf("OData-Version = %v, want 4.0", odataVersion)
 	}
 }
@@ -452,8 +458,11 @@ func TestWriteError_RespectsVersionNegotiation_401(t *testing.T) {
 	}
 
 	// Verify OData-Version header matches negotiated version
-	odataVersion := w.Header()["OData-Version"]
-	if odataVersion[0] != "4.01" {
+	odataVersion, err := GetODataVersionHeaderFromRequest(w, "OData-Version")
+	if err != nil {
+		t.Error(err)
+	}
+	if odataVersion != "4.01" {
 		t.Errorf("OData-Version = %v, want 4.01", odataVersion)
 	}
 }
@@ -480,8 +489,11 @@ func TestWriteODataError_RespectsVersionNegotiation(t *testing.T) {
 	}
 
 	// Verify OData-Version header matches negotiated version
-	odataVersion := w.Header()["OData-Version"]
-	if odataVersion[0] != "4.0" {
+	odataVersion, err := GetODataVersionHeaderFromRequest(w, "OData-Version")
+	if err != nil {
+		t.Error(err)
+	}
+	if odataVersion != "4.0" {
 		t.Errorf("OData-Version = %v, want 4.0", odataVersion)
 	}
 }

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -21,6 +21,14 @@ func SetODataVersionHeaderFromRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header()[HeaderODataVersion] = []string{ver.String()} // see Handlers.SetODataHeader
 }
 
+func GetODataVersionHeaderFromRequest(w http.ResponseWriter, key string) (string, error) {
+	val := w.Header()[key]
+	if len(val) == 0 {
+		return "", fmt.Errorf("key '%s' does not exist in headers", key)
+	}
+	return val[0], nil
+}
+
 // ODataResponse represents the structure of an OData JSON response.
 type ODataResponse struct {
 	Context  string      `json:"@odata.context,omitempty"`

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -18,7 +18,7 @@ const (
 // SetODataVersionHeaderFromRequest sets the OData-Version header based on the negotiated version in the request context.
 func SetODataVersionHeaderFromRequest(w http.ResponseWriter, r *http.Request) {
 	ver := version.GetVersion(r.Context())
-	w.Header().Set(HeaderODataVersion, ver.String())
+	w.Header()[HeaderODataVersion] = []string{ver.String()} // see Handlers.SetODataHeader
 }
 
 // ODataResponse represents the structure of an OData JSON response.

--- a/test/custom_fk_expand_test.go
+++ b/test/custom_fk_expand_test.go
@@ -20,9 +20,9 @@ import (
 // differs from the default convention (<EntityName><KeyName>).
 // Here the FK is "SuiteID" not "CustomFKSuiteID", which triggers Bug B if not fixed.
 type CustomFKSuite struct {
-	ID   string         `json:"ID" gorm:"primaryKey" odata:"key"`
-	Name string         `json:"Name"`
-	Runs []CustomFKRun  `json:"Runs,omitempty" gorm:"foreignKey:SuiteID;references:ID" odata:"nav"`
+	ID   string        `json:"ID" gorm:"primaryKey" odata:"key"`
+	Name string        `json:"Name"`
+	Runs []CustomFKRun `json:"Runs,omitempty" gorm:"foreignKey:SuiteID;references:ID" odata:"nav"`
 }
 
 // CustomFKRun is a child entity whose FK column is "suite_id" (from field SuiteID),

--- a/test/deep_update_test.go
+++ b/test/deep_update_test.go
@@ -23,10 +23,10 @@ type DeepUpdateSupplier struct {
 
 // DeepUpdateProduct has a BelongsTo relationship to DeepUpdateSupplier.
 type DeepUpdateProduct struct {
-	ID         int                  `json:"ID" gorm:"primaryKey;autoIncrement" odata:"key"`
-	Name       string               `json:"Name"`
-	SupplierID *int                 `json:"SupplierID,omitempty"`
-	Supplier   *DeepUpdateSupplier  `json:"Supplier,omitempty" gorm:"foreignKey:SupplierID"`
+	ID         int                 `json:"ID" gorm:"primaryKey;autoIncrement" odata:"key"`
+	Name       string              `json:"Name"`
+	SupplierID *int                `json:"SupplierID,omitempty"`
+	Supplier   *DeepUpdateSupplier `json:"Supplier,omitempty" gorm:"foreignKey:SupplierID"`
 }
 
 // DeepUpdateAddress has a HasOne relationship from DeepUpdateOrder (FK is on Address).

--- a/test/error_response_test.go
+++ b/test/error_response_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	odata "github.com/nlstn/go-odata"
+	"github.com/nlstn/go-odata/internal/handlers"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -372,9 +373,12 @@ func TestErrorResponse_ODataVersion(t *testing.T) {
 			// Verify OData-Version header is present
 			// Access using direct map access since we use non-canonical capitalization
 			//nolint:staticcheck // SA1008: intentionally using non-canonical header key per OData spec
-			odataVersionValues := w.Header()["OData-Version"]
-			if len(odataVersionValues) == 0 || odataVersionValues[0] != "4.01" {
-				t.Errorf("OData-Version header = %v, want [4.01]", odataVersionValues)
+			value, err := handlers.GetODataHeader(w, "OData-Version")
+			if err != nil {
+				t.Error(err)
+			}
+			if value != "4.01" {
+				t.Errorf("OData-Version header = %v, want [4.01]", value)
 			}
 
 			// Verify Content-Type header

--- a/test/put_test.go
+++ b/test/put_test.go
@@ -494,7 +494,7 @@ func TestPutEntity_DifferenceFromPatch(t *testing.T) {
 
 // TestPutUpsert_GetAfterCreate verifies that a GET request after an upsert returns the new entity.
 func TestPutUpsert_GetAfterCreate(t *testing.T) {
-		// Per OData v4 spec, PUT to non-existent entity returns 404 (not 201 create)
+	// Per OData v4 spec, PUT to non-existent entity returns 404 (not 201 create)
 	service, _ := setupPutTestService(t)
 
 	// PUT to non-existent key
@@ -524,10 +524,10 @@ func TestPutUpsert_GetAfterCreate(t *testing.T) {
 
 // TestPutUpsert_ThenUpdate verifies that upsert followed by PUT update works correctly.
 func TestPutUpsert_ThenUpdate(t *testing.T) {
-		// First PUT to non-existent entity returns 404 per OData v4 spec
+	// First PUT to non-existent entity returns 404 per OData v4 spec
 	service, db := setupPutTestService(t)
 
-	// First, create an entity so we can test UPDATE  
+	// First, create an entity so we can test UPDATE
 	initialProduct := PutTestProduct{
 		ID:    77,
 		Name:  "Initial",
@@ -571,7 +571,7 @@ func TestPutUpsert_ThenUpdate(t *testing.T) {
 
 // TestPutUpsert_CompositeKey verifies upsert with a composite key.
 func TestPutUpsert_CompositeKey(t *testing.T) {
-		// Per OData v4 spec, PUT to non-existent entity returns 404 (not 201 create)
+	// Per OData v4 spec, PUT to non-existent entity returns 404 (not 201 create)
 	service, db := setupPutCompositeKeyTestService(t)
 
 	body, _ := json.Marshal(map[string]interface{}{


### PR DESCRIPTION
This fixes issue #874 for me.

What the changes are:
- Correct handling of the odata header in places where it wasn't handled.
- Prefer JSON over ATOM (whichever comes first). IsAtom just checked if there is atom, although PowerQuery askes for it, it does seem to struggle with it (i think mainly due to the `;charset=utf-8` that is added). The change first checks if json is wanted and if so assumes that ATOM should not be used.

All tests pass correctly and PowerQuery (tested with Excel) also works.

