### PR TITLE
Support builds with CGO disabled

### DIFF
--- a/sqlite_nocgo.go
+++ b/sqlite_nocgo.go
@@ -1,0 +1,9 @@
+//go:build !cgo
+
+package odata
+
+import "gorm.io/gorm"
+
+func ensureSQLiteRegexp(_ *gorm.DB) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

Add the missing `!cgo` implementation of `ensureSQLiteRegexp` so non-SQLite consumers can compile go-odata in static and cross-compilation environments. CGO-enabled SQLite behavior is unchanged.

## Validation

- `CGO_ENABLED=0 go build ./...`
- `go test ./...`
- `golangci-lint v2.5.0 run ./...`