### PR TITLE
Clarify support and production requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Go library for building services that expose OData v4 APIs with automatic hand
 
 ### Key Features
 
-- ✅ **Full OData v4 support** - 100% compliant with OData v4 specification
+- **Broad OData v4 support** - CRUD, metadata, query options, batch requests, actions, functions, ETags, and change tracking
 - 🚀 **Simple API** - Define structs, register entities, and you're done
 - 🔍 **Rich querying** - Supports all OData query options ($filter, $select, $expand, etc.)
 - 🌍 **Geospatial functions** - Query geographic data with geo.distance, geo.length, and geo.intersects
@@ -21,7 +21,7 @@ A Go library for building services that expose OData v4 APIs with automatic hand
 - 🎯 **Custom operations** - Easy registration of actions and functions
 - 🔐 **HTTP method restrictions** - Easily disable HTTP methods (POST, DELETE, etc.) for specific entities
 - 📊 **Data aggregation** - Supports $apply transformations
-- 🧪 **Fully tested** - 85+ compliance tests ensuring OData v4 adherence
+- **Protocol-focused testing** - Unit and integration coverage plus an external black-box OData compliance suite
 - 🔑 **Server-side key generation** - Validate directives during metadata analysis and plug in custom generators
 - 🌐 **Virtual entities** - Expose data from external APIs without database backing
 - 🛣️ **Custom base paths** - Mount your OData service at any path (e.g., `/api/odata`) with automatic URL generation
@@ -29,7 +29,7 @@ A Go library for building services that expose OData v4 APIs with automatic hand
 
 ### OData v4 Specification
 
-This library implements the [OData v4.01 specification](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html).
+This library targets the [OData v4.01 specification](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html). See the supported endpoints and query options below, and run the external compliance suite against your selected database before relying on a specific protocol feature.
 
 ## Installation
 
@@ -191,7 +191,7 @@ Once your service is running, it automatically provides OData v4 endpoints:
 - `DELETE /Products(1)` - Delete product
 
 **Query Options:**
-All standard OData v4 query options are supported:
+Supported OData v4 query options include:
 - `$filter` - Filter results with complex expressions
 - `$select` - Choose specific properties
 - `$expand` - Include related entities
@@ -261,14 +261,13 @@ See the [OData v4 specification](https://docs.oasis-open.org/odata/odata/v4.01/o
 ## Versioning
 
 This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
-Patch releases deliver backward-compatible fixes, minor releases add new
-backward-compatible functionality, and major releases are reserved for breaking
-changes. Planned release tags will start with `v0.1.0` and continue with the
-`vMAJOR.MINOR.PATCH` pattern.
+The current `v0.x` releases are pre-1.0, so the public API can still evolve between
+minor releases. Pin the library version used by production applications and review
+release notes before upgrading.
 
 ## Requirements
 
-- Go 1.24 or later
+- Go 1.25 or later
 - GORM-compatible database driver
 
 ## Supported Databases

--- a/cmd/complianceserver/README.md
+++ b/cmd/complianceserver/README.md
@@ -59,30 +59,27 @@ The compliance sample model includes primitive-focused fields on `Products` to e
 
 ## Testing
 
-The compliance server is used by the Go-based compliance test suite in `compliance-suite/`.
+The compliance suite lives in the external
+[NLstn/odata-compliance-suite](https://github.com/NLstn/odata-compliance-suite)
+repository. It is a black-box client and does not start this server.
 
-The test suite automatically builds, starts, and stops the compliance server:
+Start the server from the repository root:
 
 ```bash
-# Run all compliance tests (server auto-builds and starts)
-cd compliance-suite
-go run .
-
-# Run specific tests by pattern
-go run . -pattern service_document
-
-# Run with verbose output
-go run . -verbose
-
-# Use an external/manual server
-cd cmd/complianceserver
-go run .
-# In another terminal:
-cd compliance-suite
-go run . -external-server
+go run ./cmd/complianceserver -db sqlite
 ```
 
-**Note:** The test suite automatically builds and manages the compliance server for each test run, ensuring a clean environment every time.
+Then run the suite from another terminal:
+
+```bash
+go run github.com/nlstn/odata-compliance-suite@latest -server http://localhost:9090
+
+# Run a focused subset
+go run github.com/nlstn/odata-compliance-suite@latest \
+  -server http://localhost:9090 -pattern service_document
+```
+
+Use a dedicated database because compliance tests can create, update, delete, and reseed data.
 
 ## Differences from Development Server
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -81,7 +81,7 @@ Leverage powerful OData v4 features:
 Ensure your OData service works correctly:
 - Unit testing strategies
 - Integration tests with GORM
-- Running the OData v4 compliance test suite (85+ tests)
+- Running the external OData v4 compliance test suite
 - Performance profiling with CPU profiles
 - SQL query tracing to identify N+1 queries and bottlenecks
 

--- a/documentation/server-configuration.md
+++ b/documentation/server-configuration.md
@@ -495,7 +495,7 @@ Features:
 
 **Use for:** Running compliance tests, validating OData v4 specification adherence
 
-**Note:** The Go-based compliance test suite automatically starts and stops the compliance server.
+**Note:** Start the compliance server first, then point the external black-box suite at `http://localhost:9090`. The suite does not manage the server process.
 
 See [cmd/complianceserver/README.md](../cmd/complianceserver/README.md) for more details.
 
@@ -574,6 +574,35 @@ db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
 ```
 
 ## Production Considerations
+
+### Schema Management
+
+Application entity migrations are the host application's responsibility. Use versioned,
+reviewable migrations in production rather than relying on `AutoMigrate` from the quick-start
+examples.
+
+Optional library features can create their own infrastructure tables:
+
+- `EnableAsyncProcessing` initializes the async job table.
+- `PersistentChangeTracking` initializes the change-tracking table.
+
+Decide whether the application is allowed to perform DDL at startup before enabling these
+features. Environments that prohibit runtime DDL should provision the required tables during
+deployment and verify startup behavior with the restricted production database role.
+
+### Request Hardening
+
+`ServiceConfig` limits IN-clause size, expand depth, and batch size. Configure these values for
+your workload and also enforce HTTP body-size limits, authentication, rate limits, and request
+deadlines in middleware around the service. The library provides authorization policy hooks but
+does not validate JWT or OIDC credentials itself.
+
+### Database-Specific Features
+
+Run integration and compliance tests against the production database. PostgreSQL and SQLite use
+database-native full-text search; MySQL, MariaDB, SQL Server, and other backends can fall back to
+in-memory `$search`, which should not be enabled for unbounded production datasets without load
+testing.
 
 ### Timeouts
 


### PR DESCRIPTION
## Summary

Replace unqualified compliance claims with evidence-based support language, align the documented requirement with Go 1.25, clarify pre-1.0 API stability, and correct compliance-server instructions for the external black-box suite.

Add production guidance for schema ownership, optional runtime DDL, request hardening, and database-specific full-text search behavior.

## Validation

- Checked affected docs for stale compliance and setup claims
- Editor diagnostics: no errors
- `git diff --check`