### PR TITLE
Add canonical EDM primitive type metadata

### DIFF
--- a/internal/handlers/entity.go
+++ b/internal/handlers/entity.go
@@ -530,7 +530,8 @@ func (h *EntityHandler) typeDiscriminatorProperty() *metadata.PropertyMetadata {
 	for _, candidate := range candidates {
 		for i := range h.metadata.Properties {
 			prop := &h.metadata.Properties[i]
-			if prop.Type.Kind() != reflect.String {
+			primitiveType, ok := prop.EffectivePrimitiveType()
+			if !ok || primitiveType != metadata.PrimitiveTypeString {
 				continue
 			}
 

--- a/internal/handlers/entity_cache.go
+++ b/internal/handlers/entity_cache.go
@@ -281,20 +281,14 @@ func (h *EntityHandler) filterSupported(expr *query.FilterExpression) bool {
 		return true
 	case query.OpContains, query.OpStartsWith, query.OpEndsWith:
 		// Ordinal string functions only make sense for string properties.
-		return prop.Type != nil && underlyingKind(prop.Type) == reflect.String
+		primitiveType, ok := prop.EffectivePrimitiveType()
+		return ok && primitiveType == metadata.PrimitiveTypeString
 	case query.OpIn:
 		_, isSlice := expr.Value.([]interface{})
 		return isSlice
 	default:
 		return false
 	}
-}
-
-func underlyingKind(t reflect.Type) reflect.Kind {
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	return t.Kind()
 }
 
 // preparedFilterNode is a query.FilterExpression with its property lookup and

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -60,15 +60,32 @@ func parseEntityKeyValues(entityKey string, keyProperties []metadata.PropertyMet
 func convertKeyValue(value string, keyName string, keyProperties []metadata.PropertyMetadata) interface{} {
 	// Find the property metadata for this key
 	var propType reflect.Type
+	var edmType metadata.PrimitiveType
 	for _, prop := range keyProperties {
 		if prop.JsonName == keyName || prop.Name == keyName {
 			propType = prop.Type
+			edmType = prop.EdmType
 			break
 		}
 	}
 
-	// If we didn't find the type or type is nil, return string
+	// Preserve exact Go types for struct-backed entities.
 	if propType == nil {
+		switch edmType {
+		case metadata.PrimitiveTypeByte, metadata.PrimitiveTypeInt16, metadata.PrimitiveTypeInt32, metadata.PrimitiveTypeInt64,
+			metadata.PrimitiveTypeSByte:
+			if intVal, err := strconv.ParseInt(value, 10, 64); err == nil {
+				return intVal
+			}
+		case metadata.PrimitiveTypeSingle, metadata.PrimitiveTypeDouble, metadata.PrimitiveTypeDecimal:
+			if floatVal, err := strconv.ParseFloat(value, 64); err == nil {
+				return floatVal
+			}
+		case metadata.PrimitiveTypeBoolean:
+			if boolVal, err := strconv.ParseBool(value); err == nil {
+				return boolVal
+			}
+		}
 		return value
 	}
 

--- a/internal/handlers/helpers_test.go
+++ b/internal/handlers/helpers_test.go
@@ -588,6 +588,15 @@ func TestConvertKeyValue(t *testing.T) {
 			expected: "abc123",
 		},
 		{
+			name:    "Convert from EDM type without Go type",
+			value:   "42",
+			keyName: "ID",
+			keyProperties: []metadata.PropertyMetadata{
+				{JsonName: "ID", Name: "ID", EdmType: metadata.PrimitiveTypeInt64},
+			},
+			expected: int64(42),
+		},
+		{
 			name:    "Invalid int - return string",
 			value:   "not-a-number",
 			keyName: "ID",

--- a/internal/handlers/metadata_handler.go
+++ b/internal/handlers/metadata_handler.go
@@ -437,7 +437,7 @@ func (m metadataModel) collectTypeDefinitions() map[string]*typeDefinitionInfo {
 
 			typeDefinitions[prop.TypeDefinitionName] = &typeDefinitionInfo{
 				Name:           tdInfo.Name,
-				UnderlyingType: tdInfo.UnderlyingType,
+				UnderlyingType: string(tdInfo.UnderlyingType),
 				Precision:      tdInfo.Precision,
 				Scale:          tdInfo.Scale,
 				MaxLength:      tdInfo.MaxLength,
@@ -527,6 +527,9 @@ func (m metadataModel) getEntitySetNameForType(entityTypeName string) string {
 
 // getEdmType converts a Go type to an EDM (Entity Data Model) type
 func getEdmType(goType reflect.Type) string {
+	if goType == nil {
+		return ""
+	}
 	// Handle pointer types
 	if goType.Kind() == reflect.Ptr {
 		goType = goType.Elem()

--- a/internal/handlers/metadata_handler_test.go
+++ b/internal/handlers/metadata_handler_test.go
@@ -98,6 +98,40 @@ func TestMetadataHandler_HandleMetadata_GetJSON(t *testing.T) {
 	}
 }
 
+func TestMetadataHandlerUsesPrimitiveTypeWithoutGoType(t *testing.T) {
+	entityMetadata := &metadata.EntityMetadata{
+		EntityName:    "RuntimeProduct",
+		EntitySetName: "RuntimeProducts",
+		Properties: []metadata.PropertyMetadata{
+			{
+				Name:     "ReleaseDate",
+				JsonName: "ReleaseDate",
+				EdmType:  metadata.PrimitiveTypeDate,
+			},
+		},
+	}
+	handler := NewMetadataHandler(map[string]*metadata.EntityMetadata{
+		entityMetadata.EntitySetName: entityMetadata,
+	})
+
+	for _, accept := range []string{"application/xml", "application/json"} {
+		t.Run(accept, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/$metadata", nil)
+			req.Header.Set("Accept", accept)
+			w := httptest.NewRecorder()
+
+			handler.HandleMetadata(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "Edm.Date") {
+				t.Fatalf("metadata does not contain declared EDM type: %s", w.Body.String())
+			}
+		})
+	}
+}
+
 func TestMetadataHandler_HandleMetadata_Head(t *testing.T) {
 	meta1, _ := metadata.AnalyzeEntity(MetadataTestProduct{})
 	entitiesMetadata := map[string]*metadata.EntityMetadata{

--- a/internal/handlers/metadata_shared.go
+++ b/internal/handlers/metadata_shared.go
@@ -118,6 +118,9 @@ func (h *MetadataHandler) propertyEdmType(model metadataModel, prop *metadata.Pr
 			return model.qualifiedTypeName(name)
 		}
 	}
+	if prop.EdmType != "" {
+		return string(prop.EdmType)
+	}
 	return getEdmType(prop.Type)
 }
 

--- a/internal/metadata/analyzer.go
+++ b/internal/metadata/analyzer.go
@@ -141,7 +141,7 @@ type PropertyMetadata struct {
 	// UnderlyingType where present. Used by $filter to type-check literals and
 	// function arguments against the property's declared type rather than just
 	// its Go reflect.Kind. Empty for navigation properties and complex types.
-	EdmType string
+	EdmType PrimitiveType
 	// Binary properties
 	ContentType string // MIME type for binary properties (e.g., "image/svg+xml"), used when serving /$value
 	// Stream properties
@@ -532,7 +532,7 @@ func analyzeField(field reflect.StructField, metadata *EntityMetadata) (Property
 		if typeDefInfo != nil {
 			property.EdmType = typeDefInfo.UnderlyingType
 		} else if !property.IsEnum {
-			if edmType, err := inferUnderlyingEdmType(fieldType); err == nil {
+			if edmType, err := PrimitiveTypeFromGoType(fieldType); err == nil {
 				property.EdmType = edmType
 			}
 		}
@@ -1200,7 +1200,7 @@ func detectTypeDiscriminator(metadata *EntityMetadata) {
 			prop := &metadata.Properties[i]
 
 			// Discriminator must be a string type
-			if prop.Type.Kind() != reflect.String {
+			if prop.EdmType != PrimitiveTypeString {
 				continue
 			}
 

--- a/internal/metadata/primitive_type.go
+++ b/internal/metadata/primitive_type.go
@@ -1,0 +1,160 @@
+package metadata
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// PrimitiveType identifies an EDM primitive type.
+type PrimitiveType string
+
+const (
+	PrimitiveTypeBinary                   PrimitiveType = "Edm.Binary"
+	PrimitiveTypeBoolean                  PrimitiveType = "Edm.Boolean"
+	PrimitiveTypeByte                     PrimitiveType = "Edm.Byte"
+	PrimitiveTypeDate                     PrimitiveType = "Edm.Date"
+	PrimitiveTypeDateTimeOffset           PrimitiveType = "Edm.DateTimeOffset"
+	PrimitiveTypeDecimal                  PrimitiveType = "Edm.Decimal"
+	PrimitiveTypeDouble                   PrimitiveType = "Edm.Double"
+	PrimitiveTypeDuration                 PrimitiveType = "Edm.Duration"
+	PrimitiveTypeGeography                PrimitiveType = "Edm.Geography"
+	PrimitiveTypeGeographyCollection      PrimitiveType = "Edm.GeographyCollection"
+	PrimitiveTypeGeographyLineString      PrimitiveType = "Edm.GeographyLineString"
+	PrimitiveTypeGeographyMultiLineString PrimitiveType = "Edm.GeographyMultiLineString"
+	PrimitiveTypeGeographyMultiPoint      PrimitiveType = "Edm.GeographyMultiPoint"
+	PrimitiveTypeGeographyMultiPolygon    PrimitiveType = "Edm.GeographyMultiPolygon"
+	PrimitiveTypeGeographyPoint           PrimitiveType = "Edm.GeographyPoint"
+	PrimitiveTypeGeographyPolygon         PrimitiveType = "Edm.GeographyPolygon"
+	PrimitiveTypeGeometry                 PrimitiveType = "Edm.Geometry"
+	PrimitiveTypeGeometryCollection       PrimitiveType = "Edm.GeometryCollection"
+	PrimitiveTypeGeometryLineString       PrimitiveType = "Edm.GeometryLineString"
+	PrimitiveTypeGeometryMultiLineString  PrimitiveType = "Edm.GeometryMultiLineString"
+	PrimitiveTypeGeometryMultiPoint       PrimitiveType = "Edm.GeometryMultiPoint"
+	PrimitiveTypeGeometryMultiPolygon     PrimitiveType = "Edm.GeometryMultiPolygon"
+	PrimitiveTypeGeometryPoint            PrimitiveType = "Edm.GeometryPoint"
+	PrimitiveTypeGeometryPolygon          PrimitiveType = "Edm.GeometryPolygon"
+	PrimitiveTypeGuid                     PrimitiveType = "Edm.Guid"
+	PrimitiveTypeInt16                    PrimitiveType = "Edm.Int16"
+	PrimitiveTypeInt32                    PrimitiveType = "Edm.Int32"
+	PrimitiveTypeInt64                    PrimitiveType = "Edm.Int64"
+	PrimitiveTypeSByte                    PrimitiveType = "Edm.SByte"
+	PrimitiveTypeSingle                   PrimitiveType = "Edm.Single"
+	PrimitiveTypeStream                   PrimitiveType = "Edm.Stream"
+	PrimitiveTypeString                   PrimitiveType = "Edm.String"
+	PrimitiveTypeTimeOfDay                PrimitiveType = "Edm.TimeOfDay"
+	PrimitiveTypeUntyped                  PrimitiveType = "Edm.Untyped"
+)
+
+var validPrimitiveTypes = map[PrimitiveType]struct{}{
+	PrimitiveTypeBinary:                   {},
+	PrimitiveTypeBoolean:                  {},
+	PrimitiveTypeByte:                     {},
+	PrimitiveTypeDate:                     {},
+	PrimitiveTypeDateTimeOffset:           {},
+	PrimitiveTypeDecimal:                  {},
+	PrimitiveTypeDouble:                   {},
+	PrimitiveTypeDuration:                 {},
+	PrimitiveTypeGeography:                {},
+	PrimitiveTypeGeographyCollection:      {},
+	PrimitiveTypeGeographyLineString:      {},
+	PrimitiveTypeGeographyMultiLineString: {},
+	PrimitiveTypeGeographyMultiPoint:      {},
+	PrimitiveTypeGeographyMultiPolygon:    {},
+	PrimitiveTypeGeographyPoint:           {},
+	PrimitiveTypeGeographyPolygon:         {},
+	PrimitiveTypeGeometry:                 {},
+	PrimitiveTypeGeometryCollection:       {},
+	PrimitiveTypeGeometryLineString:       {},
+	PrimitiveTypeGeometryMultiLineString:  {},
+	PrimitiveTypeGeometryMultiPoint:       {},
+	PrimitiveTypeGeometryMultiPolygon:     {},
+	PrimitiveTypeGeometryPoint:            {},
+	PrimitiveTypeGeometryPolygon:          {},
+	PrimitiveTypeGuid:                     {},
+	PrimitiveTypeInt16:                    {},
+	PrimitiveTypeInt32:                    {},
+	PrimitiveTypeInt64:                    {},
+	PrimitiveTypeSByte:                    {},
+	PrimitiveTypeSingle:                   {},
+	PrimitiveTypeStream:                   {},
+	PrimitiveTypeString:                   {},
+	PrimitiveTypeTimeOfDay:                {},
+	PrimitiveTypeUntyped:                  {},
+}
+
+// ParsePrimitiveType validates and returns an EDM primitive type name.
+func ParsePrimitiveType(name string) (PrimitiveType, error) {
+	primitiveType := PrimitiveType(name)
+	if _, ok := validPrimitiveTypes[primitiveType]; !ok {
+		return "", fmt.Errorf("unsupported EDM primitive type %q", name)
+	}
+	return primitiveType, nil
+}
+
+// EffectivePrimitiveType returns the declared EDM type, falling back to the Go
+// type for metadata created by legacy internal callers.
+func (p *PropertyMetadata) EffectivePrimitiveType() (PrimitiveType, bool) {
+	if p == nil {
+		return "", false
+	}
+	if p.EdmType != "" {
+		return p.EdmType, true
+	}
+	primitiveType, err := PrimitiveTypeFromGoType(p.Type)
+	return primitiveType, err == nil
+}
+
+// PrimitiveTypeFromGoType infers the EDM primitive type represented by a Go type.
+func PrimitiveTypeFromGoType(goType reflect.Type) (PrimitiveType, error) {
+	if goType == nil {
+		return "", fmt.Errorf("cannot infer EDM primitive type from nil Go type")
+	}
+	for goType.Kind() == reflect.Ptr {
+		goType = goType.Elem()
+	}
+
+	switch goType.String() {
+	case "time.Time":
+		return PrimitiveTypeDateTimeOffset, nil
+	case "uuid.UUID", "github.com/google/uuid.UUID":
+		return PrimitiveTypeGuid, nil
+	case "decimal.Decimal", "github.com/shopspring/decimal.Decimal":
+		return PrimitiveTypeDecimal, nil
+	case "json.RawMessage", "encoding/json.RawMessage":
+		return PrimitiveTypeUntyped, nil
+	}
+
+	if goType.Kind() == reflect.Interface {
+		return PrimitiveTypeUntyped, nil
+	}
+	if (goType.Kind() == reflect.Slice || goType.Kind() == reflect.Array) && goType.Elem().Kind() == reflect.Uint8 {
+		return PrimitiveTypeBinary, nil
+	}
+
+	switch goType.Kind() {
+	case reflect.String:
+		return PrimitiveTypeString, nil
+	case reflect.Bool:
+		return PrimitiveTypeBoolean, nil
+	case reflect.Int8:
+		return PrimitiveTypeSByte, nil
+	case reflect.Int16:
+		return PrimitiveTypeInt16, nil
+	case reflect.Int, reflect.Int32:
+		return PrimitiveTypeInt32, nil
+	case reflect.Int64:
+		return PrimitiveTypeInt64, nil
+	case reflect.Uint8:
+		return PrimitiveTypeByte, nil
+	case reflect.Uint16:
+		return PrimitiveTypeInt32, nil
+	case reflect.Uint, reflect.Uint32, reflect.Uint64:
+		return PrimitiveTypeInt64, nil
+	case reflect.Float32:
+		return PrimitiveTypeSingle, nil
+	case reflect.Float64:
+		return PrimitiveTypeDouble, nil
+	default:
+		return "", fmt.Errorf("unsupported Go type %s", goType)
+	}
+}

--- a/internal/metadata/primitive_type_test.go
+++ b/internal/metadata/primitive_type_test.go
@@ -1,0 +1,52 @@
+package metadata
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePrimitiveType(t *testing.T) {
+	t.Parallel()
+
+	primitiveType, err := ParsePrimitiveType("Edm.Date")
+	if err != nil {
+		t.Fatalf("ParsePrimitiveType() error = %v", err)
+	}
+	if primitiveType != PrimitiveTypeDate {
+		t.Fatalf("ParsePrimitiveType() = %q, want %q", primitiveType, PrimitiveTypeDate)
+	}
+
+	if _, err := ParsePrimitiveType("Edm.NotAType"); err == nil {
+		t.Fatal("ParsePrimitiveType() expected an error for an unsupported type")
+	}
+}
+
+func TestPrimitiveTypeFromGoType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		goType reflect.Type
+		want   PrimitiveType
+	}{
+		{name: "string", goType: reflect.TypeOf(""), want: PrimitiveTypeString},
+		{name: "int8", goType: reflect.TypeOf(int8(0)), want: PrimitiveTypeSByte},
+		{name: "uint8", goType: reflect.TypeOf(uint8(0)), want: PrimitiveTypeByte},
+		{name: "uint32", goType: reflect.TypeOf(uint32(0)), want: PrimitiveTypeInt64},
+		{name: "binary", goType: reflect.TypeOf([]byte(nil)), want: PrimitiveTypeBinary},
+		{name: "pointer", goType: reflect.TypeOf((*string)(nil)), want: PrimitiveTypeString},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := PrimitiveTypeFromGoType(test.goType)
+			if err != nil {
+				t.Fatalf("PrimitiveTypeFromGoType() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("PrimitiveTypeFromGoType() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/metadata/type_definition_registry.go
+++ b/internal/metadata/type_definition_registry.go
@@ -15,7 +15,7 @@ type TypeDefinitionInfo struct {
 	Name string
 	// UnderlyingType is the EDM primitive type (e.g., "Edm.Decimal", "Edm.String").
 	// Derived automatically from the Go type if not provided.
-	UnderlyingType string
+	UnderlyingType PrimitiveType
 	// Precision is the numeric precision facet (only for Edm.Decimal).
 	Precision int
 	// Scale is the numeric scale facet (only for Edm.Decimal).
@@ -61,6 +61,8 @@ func RegisterTypeDefinition(goType reflect.Type, info TypeDefinitionInfo) error 
 			return fmt.Errorf("cannot infer underlying EDM type for %s: %w", goType.Name(), err)
 		}
 		info.UnderlyingType = underlying
+	} else if _, err := ParsePrimitiveType(string(info.UnderlyingType)); err != nil {
+		return fmt.Errorf("invalid underlying EDM type for %s: %w", goType.Name(), err)
 	}
 
 	typeDefinitionRegistry.Lock()
@@ -90,46 +92,6 @@ func GetTypeDefinition(goType reflect.Type) (*TypeDefinitionInfo, bool) {
 }
 
 // inferUnderlyingEdmType returns the EDM primitive type name for the given Go type.
-func inferUnderlyingEdmType(t reflect.Type) (string, error) {
-	// Check for well-known named types first
-	switch t.String() {
-	case "time.Time":
-		return "Edm.DateTimeOffset", nil
-	case "uuid.UUID", "github.com/google/uuid.UUID":
-		return "Edm.Guid", nil
-	case "decimal.Decimal", "github.com/shopspring/decimal.Decimal":
-		return "Edm.Decimal", nil
-	}
-
-	switch t.Kind() {
-	case reflect.String:
-		return "Edm.String", nil
-	case reflect.Bool:
-		return "Edm.Boolean", nil
-	case reflect.Int8:
-		return "Edm.SByte", nil
-	case reflect.Int16:
-		return "Edm.Int16", nil
-	case reflect.Int, reflect.Int32:
-		return "Edm.Int32", nil
-	case reflect.Int64:
-		return "Edm.Int64", nil
-	case reflect.Uint8:
-		return "Edm.Byte", nil
-	case reflect.Uint16:
-		return "Edm.Int32", nil
-	case reflect.Uint, reflect.Uint32:
-		return "Edm.Int64", nil
-	case reflect.Uint64:
-		return "Edm.Int64", nil
-	case reflect.Float32:
-		return "Edm.Single", nil
-	case reflect.Float64:
-		return "Edm.Double", nil
-	default:
-		if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8 {
-			return "Edm.Binary", nil
-		}
-		return "", fmt.Errorf("unsupported underlying kind %s for TypeDefinition", t.Kind())
-	}
+func inferUnderlyingEdmType(t reflect.Type) (PrimitiveType, error) {
+	return PrimitiveTypeFromGoType(t)
 }

--- a/internal/metadata/type_definition_registry_test.go
+++ b/internal/metadata/type_definition_registry_test.go
@@ -155,7 +155,7 @@ func TestInferUnderlyingEdmType(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-			if got != tt.want {
+			if string(got) != tt.want {
 				t.Errorf("inferUnderlyingEdmType(%s) = %s, want %s", tt.name, got, tt.want)
 			}
 		})

--- a/internal/query/apply_transform.go
+++ b/internal/query/apply_transform.go
@@ -1017,7 +1017,7 @@ func isFloatingProperty(prop *metadata.PropertyMetadata) bool {
 	if prop == nil {
 		return false
 	}
-	if prop.EdmType == "Edm.Double" || prop.EdmType == "Edm.Single" {
+	if prop.EdmType == metadata.PrimitiveTypeDouble || prop.EdmType == metadata.PrimitiveTypeSingle {
 		return true
 	}
 	if prop.Type != nil {

--- a/internal/query/ast_parser_functions.go
+++ b/internal/query/ast_parser_functions.go
@@ -190,18 +190,18 @@ func convertSingleArgFunctionWithContext(n *FunctionCallExpr, functionName strin
 // set of EDM primitive types its argument may be declared as. Per OData Protocol
 // §11.2.5.1, these functions only apply to Edm.Date/Edm.TimeOfDay/Edm.DateTimeOffset/
 // Edm.Duration values - applying them to e.g. an Edm.String property is a type error.
-var dateTimeFunctionCompatibleEdmTypes = map[string]map[string]bool{
-	"year":               {"Edm.Date": true, "Edm.DateTimeOffset": true},
-	"month":              {"Edm.Date": true, "Edm.DateTimeOffset": true},
-	"day":                {"Edm.Date": true, "Edm.DateTimeOffset": true},
-	"hour":               {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
-	"minute":             {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
-	"second":             {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
-	"fractionalseconds":  {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
-	"date":               {"Edm.Date": true, "Edm.DateTimeOffset": true},
-	"time":               {"Edm.TimeOfDay": true, "Edm.DateTimeOffset": true},
-	"totaloffsetminutes": {"Edm.DateTimeOffset": true},
-	"totalseconds":       {"Edm.Duration": true},
+var dateTimeFunctionCompatibleEdmTypes = map[string]map[metadata.PrimitiveType]bool{
+	"year":               {metadata.PrimitiveTypeDate: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"month":              {metadata.PrimitiveTypeDate: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"day":                {metadata.PrimitiveTypeDate: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"hour":               {metadata.PrimitiveTypeTimeOfDay: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"minute":             {metadata.PrimitiveTypeTimeOfDay: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"second":             {metadata.PrimitiveTypeTimeOfDay: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"fractionalseconds":  {metadata.PrimitiveTypeTimeOfDay: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"date":               {metadata.PrimitiveTypeDate: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"time":               {metadata.PrimitiveTypeTimeOfDay: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"totaloffsetminutes": {metadata.PrimitiveTypeDateTimeOffset: true},
+	"totalseconds":       {metadata.PrimitiveTypeDuration: true},
 }
 
 // validateDateTimeFunctionArgType rejects date/time-extraction functions applied to a

--- a/internal/query/ast_parser_validation.go
+++ b/internal/query/ast_parser_validation.go
@@ -392,12 +392,12 @@ func resolveEnumMemberName(enumLiteral string, property string, entityMetadata *
 // it may be compared against. Unlike the Go-reflect-based checks below, these
 // literal types are unambiguous at parse time, so a mismatch here is a genuine
 // client error per OData Protocol §11.2.5.1.
-var dateTimeLiteralCompatibleEdmTypes = map[string]map[string]bool{
-	"date":     {"Edm.Date": true, "Edm.DateTimeOffset": true},
-	"time":     {"Edm.TimeOfDay": true},
-	"datetime": {"Edm.DateTimeOffset": true},
-	"duration": {"Edm.Duration": true},
-	"guid":     {"Edm.Guid": true},
+var dateTimeLiteralCompatibleEdmTypes = map[string]map[metadata.PrimitiveType]bool{
+	"date":     {metadata.PrimitiveTypeDate: true, metadata.PrimitiveTypeDateTimeOffset: true},
+	"time":     {metadata.PrimitiveTypeTimeOfDay: true},
+	"datetime": {metadata.PrimitiveTypeDateTimeOffset: true},
+	"duration": {metadata.PrimitiveTypeDuration: true},
+	"guid":     {metadata.PrimitiveTypeGuid: true},
 }
 
 // validateValueAgainstPropertyType validates that a filter value is appropriate for the target property type.
@@ -417,13 +417,9 @@ func validateValueAgainstPropertyType(property string, value interface{}, litera
 		}
 	}
 
-	// Get the property's Go type (handling pointers)
+	// Reflection remains a secondary hint for exact Go-width overflow checks.
 	propType := prop.Type
-	if propType == nil {
-		// Type not available - skip validation (may be enum or other special type)
-		return nil
-	}
-	if propType.Kind() == reflect.Ptr {
+	if propType != nil && propType.Kind() == reflect.Ptr {
 		propType = propType.Elem()
 	}
 
@@ -438,7 +434,7 @@ func validateValueAgainstPropertyType(property string, value interface{}, litera
 	if isNumeric {
 		// Validate numeric value against numeric property
 		// Check for Int64 overflow (only relevant for float64 values)
-		if floatVal, isFloat := value.(float64); isFloat {
+		if floatVal, isFloat := value.(float64); isFloat && propType != nil {
 			if propType.Kind() == reflect.Int64 || propType.Kind() == reflect.Uint64 {
 				const maxInt64Plus1 = 9223372036854775808.0 // 2^63
 				const minInt64 = -9223372036854775808.0     // -2^63
@@ -449,13 +445,13 @@ func validateValueAgainstPropertyType(property string, value interface{}, litera
 		}
 
 		// Verify property is numeric (compatible with numeric value)
-		switch propType.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-			reflect.Float32, reflect.Float64:
+		switch prop.EdmType {
+		case metadata.PrimitiveTypeByte, metadata.PrimitiveTypeSByte,
+			metadata.PrimitiveTypeInt16, metadata.PrimitiveTypeInt32, metadata.PrimitiveTypeInt64,
+			metadata.PrimitiveTypeSingle, metadata.PrimitiveTypeDouble, metadata.PrimitiveTypeDecimal:
 			// All good - numeric value for numeric property
 			return nil
-		case reflect.String:
+		case metadata.PrimitiveTypeString:
 			// Type mismatch: numeric value for string property
 			return fmt.Errorf("type mismatch: cannot compare numeric value %v to string property '%s'", value, property)
 		default:
@@ -472,13 +468,13 @@ func validateValueAgainstPropertyType(property string, value interface{}, litera
 		}
 
 		// Validate string value against string property
-		switch propType.Kind() {
-		case reflect.String:
+		switch prop.EdmType {
+		case metadata.PrimitiveTypeString:
 			// All good - string value for string property
 			return nil
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-			reflect.Float32, reflect.Float64:
+		case metadata.PrimitiveTypeByte, metadata.PrimitiveTypeSByte,
+			metadata.PrimitiveTypeInt16, metadata.PrimitiveTypeInt32, metadata.PrimitiveTypeInt64,
+			metadata.PrimitiveTypeSingle, metadata.PrimitiveTypeDouble, metadata.PrimitiveTypeDecimal:
 			// Type mismatch: string value for numeric property
 			return fmt.Errorf("type mismatch: cannot compare string value %q to numeric property '%s'", strVal, property)
 		default:

--- a/internal/query/edm_type_validation_test.go
+++ b/internal/query/edm_type_validation_test.go
@@ -1,0 +1,33 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+func TestValidateValueAgainstPropertyTypeWithoutGoType(t *testing.T) {
+	t.Parallel()
+
+	entityMetadata := &metadata.EntityMetadata{
+		Properties: []metadata.PropertyMetadata{
+			{Name: "Name", JsonName: "Name", EdmType: metadata.PrimitiveTypeString},
+			{Name: "Amount", JsonName: "Amount", EdmType: metadata.PrimitiveTypeDecimal},
+		},
+	}
+
+	if err := validateValueAgainstPropertyType("Amount", float64(42), "number", entityMetadata); err != nil {
+		t.Fatalf("numeric value for Edm.Decimal returned error: %v", err)
+	}
+
+	err := validateValueAgainstPropertyType("Name", float64(42), "number", entityMetadata)
+	if err == nil || !strings.Contains(err.Error(), "string property") {
+		t.Fatalf("numeric value for Edm.String error = %v, want type mismatch", err)
+	}
+
+	err = validateValueAgainstPropertyType("Amount", "forty-two", "string", entityMetadata)
+	if err == nil || !strings.Contains(err.Error(), "numeric property") {
+		t.Fatalf("string value for Edm.Decimal error = %v, want type mismatch", err)
+	}
+}

--- a/internal/query/fts.go
+++ b/internal/query/fts.go
@@ -214,7 +214,8 @@ func (m *FTSManager) getSearchableColumns(entityMetadata *metadata.EntityMetadat
 func (m *FTSManager) getAllStringColumns(entityMetadata *metadata.EntityMetadata) []string {
 	var cols []string
 	for _, prop := range entityMetadata.Properties {
-		if prop.Type.String() == "string" && !prop.IsNavigationProp {
+		primitiveType, ok := prop.EffectivePrimitiveType()
+		if ok && primitiveType == metadata.PrimitiveTypeString && !prop.IsNavigationProp {
 			// Use cached column name from metadata
 			cols = append(cols, prop.ColumnName)
 		}

--- a/internal/query/search.go
+++ b/internal/query/search.go
@@ -77,7 +77,8 @@ func getSearchableProperties(entityMetadata *metadata.EntityMetadata) []metadata
 func getAllStringProperties(entityMetadata *metadata.EntityMetadata) []metadata.PropertyMetadata {
 	var stringProps []metadata.PropertyMetadata
 	for _, prop := range entityMetadata.Properties {
-		if prop.Type.Kind() == reflect.String && !prop.IsNavigationProp {
+		primitiveType, ok := prop.EffectivePrimitiveType()
+		if ok && primitiveType == metadata.PrimitiveTypeString && !prop.IsNavigationProp {
 			// Set default fuzziness to 1 (exact substring match) for implicitly searchable properties
 			prop.SearchFuzziness = 1
 			stringProps = append(stringProps, prop)

--- a/primitive_type.go
+++ b/primitive_type.go
@@ -1,0 +1,48 @@
+package odata
+
+import "github.com/nlstn/go-odata/internal/metadata"
+
+// PrimitiveType identifies an EDM primitive type.
+type PrimitiveType = metadata.PrimitiveType
+
+const (
+	EdmBinary                   = metadata.PrimitiveTypeBinary
+	EdmBoolean                  = metadata.PrimitiveTypeBoolean
+	EdmByte                     = metadata.PrimitiveTypeByte
+	EdmDate                     = metadata.PrimitiveTypeDate
+	EdmDateTimeOffset           = metadata.PrimitiveTypeDateTimeOffset
+	EdmDecimal                  = metadata.PrimitiveTypeDecimal
+	EdmDouble                   = metadata.PrimitiveTypeDouble
+	EdmDuration                 = metadata.PrimitiveTypeDuration
+	EdmGeography                = metadata.PrimitiveTypeGeography
+	EdmGeographyCollection      = metadata.PrimitiveTypeGeographyCollection
+	EdmGeographyLineString      = metadata.PrimitiveTypeGeographyLineString
+	EdmGeographyMultiLineString = metadata.PrimitiveTypeGeographyMultiLineString
+	EdmGeographyMultiPoint      = metadata.PrimitiveTypeGeographyMultiPoint
+	EdmGeographyMultiPolygon    = metadata.PrimitiveTypeGeographyMultiPolygon
+	EdmGeographyPoint           = metadata.PrimitiveTypeGeographyPoint
+	EdmGeographyPolygon         = metadata.PrimitiveTypeGeographyPolygon
+	EdmGeometry                 = metadata.PrimitiveTypeGeometry
+	EdmGeometryCollection       = metadata.PrimitiveTypeGeometryCollection
+	EdmGeometryLineString       = metadata.PrimitiveTypeGeometryLineString
+	EdmGeometryMultiLineString  = metadata.PrimitiveTypeGeometryMultiLineString
+	EdmGeometryMultiPoint       = metadata.PrimitiveTypeGeometryMultiPoint
+	EdmGeometryMultiPolygon     = metadata.PrimitiveTypeGeometryMultiPolygon
+	EdmGeometryPoint            = metadata.PrimitiveTypeGeometryPoint
+	EdmGeometryPolygon          = metadata.PrimitiveTypeGeometryPolygon
+	EdmGuid                     = metadata.PrimitiveTypeGuid
+	EdmInt16                    = metadata.PrimitiveTypeInt16
+	EdmInt32                    = metadata.PrimitiveTypeInt32
+	EdmInt64                    = metadata.PrimitiveTypeInt64
+	EdmSByte                    = metadata.PrimitiveTypeSByte
+	EdmSingle                   = metadata.PrimitiveTypeSingle
+	EdmStream                   = metadata.PrimitiveTypeStream
+	EdmString                   = metadata.PrimitiveTypeString
+	EdmTimeOfDay                = metadata.PrimitiveTypeTimeOfDay
+	EdmUntyped                  = metadata.PrimitiveTypeUntyped
+)
+
+// ParsePrimitiveType validates an EDM primitive type name.
+func ParsePrimitiveType(name string) (PrimitiveType, error) {
+	return metadata.ParsePrimitiveType(name)
+}

--- a/type_definition.go
+++ b/type_definition.go
@@ -48,9 +48,18 @@ func RegisterTypeDefinition(goValue interface{}, name string, facets TypeDefinit
 		goType = goType.Elem()
 	}
 
+	var underlyingType PrimitiveType
+	if facets.UnderlyingType != "" {
+		var err error
+		underlyingType, err = ParsePrimitiveType(facets.UnderlyingType)
+		if err != nil {
+			return err
+		}
+	}
+
 	return metadata.RegisterTypeDefinition(goType, metadata.TypeDefinitionInfo{
 		Name:           name,
-		UnderlyingType: facets.UnderlyingType,
+		UnderlyingType: underlyingType,
 		Precision:      facets.Precision,
 		Scale:          facets.Scale,
 		MaxLength:      facets.MaxLength,


### PR DESCRIPTION
Makes declared EDM primitive types authoritative for protocol behavior while retaining Go reflection for struct and storage mechanics.

## Summary

- add a validated `PrimitiveType` API and constants for supported EDM primitive types
- centralize Go-to-EDM primitive inference and validate TypeDefinition overrides
- make CSDL generation, filter compatibility, temporal validation, key parsing, search/FTS classification, cache filtering, discriminator detection, and numeric classification use EDM metadata
- retain fallback inference for legacy internal metadata constructed with only a Go type
- add regression coverage for metadata, key parsing, and filter validation when no `reflect.Type` is available

This prepares the metadata and protocol layers for runtime-defined entities without changing existing struct-based registration.

Related to #892.

## Validation

- `go test ./...`
- `go build ./...`
- `golangci-lint run ./...`