### PR TITLE
Validate OData request payload versions

### DIFF
--- a/cmd/complianceserver/reseed.go
+++ b/cmd/complianceserver/reseed.go
@@ -206,6 +206,12 @@ func registerReseedAction(service *odata.Service, db *gorm.DB) {
 		Parameters: []odata.ParameterDefinition{},
 		ReturnType: nil,
 		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			// The HTTP gate blocks new requests while Reseed runs. Wait for jobs
+			// accepted by earlier requests before dropping tables beneath them.
+			if manager := service.AsyncManager(); manager != nil {
+				manager.WaitForActiveJobs()
+			}
+
 			// Reseed the database
 			if err := seedDatabase(db); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/complianceserver/reseed_gate.go
+++ b/cmd/complianceserver/reseed_gate.go
@@ -23,6 +23,11 @@ func (g *reseedGate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost && strings.Trim(r.URL.Path, "/") == "Reseed" {
 		g.mu.Lock()
 		defer g.mu.Unlock()
+
+		// Reseed must remain synchronous because its handler waits for jobs
+		// accepted before the exclusive gate was acquired.
+		r = r.Clone(r.Context())
+		r.Header.Del("Prefer")
 	} else {
 		g.mu.RLock()
 		defer g.mu.RUnlock()

--- a/cmd/complianceserver/reseed_gate_test.go
+++ b/cmd/complianceserver/reseed_gate_test.go
@@ -88,3 +88,22 @@ func TestReseedGateBlocksNewRequestsDuringReseed(t *testing.T) {
 		t.Fatalf("product requests after reseed = %d, want 1", got)
 	}
 }
+
+func TestReseedGateForcesSynchronousReseed(t *testing.T) {
+	var gotPrefer string
+	handler := newReseedGate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPrefer = r.Header.Get("Prefer")
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/Reseed", nil)
+	req.Header.Set("Prefer", "respond-async")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotPrefer != "" {
+		t.Fatalf("Reseed Prefer header = %q, want empty", gotPrefer)
+	}
+	if got := req.Header.Get("Prefer"); got != "respond-async" {
+		t.Fatalf("original request Prefer header = %q, want respond-async", got)
+	}
+}

--- a/http_runtime.go
+++ b/http_runtime.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/nlstn/go-odata/internal/handlers"
 	"github.com/nlstn/go-odata/internal/response"
+	"github.com/nlstn/go-odata/internal/version"
 )
 
 // ServeHTTP implements http.Handler by delegating to the runtime.
@@ -29,6 +31,16 @@ func (s *Service) serveHTTP(w http.ResponseWriter, r *http.Request, allowAsync b
 		ctx := context.WithValue(r.Context(), response.BasePathContextKey, basePath)
 		r = r.WithContext(ctx)
 	}
+
+	requestVersion, responseVersion, requestVersionErr := version.ResolveRequestVersions(r.Header, r.ContentLength != 0)
+	r = r.WithContext(version.WithVersion(r.Context(), responseVersion))
+	if requestVersionErr != nil {
+		if writeErr := response.WriteError(w, r, http.StatusBadRequest, handlers.ErrMsgVersionNotSupported, handlers.ErrDetailRequestVersion); writeErr != nil {
+			http.Error(w, writeErr.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	r = r.WithContext(version.WithRequestVersion(r.Context(), requestVersion))
 
 	// Negotiate content format once per request and cache the result on the
 	// context. The $format query parameter and Accept header are immutable for

--- a/internal/async/manager.go
+++ b/internal/async/manager.go
@@ -234,6 +234,22 @@ func (m *Manager) GetJob(id string) (*Job, bool) {
 	return job, ok
 }
 
+// WaitForActiveJobs blocks until every job active at the time of the call has
+// reached a terminal state. Callers must prevent new jobs from being submitted
+// when they require the manager to remain idle after this method returns.
+func (m *Manager) WaitForActiveJobs() {
+	m.mu.Lock()
+	jobs := make([]*Job, 0, len(m.jobs))
+	for _, job := range m.jobs {
+		jobs = append(jobs, job)
+	}
+	m.mu.Unlock()
+
+	for _, job := range jobs {
+		job.Wait()
+	}
+}
+
 // CancelJob requests cancellation of the specified job.
 func (m *Manager) CancelJob(id string) bool {
 	m.mu.Lock()

--- a/internal/async/manager_test.go
+++ b/internal/async/manager_test.go
@@ -126,6 +126,40 @@ func TestManagerLifecycle(t *testing.T) {
 	}
 }
 
+func TestManagerWaitForActiveJobs(t *testing.T) {
+	mgr, _ := newTestManager(t, 0)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	if _, err := mgr.StartJob(context.Background(), func(context.Context) (*StoredResponse, error) {
+		close(started)
+		<-release
+		return &StoredResponse{StatusCode: http.StatusNoContent}, nil
+	}); err != nil {
+		t.Fatalf("StartJob error: %v", err)
+	}
+	<-started
+
+	waitDone := make(chan struct{})
+	go func() {
+		mgr.WaitForActiveJobs()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		t.Fatal("WaitForActiveJobs returned while a job was active")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("WaitForActiveJobs did not return after the job completed")
+	}
+}
+
 func TestManagerCancellation(t *testing.T) {
 	mgr, _ := newTestManager(t, 0)
 

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -84,11 +84,12 @@ func (h *BatchHandler) SetPreRequestHook(hook func(r *http.Request) (context.Con
 
 // batchRequest represents a single request within a batch
 type batchRequest struct {
-	Method    string
-	URL       string
-	Headers   http.Header
-	Body      []byte
-	ContentID string // Content-ID from the MIME part envelope (to be echoed in response)
+	Method     string
+	URL        string
+	Headers    http.Header
+	Body       []byte
+	HasPayload bool
+	ContentID  string // Content-ID from the MIME part envelope (to be echoed in response)
 }
 
 // batchResponse represents a single response within a batch
@@ -474,13 +475,29 @@ func (h *BatchHandler) parseHTTPRequest(r io.Reader) (*batchRequest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
+	hasPayload := len(body) > 0
+	if contentLength, parseErr := strconv.ParseInt(headers.Get("Content-Length"), 10, 64); parseErr == nil && contentLength > 0 {
+		hasPayload = true
+	}
 
 	return &batchRequest{
-		Method:  method,
-		URL:     reqURL,
-		Headers: headers,
-		Body:    bytes.TrimSpace(body),
+		Method:     method,
+		URL:        reqURL,
+		Headers:    headers,
+		Body:       bytes.TrimSpace(body),
+		HasPayload: hasPayload,
 	}, nil
+}
+
+func inheritBatchVersionHeaders(headers http.Header, parentReq *http.Request) {
+	for _, name := range []string{HeaderODataVersion, HeaderODataMaxVersion} {
+		if len(version.HeaderValues(headers, name)) != 0 {
+			continue
+		}
+		for _, value := range version.HeaderValues(parentReq.Header, name) {
+			headers.Add(name, value)
+		}
+	}
 }
 
 // executeRequest executes a single batch request.
@@ -488,6 +505,8 @@ func (h *BatchHandler) parseHTTPRequest(r io.Reader) (*batchRequest, error) {
 // Sub-requests are routed through the service handler which invokes the PreRequestHook.
 // Cookies from the parent batch request are forwarded to enable cookie-based authentication.
 func (h *BatchHandler) executeRequest(req *batchRequest, parentReq *http.Request) batchResponse {
+	inheritBatchVersionHeaders(req.Headers, parentReq)
+
 	// Ensure URL has a leading slash to avoid httptest.NewRequest panic
 	url := req.URL
 	if !strings.HasPrefix(url, "/") {
@@ -503,6 +522,9 @@ func (h *BatchHandler) executeRequest(req *batchRequest, parentReq *http.Request
 
 	// Create an HTTP request
 	httpReq := httptest.NewRequest(req.Method, url, bytes.NewReader(req.Body))
+	if req.HasPayload && httpReq.ContentLength == 0 {
+		httpReq.ContentLength = -1
+	}
 	for key, values := range req.Headers {
 		for _, value := range values {
 			httpReq.Header.Add(key, value)
@@ -528,6 +550,8 @@ func (h *BatchHandler) executeRequest(req *batchRequest, parentReq *http.Request
 
 // executeRequestInTransaction executes a request within a transaction
 func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.DB, pendingEvents *[]pendingChangeEvent, parentReq *http.Request) batchResponse {
+	inheritBatchVersionHeaders(req.Headers, parentReq)
+
 	// Create temporary handlers that use the transaction
 	txHandlers := make(map[string]*EntityHandler)
 	for name, handler := range h.handlers {
@@ -803,6 +827,9 @@ func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.D
 
 	// Create an HTTP request
 	httpReq := httptest.NewRequest(req.Method, url, bytes.NewReader(req.Body))
+	if req.HasPayload && httpReq.ContentLength == 0 {
+		httpReq.ContentLength = -1
+	}
 	for key, values := range req.Headers {
 		for _, value := range values {
 			httpReq.Header.Add(key, value)
@@ -814,8 +841,20 @@ func (h *BatchHandler) executeRequestInTransaction(req *batchRequest, tx *gorm.D
 		httpReq.AddCookie(cookie)
 	}
 
+	requestVersion, responseVersion, requestVersionErr := version.ResolveRequestVersions(httpReq.Header, req.HasPayload)
+	ctx := version.WithVersion(httpReq.Context(), responseVersion)
+	if requestVersionErr != nil {
+		recorder := httptest.NewRecorder()
+		httpReq = httpReq.WithContext(ctx)
+		if err := response.WriteError(recorder, httpReq, http.StatusBadRequest, ErrMsgVersionNotSupported, ErrDetailRequestVersion); err != nil {
+			return h.createErrorResponse(http.StatusInternalServerError, err.Error())
+		}
+		return batchResponse{StatusCode: recorder.Code, Headers: recorder.Header(), Body: recorder.Body.Bytes()}
+	}
+	ctx = version.WithRequestVersion(ctx, requestVersion)
+	httpReq = httpReq.WithContext(ctx)
+
 	// Call the pre-request hook if configured (for changeset sub-requests)
-	ctx := httpReq.Context()
 	if h.preRequestHook != nil {
 		hookCtx, err := h.preRequestHook(httpReq)
 		if err != nil {
@@ -1299,11 +1338,12 @@ func (h *BatchHandler) jsonItemToBatchRequest(item jsonBatchRequestItem) (*batch
 	}
 
 	return &batchRequest{
-		Method:    item.Method,
-		URL:       reqURL,
-		Headers:   headers,
-		Body:      bodyBytes,
-		ContentID: item.ID,
+		Method:     item.Method,
+		URL:        reqURL,
+		Headers:    headers,
+		Body:       bodyBytes,
+		HasPayload: len(bodyBytes) > 0,
+		ContentID:  item.ID,
 	}, nil
 }
 

--- a/internal/handlers/batch_test.go
+++ b/internal/handlers/batch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/observability"
+	"github.com/nlstn/go-odata/internal/version"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -109,6 +110,85 @@ func TestBatchHandler_InvalidContentType(t *testing.T) {
 				t.Errorf("Status = %v, want %v", w.Code, http.StatusBadRequest)
 			}
 		})
+	}
+}
+
+func TestInheritBatchVersionHeaders(t *testing.T) {
+	parentReq := httptest.NewRequest(http.MethodPost, "/$batch", nil)
+	parentReq.Header.Set(HeaderODataVersion, "4.0")
+	parentReq.Header.Set(HeaderODataMaxVersion, "4.01")
+	childHeaders := http.Header{HeaderODataVersion: []string{"4.01"}}
+
+	inheritBatchVersionHeaders(childHeaders, parentReq)
+
+	if got := version.HeaderValues(childHeaders, HeaderODataVersion); len(got) != 1 || got[0] != "4.01" {
+		t.Errorf("explicit child OData-Version = %v, want [4.01]", got)
+	}
+	if got := version.HeaderValues(childHeaders, HeaderODataMaxVersion); len(got) != 1 || got[0] != "4.01" {
+		t.Errorf("inherited child OData-MaxVersion = %v, want [4.01]", got)
+	}
+}
+
+func TestBatchTransactionRejectsInvalidRequestVersionBeforeHook(t *testing.T) {
+	handler, db, _ := setupBatchTestHandler(t)
+	hookCalled := false
+	handler.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+		hookCalled = true
+		return r.Context(), nil
+	})
+	tx := db.Begin()
+	t.Cleanup(func() { tx.Rollback() })
+	pendingEvents := make([]pendingChangeEvent, 0)
+	req := &batchRequest{
+		Method:     http.MethodPost,
+		URL:        "/BatchTestProducts",
+		Headers:    http.Header{"Content-Type": []string{"application/json"}, HeaderODataVersion: []string{"4.1"}},
+		Body:       []byte(`{"Name":"Invalid version"}`),
+		HasPayload: true,
+	}
+
+	resp := handler.executeRequestInTransaction(req, tx, &pendingEvents, httptest.NewRequest(http.MethodPost, "/$batch", nil))
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusBadRequest, resp.Body)
+	}
+	if hookCalled {
+		t.Fatal("pre-request hook was called for an invalid payload version")
+	}
+}
+
+func TestBatchTransactionProvidesInheritedVersionContextToHook(t *testing.T) {
+	handler, db, _ := setupBatchTestHandler(t)
+	var gotRequestVersion, gotResponseVersion version.Version
+	handler.SetPreRequestHook(func(r *http.Request) (context.Context, error) {
+		gotRequestVersion = version.GetRequestVersion(r.Context())
+		gotResponseVersion = version.GetVersion(r.Context())
+		return r.Context(), fmt.Errorf("stop after context capture")
+	})
+	tx := db.Begin()
+	t.Cleanup(func() { tx.Rollback() })
+	pendingEvents := make([]pendingChangeEvent, 0)
+	parentReq := httptest.NewRequest(http.MethodPost, "/$batch", nil)
+	parentReq.Header.Set(HeaderODataVersion, "4.01")
+	parentReq.Header.Set(HeaderODataMaxVersion, "4.0")
+	req := &batchRequest{
+		Method:     http.MethodPost,
+		URL:        "/BatchTestProducts",
+		Headers:    http.Header{"Content-Type": []string{"application/json"}},
+		Body:       []byte(`{"Name":"Version context"}`),
+		HasPayload: true,
+	}
+
+	resp := handler.executeRequestInTransaction(req, tx, &pendingEvents, parentReq)
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	if gotRequestVersion != (version.Version{Major: 4, Minor: 1}) {
+		t.Errorf("request version = %v, want 4.01", gotRequestVersion)
+	}
+	if gotResponseVersion != (version.Version{Major: 4, Minor: 0}) {
+		t.Errorf("response version = %v, want 4.0", gotResponseVersion)
 	}
 }
 

--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -31,6 +31,7 @@ const (
 	ErrDetailPreconditionFailed  = "The entity has been modified. Please refresh and try again."
 	ErrMsgVersionNotSupported    = "OData version not supported"
 	ErrDetailVersionNotSupported = "This service only supports OData version 4.0 and above. The maximum version specified in the OData-MaxVersion header is below 4.0."
+	ErrDetailRequestVersion      = "The OData-Version header must specify a request payload version supported by this service: 4.0 or 4.01."
 	ErrMsgValidationFailed       = "Validation failed"
 	ErrMsgNotImplemented         = "Not implemented"
 	ErrMsgConflict               = "Conflict"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -12,6 +13,7 @@ import (
 type contextKey string
 
 const negotiatedVersionKey contextKey = "odata.negotiated.version"
+const requestVersionKey contextKey = "odata.request.version"
 
 // Version represents an OData protocol version
 type Version struct {
@@ -111,6 +113,51 @@ func ParseVersionString(versionStr string) Version {
 	return Version{Major: major, Minor: minor}
 }
 
+// ParseRequestVersion validates an OData-Version request header value against
+// the payload versions supported by the service.
+func ParseRequestVersion(versionStr string) (Version, error) {
+	switch strings.TrimSpace(versionStr) {
+	case "4.0":
+		return Version{Major: 4, Minor: 0}, nil
+	case "4.01":
+		return Version{Major: 4, Minor: 1}, nil
+	default:
+		return Version{}, fmt.Errorf("unsupported OData-Version %q: expected 4.0 or 4.01", versionStr)
+	}
+}
+
+// HeaderValues returns all values for a header field regardless of how its key
+// is capitalized in the raw map.
+func HeaderValues(header http.Header, name string) []string {
+	var values []string
+	for key, keyValues := range header {
+		if strings.EqualFold(key, name) {
+			values = append(values, keyValues...)
+		}
+	}
+	return values
+}
+
+// ResolveRequestVersions returns the versions used to interpret the request
+// payload and generate the response.
+func ResolveRequestVersions(header http.Header, hasPayload bool) (Version, Version, error) {
+	responseVersion := NegotiateVersion(header.Get("OData-MaxVersion"))
+	requestVersion := responseVersion
+	requestVersionValues := HeaderValues(header, "OData-Version")
+	if !hasPayload || len(requestVersionValues) == 0 {
+		return requestVersion, responseVersion, nil
+	}
+	if len(requestVersionValues) != 1 {
+		return Version{}, responseVersion, fmt.Errorf("multiple OData-Version header values")
+	}
+
+	requestVersion, err := ParseRequestVersion(requestVersionValues[0])
+	if err != nil {
+		return Version{}, responseVersion, err
+	}
+	return requestVersion, responseVersion, nil
+}
+
 // NegotiateVersion determines the OData version to use in the response
 // based on the client's OData-MaxVersion header.
 // It returns the highest version supported by the service that is less than
@@ -155,5 +202,19 @@ func GetVersion(ctx context.Context) Version {
 		return v
 	}
 	// Default to the highest supported version
+	return Version{Major: 4, Minor: 1}
+}
+
+// WithRequestVersion stores the version used to interpret the request payload.
+func WithRequestVersion(ctx context.Context, version Version) context.Context {
+	return context.WithValue(ctx, requestVersionKey, version)
+}
+
+// GetRequestVersion retrieves the request payload version from the context.
+// If no version is stored, it returns the highest supported version.
+func GetRequestVersion(ctx context.Context) Version {
+	if v, ok := ctx.Value(requestVersionKey).(Version); ok {
+		return v
+	}
 	return Version{Major: 4, Minor: 1}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -131,6 +131,37 @@ func TestParseVersionString(t *testing.T) {
 	}
 }
 
+func TestParseRequestVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Version
+		wantErr bool
+	}{
+		{name: "4.0", input: "4.0", want: Version{4, 0}},
+		{name: "4.01", input: "4.01", want: Version{4, 1}},
+		{name: "surrounding whitespace", input: " 4.01\t", want: Version{4, 1}},
+		{name: "missing minor", input: "4", wantErr: true},
+		{name: "noncanonical minor", input: "4.1", wantErr: true},
+		{name: "unsupported minor", input: "4.02", wantErr: true},
+		{name: "unsupported major", input: "5.0", wantErr: true},
+		{name: "multiple values", input: "4.0, 4.01", wantErr: true},
+		{name: "invalid", input: "invalid", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRequestVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseRequestVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseRequestVersion(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNegotiateVersion(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -174,5 +205,17 @@ func TestGetVersion_Default(t *testing.T) {
 
 	if retrieved != expected {
 		t.Errorf("GetVersion() without context value = %v, want %v", retrieved, expected)
+	}
+}
+
+func TestRequestAndResponseVersionsAreIndependent(t *testing.T) {
+	ctx := WithVersion(context.Background(), Version{4, 0})
+	ctx = WithRequestVersion(ctx, Version{4, 1})
+
+	if got := GetVersion(ctx); got != (Version{4, 0}) {
+		t.Errorf("GetVersion() = %v, want 4.0", got)
+	}
+	if got := GetRequestVersion(ctx); got != (Version{4, 1}) {
+		t.Errorf("GetRequestVersion() = %v, want 4.01", got)
 	}
 }

--- a/test/version_header_test.go
+++ b/test/version_header_test.go
@@ -333,6 +333,67 @@ func TestODataMaxVersion_WithPOSTRequest(t *testing.T) {
 	}
 }
 
+func TestODataRequestVersion_WithPayload(t *testing.T) {
+	tests := []struct {
+		name        string
+		values      []string
+		maxVersion  string
+		wantStatus  int
+		wantVersion string
+	}{
+		{name: "4.0", values: []string{"4.0"}, wantStatus: http.StatusCreated, wantVersion: "4.01"},
+		{name: "4.01", values: []string{"4.01"}, wantStatus: http.StatusCreated, wantVersion: "4.01"},
+		{name: "request and response versions are independent", values: []string{"4.01"}, maxVersion: "4.0", wantStatus: http.StatusCreated, wantVersion: "4.0"},
+		{name: "malformed", values: []string{"4.1"}, wantStatus: http.StatusBadRequest, wantVersion: "4.01"},
+		{name: "unsupported", values: []string{"5.0"}, wantStatus: http.StatusBadRequest, wantVersion: "4.01"},
+		{name: "multiple", values: []string{"4.0", "4.01"}, wantStatus: http.StatusBadRequest, wantVersion: "4.01"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := setupVersionTestService(t)
+			req := httptest.NewRequest(http.MethodPost, "/VersionTestProducts", strings.NewReader(`{"name":"Keyboard","price":79.99}`))
+			req.Header.Set("Content-Type", "application/json")
+			for _, value := range tt.values {
+				req.Header.Add("OData-Version", value)
+			}
+			if tt.maxVersion != "" {
+				req.Header.Set("OData-MaxVersion", tt.maxVersion)
+			}
+			w := httptest.NewRecorder()
+
+			service.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if got := exactHeaderValues(w.Header(), "OData-Version"); len(got) != 1 || got[0] != tt.wantVersion {
+				t.Errorf("OData-Version = %v, want [%s]", got, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestODataRequestVersion_ValidatedOnlyWithPayload(t *testing.T) {
+	service := setupVersionTestService(t)
+
+	bodylessReq := httptest.NewRequest(http.MethodGet, "/VersionTestProducts", nil)
+	bodylessReq.Header.Set("OData-Version", "invalid")
+	bodylessRec := httptest.NewRecorder()
+	service.ServeHTTP(bodylessRec, bodylessReq)
+	if bodylessRec.Code != http.StatusOK {
+		t.Fatalf("bodyless request status = %d, want %d", bodylessRec.Code, http.StatusOK)
+	}
+
+	payloadReq := httptest.NewRequest(http.MethodGet, "/VersionTestProducts", strings.NewReader("{}"))
+	payloadReq.Header.Set("OData-Version", "invalid")
+	payloadRec := httptest.NewRecorder()
+	service.ServeHTTP(payloadRec, payloadReq)
+	if payloadRec.Code != http.StatusBadRequest {
+		t.Fatalf("payload request status = %d, want %d", payloadRec.Code, http.StatusBadRequest)
+	}
+}
+
 // TestODataMaxVersion_WithDELETERequest tests version validation with DELETE requests
 func TestODataMaxVersion_WithDELETERequest(t *testing.T) {
 	service := setupVersionTestService(t)


### PR DESCRIPTION
## Summary

Validate payload-bearing `OData-Version` request headers strictly as `4.0` or `4.01` before hooks and async dispatch. Keep request payload and negotiated response versions independent, inherit version headers in batch parts, and enforce the same behavior in transactional changesets.

Malformed, unsupported, repeated, or comma-separated payload version declarations return an OData `400` response. Bodyless requests retain existing behavior.

## Validation

- Added parser, service integration, and transactional batch regression tests
- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `golangci-lint v2.5.0 run ./...`