### PR TITLE
Add a security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released minor version. Users should
+upgrade to the newest patch release before reporting an issue that may already
+be resolved. The `main` branch is under active development and is not a stable
+release channel.
+
+## Reporting a Vulnerability
+
+Use GitHub's **Security** tab and select **Report a vulnerability** to submit a
+private security advisory. Include:
+
+- The affected go-odata version or commit
+- A description of the impact and affected protocol surface
+- Reproduction steps or a minimal test case
+- Any known mitigations
+
+Do not open a public issue or pull request containing vulnerability details. If
+private vulnerability reporting is unavailable, contact the repository owner
+through GitHub before sharing sensitive information.
+
+Reports will be assessed privately. After a fix is available, maintainers may
+publish an advisory describing affected versions, remediation, and appropriate
+credit for the reporter.


### PR DESCRIPTION
## Summary

Add a repository security policy describing the supported release line, private vulnerability reporting through GitHub Security Advisories, requested report details, and responsible disclosure expectations.

## Validation

- Editor diagnostics: no errors
- `git diff --check`