### PR TITLE
Add runtime entity definitions

### DIFF
--- a/entity_definition.go
+++ b/entity_definition.go
@@ -1,0 +1,9 @@
+package odata
+
+import "github.com/nlstn/go-odata/internal/metadata"
+
+// PropertyDefinition describes a primitive property of a runtime entity.
+type PropertyDefinition = metadata.PropertyDefinition
+
+// EntityDefinition describes a map-backed entity type registered at runtime.
+type EntityDefinition = metadata.EntityDefinition

--- a/internal/metadata/definition.go
+++ b/internal/metadata/definition.go
@@ -1,0 +1,181 @@
+package metadata
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// PropertyDefinition describes a primitive structural property without a Go struct field.
+type PropertyDefinition struct {
+	Name     string
+	Type     PrimitiveType
+	Nullable *bool
+}
+
+// EntityDefinition describes a map-backed entity type registered at runtime.
+type EntityDefinition struct {
+	Name            string
+	EntitySetName   string
+	Properties      []PropertyDefinition
+	Keys            []string
+	DisabledMethods []string
+}
+
+// Validate checks whether the definition can represent a top-level OData entity set.
+func (definition EntityDefinition) Validate() error {
+	if err := validateDefinitionIdentifier("entity name", definition.Name); err != nil {
+		return err
+	}
+	if err := validateDefinitionIdentifier("entity set name", definition.EntitySetName); err != nil {
+		return err
+	}
+	if len(definition.Properties) == 0 {
+		return fmt.Errorf("entity definition must contain at least one property")
+	}
+
+	properties := make(map[string]PropertyDefinition, len(definition.Properties))
+	for _, property := range definition.Properties {
+		if err := validateDefinitionIdentifier("property name", property.Name); err != nil {
+			return err
+		}
+		if _, exists := properties[property.Name]; exists {
+			return fmt.Errorf("property %q is defined more than once", property.Name)
+		}
+		if _, err := ParsePrimitiveType(string(property.Type)); err != nil {
+			return fmt.Errorf("property %q: %w", property.Name, err)
+		}
+		properties[property.Name] = property
+	}
+
+	if len(definition.Keys) == 0 {
+		return fmt.Errorf("entity %q must have at least one key property", definition.Name)
+	}
+	keys := make(map[string]struct{}, len(definition.Keys))
+	for _, keyName := range definition.Keys {
+		if _, exists := keys[keyName]; exists {
+			return fmt.Errorf("key property %q is listed more than once", keyName)
+		}
+		keys[keyName] = struct{}{}
+
+		property, exists := properties[keyName]
+		if !exists {
+			return fmt.Errorf("key property %q is not defined", keyName)
+		}
+		if property.Nullable != nil && *property.Nullable {
+			return fmt.Errorf("key property %q must not be nullable", keyName)
+		}
+		if !isValidPrimitiveKeyType(property.Type) {
+			return fmt.Errorf("key property %q cannot use %s", keyName, property.Type)
+		}
+	}
+
+	disabledMethods := make(map[string]struct{}, len(definition.DisabledMethods))
+	for _, method := range definition.DisabledMethods {
+		normalized := strings.ToUpper(strings.TrimSpace(method))
+		switch normalized {
+		case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		default:
+			return fmt.Errorf("unsupported HTTP method %q; supported methods are GET, POST, PUT, PATCH, DELETE", method)
+		}
+		if _, exists := disabledMethods[normalized]; exists {
+			return fmt.Errorf("HTTP method %q is disabled more than once", normalized)
+		}
+		disabledMethods[normalized] = struct{}{}
+	}
+
+	return nil
+}
+
+// AnalyzeEntityDefinition validates a runtime definition and converts it to entity metadata.
+func AnalyzeEntityDefinition(definition EntityDefinition) (*EntityMetadata, error) {
+	if err := definition.Validate(); err != nil {
+		return nil, err
+	}
+
+	keyNames := make(map[string]struct{}, len(definition.Keys))
+	for _, keyName := range definition.Keys {
+		keyNames[keyName] = struct{}{}
+	}
+
+	entityMetadata := &EntityMetadata{
+		EntityName:      definition.Name,
+		EntitySetName:   definition.EntitySetName,
+		TableName:       definition.EntitySetName,
+		IsVirtual:       true,
+		Properties:      make([]PropertyMetadata, 0, len(definition.Properties)),
+		KeyProperties:   make([]PropertyMetadata, 0, len(definition.Keys)),
+		DisabledMethods: make(map[string]bool, len(definition.DisabledMethods)),
+	}
+	properties := make(map[string]PropertyMetadata, len(definition.Properties))
+	for _, definitionProperty := range definition.Properties {
+		_, isKey := keyNames[definitionProperty.Name]
+		nullable := !isKey
+		if definitionProperty.Nullable != nil {
+			nullable = *definitionProperty.Nullable
+		}
+		property := PropertyMetadata{
+			Name:       definitionProperty.Name,
+			FieldName:  definitionProperty.Name,
+			ColumnName: definitionProperty.Name,
+			JsonName:   definitionProperty.Name,
+			EdmType:    definitionProperty.Type,
+			IsKey:      isKey,
+			IsRequired: !nullable,
+			Nullable:   boolPointer(nullable),
+		}
+		entityMetadata.Properties = append(entityMetadata.Properties, property)
+		properties[property.Name] = property
+	}
+	for _, keyName := range definition.Keys {
+		entityMetadata.KeyProperties = append(entityMetadata.KeyProperties, properties[keyName])
+	}
+	if len(entityMetadata.KeyProperties) == 1 {
+		entityMetadata.KeyProperty = &entityMetadata.KeyProperties[0]
+	}
+	for _, method := range definition.DisabledMethods {
+		entityMetadata.DisabledMethods[strings.ToUpper(strings.TrimSpace(method))] = true
+	}
+
+	return entityMetadata, nil
+}
+
+func validateDefinitionIdentifier(kind, identifier string) error {
+	if identifier == "" {
+		return fmt.Errorf("%s cannot be empty", kind)
+	}
+	if !utf8.ValidString(identifier) || utf8.RuneCountInString(identifier) > 128 {
+		return fmt.Errorf("%s %q is not a valid OData identifier", kind, identifier)
+	}
+	for index, character := range []rune(identifier) {
+		if index == 0 {
+			if character != '_' && !unicode.IsLetter(character) {
+				return fmt.Errorf("%s %q is not a valid OData identifier", kind, identifier)
+			}
+			continue
+		}
+		if character != '_' && !unicode.IsLetter(character) && !unicode.IsDigit(character) &&
+			!unicode.In(character, unicode.Mn, unicode.Mc, unicode.Pc, unicode.Cf) {
+			return fmt.Errorf("%s %q is not a valid OData identifier", kind, identifier)
+		}
+	}
+	return nil
+}
+
+func isValidPrimitiveKeyType(primitiveType PrimitiveType) bool {
+	switch primitiveType {
+	case PrimitiveTypeBoolean, PrimitiveTypeByte, PrimitiveTypeDate, PrimitiveTypeDateTimeOffset,
+		PrimitiveTypeDecimal, PrimitiveTypeDuration, PrimitiveTypeGuid, PrimitiveTypeInt16,
+		PrimitiveTypeInt32, PrimitiveTypeInt64, PrimitiveTypeSByte, PrimitiveTypeString,
+		PrimitiveTypeTimeOfDay:
+		return true
+	default:
+		return false
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}

--- a/internal/metadata/definition_test.go
+++ b/internal/metadata/definition_test.go
@@ -1,0 +1,195 @@
+package metadata
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeEntityDefinition(t *testing.T) {
+	t.Parallel()
+
+	nullable := true
+	definition := EntityDefinition{
+		Name:          "Produkt",
+		EntitySetName: "Produkte",
+		Properties: []PropertyDefinition{
+			{Name: "Locale", Type: PrimitiveTypeString},
+			{Name: "ID", Type: PrimitiveTypeInt64},
+			{Name: "Description", Type: PrimitiveTypeString, Nullable: &nullable},
+		},
+		Keys:            []string{"ID", "Locale"},
+		DisabledMethods: []string{" post ", "delete"},
+	}
+
+	entityMetadata, err := AnalyzeEntityDefinition(definition)
+	if err != nil {
+		t.Fatalf("AnalyzeEntityDefinition() error = %v", err)
+	}
+	if entityMetadata.EntityType != nil {
+		t.Fatalf("EntityType = %v, want nil", entityMetadata.EntityType)
+	}
+	if !entityMetadata.IsVirtual {
+		t.Fatal("IsVirtual = false, want true")
+	}
+	if entityMetadata.KeyProperty != nil {
+		t.Fatalf("KeyProperty = %v, want nil for a composite key", entityMetadata.KeyProperty)
+	}
+	if got := []string{entityMetadata.KeyProperties[0].Name, entityMetadata.KeyProperties[1].Name}; !reflect.DeepEqual(got, definition.Keys) {
+		t.Fatalf("key order = %v, want %v", got, definition.Keys)
+	}
+	if entityMetadata.Properties[0].Nullable == nil || *entityMetadata.Properties[0].Nullable {
+		t.Fatal("key property Nullable must resolve to false")
+	}
+	if entityMetadata.Properties[2].Nullable == nil || !*entityMetadata.Properties[2].Nullable {
+		t.Fatal("ordinary property Nullable must resolve to true")
+	}
+	if !entityMetadata.DisabledMethods["POST"] || !entityMetadata.DisabledMethods["DELETE"] {
+		t.Fatalf("DisabledMethods = %v", entityMetadata.DisabledMethods)
+	}
+	if definition.DisabledMethods[0] != " post " || !nullable {
+		t.Fatal("AnalyzeEntityDefinition mutated its input")
+	}
+}
+
+func TestAnalyzeEntityDefinitionSetsSingleKeyProperty(t *testing.T) {
+	t.Parallel()
+
+	entityMetadata, err := AnalyzeEntityDefinition(EntityDefinition{
+		Name:          "Product",
+		EntitySetName: "Products",
+		Properties:    []PropertyDefinition{{Name: "ID", Type: PrimitiveTypeInt64}},
+		Keys:          []string{"ID"},
+	})
+	if err != nil {
+		t.Fatalf("AnalyzeEntityDefinition() error = %v", err)
+	}
+	if entityMetadata.KeyProperty != &entityMetadata.KeyProperties[0] {
+		t.Fatal("KeyProperty does not reference the single ordered key")
+	}
+}
+
+func TestEntityDefinitionValidation(t *testing.T) {
+	t.Parallel()
+
+	trueValue := true
+	valid := EntityDefinition{
+		Name:          "Product",
+		EntitySetName: "Products",
+		Properties: []PropertyDefinition{
+			{Name: "ID", Type: PrimitiveTypeInt64},
+			{Name: "Name", Type: PrimitiveTypeString},
+		},
+		Keys: []string{"ID"},
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(*EntityDefinition)
+		wantError string
+	}{
+		{name: "empty entity name", mutate: func(value *EntityDefinition) { value.Name = "" }, wantError: "entity name cannot be empty"},
+		{name: "invalid entity name", mutate: func(value *EntityDefinition) { value.Name = "1Product" }, wantError: "not a valid OData identifier"},
+		{name: "long entity set name", mutate: func(value *EntityDefinition) { value.EntitySetName = "P" + strings.Repeat("x", 128) }, wantError: "not a valid OData identifier"},
+		{name: "no properties", mutate: func(value *EntityDefinition) { value.Properties = nil }, wantError: "at least one property"},
+		{name: "duplicate property", mutate: func(value *EntityDefinition) { value.Properties = append(value.Properties, value.Properties[0]) }, wantError: "defined more than once"},
+		{name: "invalid property type", mutate: func(value *EntityDefinition) { value.Properties[0].Type = PrimitiveType("Edm.Nope") }, wantError: "unsupported EDM primitive type"},
+		{name: "no key", mutate: func(value *EntityDefinition) { value.Keys = nil }, wantError: "at least one key property"},
+		{name: "duplicate key", mutate: func(value *EntityDefinition) { value.Keys = []string{"ID", "ID"} }, wantError: "listed more than once"},
+		{name: "missing key", mutate: func(value *EntityDefinition) { value.Keys = []string{"Missing"} }, wantError: "is not defined"},
+		{name: "nullable key", mutate: func(value *EntityDefinition) { value.Properties[0].Nullable = &trueValue }, wantError: "must not be nullable"},
+		{name: "invalid key type", mutate: func(value *EntityDefinition) { value.Properties[0].Type = PrimitiveTypeDouble }, wantError: "cannot use Edm.Double"},
+		{name: "unsupported method", mutate: func(value *EntityDefinition) { value.DisabledMethods = []string{"TRACE"} }, wantError: "unsupported HTTP method"},
+		{name: "duplicate method", mutate: func(value *EntityDefinition) { value.DisabledMethods = []string{"post", " POST "} }, wantError: "disabled more than once"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			definition := valid
+			definition.Properties = append([]PropertyDefinition(nil), valid.Properties...)
+			definition.Keys = append([]string(nil), valid.Keys...)
+			test.mutate(&definition)
+			if err := definition.Validate(); err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("Validate() error = %v, want error containing %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestEntityDefinitionAcceptsPrimitivePropertiesAndKeyTypes(t *testing.T) {
+	t.Parallel()
+
+	for primitiveType := range validPrimitiveTypes {
+		definition := EntityDefinition{
+			Name:          "Record",
+			EntitySetName: "Records",
+			Properties: []PropertyDefinition{
+				{Name: "ID", Type: PrimitiveTypeInt64},
+				{Name: "Value", Type: primitiveType},
+			},
+			Keys: []string{"ID"},
+		}
+		if err := definition.Validate(); err != nil {
+			t.Errorf("Validate() rejected property type %s: %v", primitiveType, err)
+		}
+	}
+
+	for _, primitiveType := range []PrimitiveType{
+		PrimitiveTypeBoolean, PrimitiveTypeByte, PrimitiveTypeDate, PrimitiveTypeDateTimeOffset,
+		PrimitiveTypeDecimal, PrimitiveTypeDuration, PrimitiveTypeGuid, PrimitiveTypeInt16,
+		PrimitiveTypeInt32, PrimitiveTypeInt64, PrimitiveTypeSByte, PrimitiveTypeString,
+		PrimitiveTypeTimeOfDay,
+	} {
+		definition := EntityDefinition{
+			Name:          "Record",
+			EntitySetName: "Records",
+			Properties:    []PropertyDefinition{{Name: "ID", Type: primitiveType}},
+			Keys:          []string{"ID"},
+		}
+		if err := definition.Validate(); err != nil {
+			t.Errorf("Validate() rejected key type %s: %v", primitiveType, err)
+		}
+	}
+}
+
+func TestEntityDefinitionRejectsInvalidPrimitiveKeyTypes(t *testing.T) {
+	t.Parallel()
+
+	invalidKeyTypes := []PrimitiveType{
+		PrimitiveTypeBinary,
+		PrimitiveTypeDouble,
+		PrimitiveTypeSingle,
+		PrimitiveTypeStream,
+		PrimitiveTypeUntyped,
+		PrimitiveTypeGeography,
+		PrimitiveTypeGeographyCollection,
+		PrimitiveTypeGeographyLineString,
+		PrimitiveTypeGeographyMultiLineString,
+		PrimitiveTypeGeographyMultiPoint,
+		PrimitiveTypeGeographyMultiPolygon,
+		PrimitiveTypeGeographyPoint,
+		PrimitiveTypeGeographyPolygon,
+		PrimitiveTypeGeometry,
+		PrimitiveTypeGeometryCollection,
+		PrimitiveTypeGeometryLineString,
+		PrimitiveTypeGeometryMultiLineString,
+		PrimitiveTypeGeometryMultiPoint,
+		PrimitiveTypeGeometryMultiPolygon,
+		PrimitiveTypeGeometryPoint,
+		PrimitiveTypeGeometryPolygon,
+	}
+
+	for _, primitiveType := range invalidKeyTypes {
+		t.Run(string(primitiveType), func(t *testing.T) {
+			definition := EntityDefinition{
+				Name:          "Record",
+				EntitySetName: "Records",
+				Properties:    []PropertyDefinition{{Name: "ID", Type: primitiveType}},
+				Keys:          []string{"ID"},
+			}
+			if err := definition.Validate(); err == nil || !strings.Contains(err.Error(), "cannot use") {
+				t.Fatalf("Validate() error = %v, want invalid key type error", err)
+			}
+		})
+	}
+}

--- a/test/entity_definition_test.go
+++ b/test/entity_definition_test.go
@@ -1,0 +1,25 @@
+package odata_test
+
+import (
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+)
+
+func TestPublicEntityDefinition(t *testing.T) {
+	t.Parallel()
+
+	definition := odata.EntityDefinition{
+		Name:          "Product",
+		EntitySetName: "Products",
+		Properties: []odata.PropertyDefinition{
+			{Name: "ID", Type: odata.EdmInt64},
+			{Name: "Name", Type: odata.EdmString},
+		},
+		Keys: []string{"ID"},
+	}
+
+	if err := definition.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}


### PR DESCRIPTION
Introduce the validated descriptor layer for runtime, map-backed OData entities.

- expose `EntityDefinition` and `PropertyDefinition` from the public package
- validate Unicode OData SimpleIdentifiers, primitive EDM types, ordered keys, key nullability/type constraints, and disabled methods
- convert definitions into reflection-free `EntityMetadata` with resolved nullability and preserved composite-key order
- add internal boundary tests and an external-package public API test

This intentionally does not register handlers yet, avoiding a public API that could publish partially routable entities. It is the next prerequisite for #892.