### PR TITLE
Enforce guards for overwrite mutations

### DIFF
--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -32,6 +32,12 @@ func (h *EntityHandler) handlePostEntity(w http.ResponseWriter, r *http.Request)
 
 	// Check if there's an overwrite handler
 	if h.overwrite.hasCreate() {
+		if !h.enforceInsertRestrictions(w, r) {
+			return
+		}
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, "", nil), auth.OperationCreate, h.logger) {
+			return
+		}
 		h.handlePostEntityOverwrite(w, r)
 		return
 	}
@@ -559,6 +565,22 @@ func (h *EntityHandler) handlePostEntityOverwrite(w http.ResponseWriter, r *http
 
 	if err := h.decodeBinaryPropertiesInPlace(requestData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error())
+		return
+	}
+	if err := h.validatePropertiesExistForCreate(requestData, w, r); err != nil {
+		return
+	}
+	h.filterInstanceAnnotations(requestData)
+	if err := h.validateRequiredProperties(requestData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Missing required properties", err.Error())
+		return
+	}
+	if err := h.validateRequiredFieldsNotNull(requestData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid null value", err.Error())
+		return
+	}
+	if err := h.validateMaxLength(requestData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
 		return
 	}
 

--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -58,6 +58,12 @@ func (h *EntityHandler) handleDeleteEntity(w http.ResponseWriter, r *http.Reques
 
 	// Check if there's an overwrite handler
 	if h.overwrite.hasDelete() {
+		if !h.enforceDeleteRestrictions(w, r) {
+			return
+		}
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, entityKey, nil), auth.OperationDelete, h.logger) {
+			return
+		}
 		h.handleDeleteEntityOverwrite(w, r, entityKey)
 		return
 	}
@@ -155,6 +161,12 @@ func (h *EntityHandler) handlePatchEntity(w http.ResponseWriter, r *http.Request
 
 	// Check if there's an overwrite handler
 	if h.overwrite.hasUpdate() {
+		if !h.enforceUpdateRestrictions(w, r, "PATCH") {
+			return
+		}
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, entityKey, nil), auth.OperationUpdate, h.logger) {
+			return
+		}
 		h.handleUpdateEntityOverwrite(w, r, entityKey, false)
 		return
 	}
@@ -391,6 +403,12 @@ func (h *EntityHandler) returnUpdatedEntity(w http.ResponseWriter, r *http.Reque
 func (h *EntityHandler) handlePutEntity(w http.ResponseWriter, r *http.Request, entityKey string) {
 	// Check if there's an overwrite handler
 	if h.overwrite.hasUpdate() {
+		if !h.enforceUpdateRestrictions(w, r, "PUT") {
+			return
+		}
+		if !authorizeRequest(w, r, h.policy, buildEntityResourceDescriptor(h.metadata, entityKey, nil), auth.OperationUpdate, h.logger) {
+			return
+		}
 		h.handleUpdateEntityOverwrite(w, r, entityKey, true)
 		return
 	}
@@ -828,6 +846,28 @@ func (h *EntityHandler) handleUpdateEntityOverwrite(w http.ResponseWriter, r *ht
 
 	if err := h.decodeBinaryPropertiesInPlace(updateData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error())
+		return
+	}
+	if !isFullReplace {
+		if err := h.validateKeyPropertiesNotUpdated(updateData, w, r); err != nil {
+			return
+		}
+	}
+	if err := h.validatePropertiesExistForUpdate(updateData, w, r); err != nil {
+		return
+	}
+	if isFullReplace {
+		if err := h.validateRequiredProperties(updateData); err != nil {
+			WriteError(w, r, http.StatusBadRequest, "Missing required properties", err.Error())
+			return
+		}
+	}
+	if err := h.validateRequiredFieldsNotNull(updateData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid null value", err.Error())
+		return
+	}
+	if err := h.validateMaxLength(updateData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
 		return
 	}
 

--- a/internal/handlers/overwrite_coverage_test.go
+++ b/internal/handlers/overwrite_coverage_test.go
@@ -477,12 +477,14 @@ func createTestHandlerWithMetadata() *EntityHandler {
 				{
 					Name:      "ID",
 					FieldName: "ID",
+					JsonName:  "id",
 					Type:      reflect.TypeOf(0),
 					IsKey:     true,
 				},
 				{
 					Name:      "Name",
 					FieldName: "Name",
+					JsonName:  "name",
 					Type:      reflect.TypeOf(""),
 				},
 			},

--- a/internal/handlers/overwrite_write_guards_test.go
+++ b/internal/handlers/overwrite_write_guards_test.go
@@ -1,0 +1,181 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/nlstn/go-odata/internal/auth"
+	"github.com/nlstn/go-odata/internal/metadata"
+)
+
+type denyMutationPolicy struct{}
+
+func (denyMutationPolicy) Authorize(_ auth.AuthContext, _ auth.ResourceDescriptor, _ auth.Operation) auth.Decision {
+	return auth.Deny("mutation denied")
+}
+
+func TestOverwriteWriteHandlersValidatePayloadBeforeCallback(t *testing.T) {
+	t.Parallel()
+
+	type entity struct {
+		ID   int
+		Name string
+	}
+
+	newHandler := func() (*EntityHandler, *bool) {
+		called := false
+		handler := createTestHandlerWithMetadata()
+		handler.metadata.EntityType = reflect.TypeOf(entity{})
+		handler.metadata.Properties = []metadata.PropertyMetadata{
+			{Name: "ID", FieldName: "ID", JsonName: "ID", Type: reflect.TypeOf(0), IsKey: true},
+			{Name: "Name", FieldName: "Name", JsonName: "Name", Type: reflect.TypeOf(""), IsRequired: true},
+		}
+		handler.metadata.KeyProperties = []metadata.PropertyMetadata{handler.metadata.Properties[0]}
+		handler.overwrite = &entityOverwriteHandlers{
+			create: func(*OverwriteContext, interface{}) (interface{}, error) {
+				called = true
+				return nil, nil
+			},
+			update: func(*OverwriteContext, map[string]interface{}, bool) (interface{}, error) {
+				called = true
+				return nil, nil
+			},
+		}
+		return handler, &called
+	}
+
+	tests := []struct {
+		name   string
+		method string
+		body   string
+		run    func(*EntityHandler, http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:   "create missing required property",
+			method: http.MethodPost,
+			body:   `{}`,
+			run: func(handler *EntityHandler, writer http.ResponseWriter, request *http.Request) {
+				handler.handlePostEntity(writer, request)
+			},
+		},
+		{
+			name:   "patch modifies key",
+			method: http.MethodPatch,
+			body:   `{"ID":2}`,
+			run: func(handler *EntityHandler, writer http.ResponseWriter, request *http.Request) {
+				handler.handlePatchEntity(writer, request, "1")
+			},
+		},
+		{
+			name:   "put missing required property",
+			method: http.MethodPut,
+			body:   `{"ID":1}`,
+			run: func(handler *EntityHandler, writer http.ResponseWriter, request *http.Request) {
+				handler.handlePutEntity(writer, request, "1")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			handler, called := newHandler()
+			request := httptest.NewRequest(test.method, "/Products", bytes.NewBufferString(test.body))
+			request.Header.Set("Content-Type", "application/json")
+			writer := httptest.NewRecorder()
+
+			test.run(handler, writer, request)
+
+			if writer.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", writer.Code, http.StatusBadRequest)
+			}
+			if *called {
+				t.Fatal("overwrite handler was called with an invalid payload")
+			}
+		})
+	}
+}
+
+func TestOverwriteWriteHandlersRequireAuthorization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		run    func(*EntityHandler, http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:   "create",
+			method: http.MethodPost,
+			path:   "/Products",
+			run: func(handler *EntityHandler, writer http.ResponseWriter, request *http.Request) {
+				handler.handlePostEntity(writer, request)
+			},
+		},
+		{
+			name:   "patch",
+			method: http.MethodPatch,
+			path:   "/Products(1)",
+			run: func(handler *EntityHandler, writer http.ResponseWriter, request *http.Request) {
+				handler.handlePatchEntity(writer, request, "1")
+			},
+		},
+		{
+			name:   "put",
+			method: http.MethodPut,
+			path:   "/Products(1)",
+			run: func(handler *EntityHandler, writer http.ResponseWriter, request *http.Request) {
+				handler.handlePutEntity(writer, request, "1")
+			},
+		},
+		{
+			name:   "delete",
+			method: http.MethodDelete,
+			path:   "/Products(1)",
+			run: func(handler *EntityHandler, writer http.ResponseWriter, request *http.Request) {
+				handler.handleDeleteEntity(writer, request, "1")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			handler := createTestHandlerWithMetadata()
+			handler.policy = denyMutationPolicy{}
+			handler.overwrite = &entityOverwriteHandlers{
+				create: func(*OverwriteContext, interface{}) (interface{}, error) {
+					called = true
+					return nil, nil
+				},
+				update: func(*OverwriteContext, map[string]interface{}, bool) (interface{}, error) {
+					called = true
+					return nil, nil
+				},
+				delete: func(*OverwriteContext) error {
+					called = true
+					return nil
+				},
+			}
+
+			request := httptest.NewRequest(test.method, test.path, bytes.NewBufferString(`{"Name":"updated"}`))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Authorization", "Bearer test")
+			writer := httptest.NewRecorder()
+
+			test.run(handler, writer, request)
+
+			if writer.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d", writer.Code, http.StatusForbidden)
+			}
+			if called {
+				t.Fatal("overwrite handler was called after authorization denial")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Normalize custom overwrite mutation handling so service-level policy is enforced before callbacks run.

- apply disabled-method and authorization checks to overwrite POST, PATCH, PUT, and DELETE handlers
- validate overwrite create/update payload properties, required fields, nullability, maximum lengths, and PATCH key immutability
- add focused tests proving denied and invalid requests never invoke custom mutation callbacks

This prepares the write pipeline for map-backed runtime entities without allowing custom storage to bypass OData service rules.