### PR TITLE
Vary responses by OData-MaxVersion

### DIFF
--- a/internal/service/router/router.go
+++ b/internal/service/router/router.go
@@ -122,6 +122,24 @@ func (r *Router) getNamespace() string {
 	return r.namespace
 }
 
+func addVaryHeader(header http.Header, fieldName string) {
+	for name, values := range header {
+		if !strings.EqualFold(name, "Vary") {
+			continue
+		}
+		for _, value := range values {
+			for member := range strings.SplitSeq(value, ",") {
+				member = strings.TrimSpace(member)
+				if member == "*" || strings.EqualFold(member, fieldName) {
+					return
+				}
+			}
+		}
+	}
+
+	header.Add("Vary", fieldName)
+}
+
 // ServeHTTP implements http.Handler interface.
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Check if client's OData-MaxVersion is below 4.0 (reject old versions)
@@ -151,6 +169,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Store the negotiated version in the request context
 	ctx := version.WithVersion(req.Context(), negotiatedVersion)
 	req = req.WithContext(ctx)
+
+	// Responses vary by the version selected from OData-MaxVersion.
+	addVaryHeader(w.Header(), handlers.HeaderODataMaxVersion)
 
 	// Set the OData-Version header based on the negotiated version
 	// Use direct assignment to preserve exact casing per OData spec

--- a/internal/service/router/router_additional_test.go
+++ b/internal/service/router/router_additional_test.go
@@ -50,6 +50,68 @@ func TestRouter_ODataMaxVersionInvalidIgnored(t *testing.T) {
 	}
 }
 
+func TestRouter_ODataMaxVersionAddsVaryHeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingVary []string
+		wantMembers  map[string]int
+	}{
+		{
+			name:        "no existing header",
+			wantMembers: map[string]int{"odata-maxversion": 1},
+		},
+		{
+			name:         "preserves existing member",
+			existingVary: []string{"Accept-Encoding"},
+			wantMembers:  map[string]int{"accept-encoding": 1, "odata-maxversion": 1},
+		},
+		{
+			name:         "does not duplicate case-insensitive member",
+			existingVary: []string{"Accept-Encoding, odata-maxversion"},
+			wantMembers:  map[string]int{"accept-encoding": 1, "odata-maxversion": 1},
+		},
+		{
+			name:         "preserves multiple header lines",
+			existingVary: []string{"Accept-Encoding", "Origin"},
+			wantMembers:  map[string]int{"accept-encoding": 1, "origin": 1, "odata-maxversion": 1},
+		},
+		{
+			name:         "respects wildcard",
+			existingVary: []string{"*"},
+			wantMembers:  map[string]int{"*": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRouter(nil, nil, nil, func(http.ResponseWriter, *http.Request, string, string, bool, string) {})
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("OData-MaxVersion", "4.0")
+			rec := httptest.NewRecorder()
+			for _, value := range tt.existingVary {
+				rec.Header().Add("Vary", value)
+			}
+
+			r.ServeHTTP(rec, req)
+
+			gotMembers := make(map[string]int)
+			for _, value := range rec.Header().Values("Vary") {
+				for member := range strings.SplitSeq(value, ",") {
+					gotMembers[strings.ToLower(strings.TrimSpace(member))]++
+				}
+			}
+			if len(gotMembers) != len(tt.wantMembers) {
+				t.Fatalf("Vary members = %v, want %v", gotMembers, tt.wantMembers)
+			}
+			for member, wantCount := range tt.wantMembers {
+				if gotMembers[member] != wantCount {
+					t.Errorf("Vary member %q count = %d, want %d", member, gotMembers[member], wantCount)
+				}
+			}
+		})
+	}
+}
+
 func TestRouter_ActionOrFunctionMethodNotAllowed(t *testing.T) {
 	r := newTestRouter(nil, nil, map[string][]*actions.FunctionDefinition{
 		"TopProducts": nil,


### PR DESCRIPTION
## Summary

Emit `Vary: OData-MaxVersion` for negotiated OData responses as required by OData v4.01 section 8.3.8. Merge with existing `Vary` values, avoid case-insensitive duplicates, and preserve wildcard semantics.

## Validation

- Focused OData negotiation and Vary-header tests
- `go test ./...`
- `golangci-lint v2.5.0 run ./...`