### PR TITLE
Support map-backed entity key access

### DIFF
--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -534,31 +534,11 @@ func formatUUIDFromBytes(b [16]byte) string {
 
 func (h *EntityHandler) buildEntityLocation(r *http.Request, entity interface{}) string {
 	baseURL := response.BuildBaseURL(r)
-	entitySetName := h.metadata.EntitySetName
-
-	entityValue := reflect.ValueOf(entity)
-	if entityValue.Kind() == reflect.Ptr {
-		entityValue = entityValue.Elem()
+	keyValues := response.ExtractEntityKeys(entity, h.metadata.KeyProperties)
+	if len(keyValues) != len(h.metadata.KeyProperties) {
+		return ""
 	}
-
-	if len(h.metadata.KeyProperties) == 1 {
-		keyProp := h.metadata.KeyProperties[0]
-		keyValue := entityValue.FieldByName(keyProp.Name)
-		return fmt.Sprintf("%s/%s(%v)", baseURL, entitySetName, keyValue.Interface())
-	}
-
-	var keyParts []string
-	for _, keyProp := range h.metadata.KeyProperties {
-		keyValue := entityValue.FieldByName(keyProp.Name)
-		switch keyValue.Kind() {
-		case reflect.String:
-			keyParts = append(keyParts, fmt.Sprintf("%s='%v'", keyProp.JsonName, keyValue.Interface()))
-		default:
-			keyParts = append(keyParts, fmt.Sprintf("%s=%v", keyProp.JsonName, keyValue.Interface()))
-		}
-	}
-
-	return fmt.Sprintf("%s/%s(%s)", baseURL, entitySetName, strings.Join(keyParts, ","))
+	return baseURL + "/" + response.BuildEntityID(h.metadata.EntitySetName, keyValues)
 }
 
 // handlePostEntityOverwrite handles POST entity requests using the overwrite handler

--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -534,11 +534,11 @@ func formatUUIDFromBytes(b [16]byte) string {
 
 func (h *EntityHandler) buildEntityLocation(r *http.Request, entity interface{}) string {
 	baseURL := response.BuildBaseURL(r)
-	keyValues := response.ExtractEntityKeys(entity, h.metadata.KeyProperties)
-	if len(keyValues) != len(h.metadata.KeyProperties) {
+	entityID := response.BuildEntityIDFromEntity(h.metadata.EntitySetName, entity, h.metadata.KeyProperties)
+	if entityID == "" {
 		return ""
 	}
-	return baseURL + "/" + response.BuildEntityID(h.metadata.EntitySetName, keyValues)
+	return baseURL + "/" + entityID
 }
 
 // handlePostEntityOverwrite handles POST entity requests using the overwrite handler

--- a/internal/handlers/entity_id_test.go
+++ b/internal/handlers/entity_id_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+func TestBuildEntityIDFromResultSupportsStructAndMap(t *testing.T) {
+	t.Parallel()
+
+	type entity struct {
+		ID string
+	}
+	type row map[string]interface{}
+
+	handler := &EntityHandler{metadata: &metadata.EntityMetadata{
+		EntitySetName: "Products",
+		KeyProperties: []metadata.PropertyMetadata{
+			{Name: "ID", FieldName: "ID", JsonName: "id"},
+		},
+	}}
+	request := httptest.NewRequest("GET", "http://example.com/Products", nil)
+	want := "http://example.com/Products('O''Brien')"
+
+	for _, test := range []struct {
+		name   string
+		result interface{}
+	}{
+		{name: "struct", result: entity{ID: "O'Brien"}},
+		{name: "map", result: map[string]interface{}{"id": "O'Brien"}},
+		{name: "named map", result: row{"id": "O'Brien"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := handler.buildEntityIDFromResult(test.result, request); got != want {
+				t.Fatalf("buildEntityIDFromResult() = %q, want %q", got, want)
+			}
+			if got := handler.buildEntityLocation(request, test.result); got != want {
+				t.Fatalf("buildEntityLocation() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestBuildEntityIDFromResultRequiresAllKeys(t *testing.T) {
+	t.Parallel()
+
+	handler := &EntityHandler{metadata: &metadata.EntityMetadata{
+		EntitySetName: "Products",
+		KeyProperties: []metadata.PropertyMetadata{
+			{Name: "ID", JsonName: "id"},
+			{Name: "Locale", JsonName: "locale"},
+		},
+	}}
+	request := httptest.NewRequest("GET", "http://example.com/Products", nil)
+
+	if got := handler.buildEntityIDFromResult(map[string]interface{}{"id": 1}, request); got != "" {
+		t.Fatalf("buildEntityIDFromResult() = %q, want empty ID", got)
+	}
+}

--- a/internal/handlers/entity_id_test.go
+++ b/internal/handlers/entity_id_test.go
@@ -60,3 +60,31 @@ func TestBuildEntityIDFromResultRequiresAllKeys(t *testing.T) {
 		t.Fatalf("buildEntityIDFromResult() = %q, want empty ID", got)
 	}
 }
+
+func TestBuildEntityIDFromResultPreservesCompositeKeyOrder(t *testing.T) {
+	t.Parallel()
+
+	type entity struct {
+		ProductID   int
+		LanguageKey string
+	}
+
+	handler := &EntityHandler{metadata: &metadata.EntityMetadata{
+		EntitySetName: "ProductDescriptions",
+		KeyProperties: []metadata.PropertyMetadata{
+			{Name: "ProductID", FieldName: "ProductID", JsonName: "productID"},
+			{Name: "LanguageKey", FieldName: "LanguageKey", JsonName: "languageKey"},
+		},
+	}}
+	request := httptest.NewRequest("GET", "http://example.com/ProductDescriptions", nil)
+	want := "http://example.com/ProductDescriptions(productID=1,languageKey='EN')"
+
+	for _, result := range []interface{}{
+		entity{ProductID: 1, LanguageKey: "EN"},
+		map[string]interface{}{"languageKey": "EN", "productID": 1},
+	} {
+		if got := handler.buildEntityIDFromResult(result, request); got != want {
+			t.Fatalf("buildEntityIDFromResult() = %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -1015,9 +1015,9 @@ func (h *EntityHandler) buildEntityIDFromResult(result interface{}, r *http.Requ
 	if r == nil || h.metadata == nil || len(h.metadata.KeyProperties) == 0 {
 		return ""
 	}
-	keyValues := response.ExtractEntityKeys(result, h.metadata.KeyProperties)
-	if len(keyValues) != len(h.metadata.KeyProperties) {
+	entityID := response.BuildEntityIDFromEntity(h.metadata.EntitySetName, result, h.metadata.KeyProperties)
+	if entityID == "" {
 		return ""
 	}
-	return response.BuildBaseURL(r) + "/" + response.BuildEntityID(h.metadata.EntitySetName, keyValues)
+	return response.BuildBaseURL(r) + "/" + entityID
 }

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -474,17 +474,7 @@ func (h *EntityHandler) buildOrderedEntityResponseWithMetadata(result interface{
 	resultValue := reflect.ValueOf(result)
 
 	// Build the entity ID for @odata.id
-	var entityID string
-	switch resultValue.Kind() {
-	case reflect.Ptr:
-		entityID = h.buildEntityIDFromValue(resultValue.Elem(), r)
-	case reflect.Struct:
-		entityID = h.buildEntityIDFromValue(resultValue, r)
-	case reflect.Map:
-		if mapResult, ok := result.(map[string]interface{}); ok {
-			entityID = h.buildEntityIDFromMap(mapResult, r)
-		}
-	}
+	entityID := h.buildEntityIDFromResult(result, r)
 
 	// Add @odata.id based on metadata level
 	if entityID != "" {
@@ -1020,72 +1010,14 @@ func parseVersion(version string) (int, int) {
 	return major, minor
 }
 
-// buildEntityIDFromValue builds the @odata.id value from an entity value
-func (h *EntityHandler) buildEntityIDFromValue(entityValue reflect.Value, r *http.Request) string {
-	if r == nil {
-		return ""
-	}
-	baseURL := response.BuildBaseURL(r)
-	keySegment := h.buildKeySegmentFromEntity(entityValue)
-	if keySegment == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s/%s(%s)", baseURL, h.metadata.EntitySetName, keySegment)
-}
-
-// buildEntityIDFromMap builds the @odata.id value from a map entity
-func (h *EntityHandler) buildEntityIDFromMap(entityMap map[string]interface{}, r *http.Request) string {
-	if r == nil {
-		return ""
-	}
-	baseURL := response.BuildBaseURL(r)
-
-	// Build key segment from map
-	keyProps := h.metadata.KeyProperties
-	if len(keyProps) == 0 {
-		return ""
-	}
-
-	// Single key
-	if len(keyProps) == 1 {
-		if keyValue, exists := entityMap[keyProps[0].JsonName]; exists && keyValue != nil {
-			return fmt.Sprintf("%s/%s(%v)", baseURL, h.metadata.EntitySetName, keyValue)
-		}
-		return ""
-	}
-
-	// Composite keys
-	var parts []string
-	for _, keyProp := range keyProps {
-		if keyValue, exists := entityMap[keyProp.JsonName]; exists && keyValue != nil {
-			// Quote string values
-			if strVal, ok := keyValue.(string); ok {
-				parts = append(parts, fmt.Sprintf("%s='%s'", keyProp.JsonName, strVal))
-			} else {
-				parts = append(parts, fmt.Sprintf("%s=%v", keyProp.JsonName, keyValue))
-			}
-		}
-	}
-
-	if len(parts) == 0 {
-		return ""
-	}
-
-	return fmt.Sprintf("%s/%s(%s)", baseURL, h.metadata.EntitySetName, strings.Join(parts, ","))
-}
-
 // buildEntityIDFromResult builds the @odata.id value from an entity result (any type).
 func (h *EntityHandler) buildEntityIDFromResult(result interface{}, r *http.Request) string {
-	resultValue := reflect.ValueOf(result)
-	switch resultValue.Kind() {
-	case reflect.Ptr:
-		return h.buildEntityIDFromValue(resultValue.Elem(), r)
-	case reflect.Struct:
-		return h.buildEntityIDFromValue(resultValue, r)
-	case reflect.Map:
-		if mapResult, ok := result.(map[string]interface{}); ok {
-			return h.buildEntityIDFromMap(mapResult, r)
-		}
+	if r == nil || h.metadata == nil || len(h.metadata.KeyProperties) == 0 {
+		return ""
 	}
-	return ""
+	keyValues := response.ExtractEntityKeys(result, h.metadata.KeyProperties)
+	if len(keyValues) != len(h.metadata.KeyProperties) {
+		return ""
+	}
+	return response.BuildBaseURL(r) + "/" + response.BuildEntityID(h.metadata.EntitySetName, keyValues)
 }

--- a/internal/metadata/property_value.go
+++ b/internal/metadata/property_value.go
@@ -1,0 +1,66 @@
+package metadata
+
+import "reflect"
+
+// ReadPropertyValue reads a property from a struct or string-keyed map.
+// Map values use the OData JSON property name as their canonical key.
+func ReadPropertyValue(entity interface{}, property PropertyMetadata) (interface{}, bool) {
+	if entity == nil {
+		return nil, false
+	}
+
+	value := reflect.ValueOf(entity)
+	for value.IsValid() && (value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return nil, false
+		}
+		value = value.Elem()
+	}
+
+	switch value.Kind() {
+	case reflect.Struct:
+		for _, name := range propertyFieldNames(property) {
+			field := value.FieldByName(name)
+			if field.IsValid() && field.CanInterface() {
+				return field.Interface(), true
+			}
+		}
+	case reflect.Map:
+		if value.Type().Key().Kind() != reflect.String {
+			return nil, false
+		}
+		for _, name := range propertyMapKeys(property) {
+			key := reflect.ValueOf(name).Convert(value.Type().Key())
+			mapValue := value.MapIndex(key)
+			if mapValue.IsValid() {
+				return mapValue.Interface(), true
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func propertyFieldNames(property PropertyMetadata) []string {
+	return uniquePropertyNames(property.FieldName, property.Name)
+}
+
+func propertyMapKeys(property PropertyMetadata) []string {
+	return uniquePropertyNames(property.JsonName, property.Name, property.FieldName)
+}
+
+func uniquePropertyNames(names ...string) []string {
+	result := make([]string, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	return result
+}

--- a/internal/metadata/property_value_test.go
+++ b/internal/metadata/property_value_test.go
@@ -1,0 +1,42 @@
+package metadata
+
+import "testing"
+
+func TestReadPropertyValue(t *testing.T) {
+	t.Parallel()
+
+	type entity struct {
+		ID int
+	}
+	type row map[string]interface{}
+
+	property := PropertyMetadata{Name: "ID", FieldName: "ID", JsonName: "id"}
+	tests := []struct {
+		name   string
+		entity interface{}
+		want   interface{}
+		ok     bool
+	}{
+		{name: "struct", entity: entity{ID: 1}, want: 1, ok: true},
+		{name: "struct pointer", entity: &entity{ID: 2}, want: 2, ok: true},
+		{name: "map JSON name", entity: map[string]interface{}{"id": 3}, want: 3, ok: true},
+		{name: "named map", entity: row{"id": 4}, want: 4, ok: true},
+		{name: "map field name fallback", entity: map[string]interface{}{"ID": 5}, want: 5, ok: true},
+		{name: "nil", entity: nil, ok: false},
+		{name: "nil pointer", entity: (*entity)(nil), ok: false},
+		{name: "unsupported", entity: []int{1}, ok: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ReadPropertyValue(test.entity, property)
+			if ok != test.ok {
+				t.Fatalf("ReadPropertyValue() ok = %v, want %v", ok, test.ok)
+			}
+			if got != test.want {
+				t.Fatalf("ReadPropertyValue() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/response/format_helpers.go
+++ b/internal/response/format_helpers.go
@@ -3,7 +3,6 @@ package response
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -55,16 +54,10 @@ func formatKeyValueLiteral(value interface{}) string {
 // ExtractEntityKeys extracts key values from an entity using metadata
 func ExtractEntityKeys(entity interface{}, keyProperties []metadata.PropertyMetadata) map[string]interface{} {
 	keyValues := make(map[string]interface{})
-	entityValue := reflect.ValueOf(entity)
-
-	if entityValue.Kind() == reflect.Ptr {
-		entityValue = entityValue.Elem()
-	}
 
 	for _, keyProp := range keyProperties {
-		fieldValue := entityValue.FieldByName(keyProp.Name)
-		if fieldValue.IsValid() {
-			keyValues[keyProp.JsonName] = fieldValue.Interface()
+		if value, ok := metadata.ReadPropertyValue(entity, keyProp); ok {
+			keyValues[keyProp.JsonName] = value
 		}
 	}
 

--- a/internal/response/format_helpers.go
+++ b/internal/response/format_helpers.go
@@ -41,6 +41,25 @@ func BuildEntityID(entitySetName string, keyValues map[string]interface{}) strin
 	return fmt.Sprintf("%s(%s)", entitySetName, strings.Join(keyParts, ","))
 }
 
+// BuildEntityIDFromEntity constructs an entity ID using the key declaration order.
+// It returns an empty string when any key value cannot be read from the entity.
+func BuildEntityIDFromEntity(entitySetName string, entity interface{}, keyProperties []metadata.PropertyMetadata) string {
+	keyParts := make([]string, 0, len(keyProperties))
+	for _, keyProp := range keyProperties {
+		value, ok := metadata.ReadPropertyValue(entity, keyProp)
+		if !ok {
+			return ""
+		}
+
+		if len(keyProperties) == 1 {
+			return fmt.Sprintf("%s(%s)", entitySetName, formatKeyValueLiteral(value))
+		}
+		keyParts = append(keyParts, fmt.Sprintf("%s=%s", keyProp.JsonName, formatKeyValueLiteral(value)))
+	}
+
+	return fmt.Sprintf("%s(%s)", entitySetName, strings.Join(keyParts, ","))
+}
+
 func formatKeyValueLiteral(value interface{}) string {
 	switch v := value.(type) {
 	case string:

--- a/internal/response/format_helpers_test.go
+++ b/internal/response/format_helpers_test.go
@@ -105,6 +105,19 @@ func TestExtractEntityKeysPointer(t *testing.T) {
 	}
 }
 
+func TestExtractEntityKeysMap(t *testing.T) {
+	entity := map[string]interface{}{"id": 456}
+	keyProperties := []metadata.PropertyMetadata{
+		{Name: "ID", FieldName: "ID", JsonName: "id"},
+	}
+
+	keyValues := ExtractEntityKeys(entity, keyProperties)
+
+	if keyValues["id"] != 456 {
+		t.Errorf("Expected ID=456, got %v", keyValues["id"])
+	}
+}
+
 func TestExtractEntityKeysComposite(t *testing.T) {
 	type TestEntity struct {
 		ProductID   int    `json:"productId"`
@@ -174,14 +187,10 @@ func TestExtractEntityKeysNilEntity(t *testing.T) {
 		{Name: "ID", JsonName: "id"},
 	}
 
-	// Test with nil value - should panic (expected behavior)
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("ExtractEntityKeys should panic with nil entity")
-		}
-	}()
-
-	ExtractEntityKeys(nil, keyProperties)
+	keyValues := ExtractEntityKeys(nil, keyProperties)
+	if len(keyValues) != 0 {
+		t.Errorf("Expected 0 key values, got %d", len(keyValues))
+	}
 }
 
 func TestExtractEntityKeysReflection(t *testing.T) {


### PR DESCRIPTION
Centralizes property reads across struct-backed and map-backed entity values as the next prerequisite for runtime-defined entities.

## Summary

- add a metadata-level property reader for structs, pointers, and named string-keyed maps
- make entity key extraction use the shared accessor and handle nil values safely
- unify `Location` and `@odata.id` construction through the canonical OData key formatter
- support named map row types and correctly escape quoted string keys
- suppress malformed IDs when required key properties are missing

Related to #892.

## Validation

- `go test ./...`
- `go build ./...`
- `golangci-lint run ./...`