### PR TITLE
Register map-backed entities at runtime

### DIFF
--- a/documentation/virtual-entities.md
+++ b/documentation/virtual-entities.md
@@ -16,6 +16,56 @@ This design ensures that:
 2. No unexpected database operations occur
 3. The service clearly communicates which operations are supported
 
+## Registering an Entity Without a Go Struct
+
+Use `RegisterDynamicEntity` when the entity schema is known only at runtime. Dynamic entities are map-backed and support primitive EDM properties. Register them during service setup, before serving requests.
+
+```go
+required := false
+definition := odata.EntityDefinition{
+    Name:          "ExternalProduct",
+    EntitySetName: "ExternalProducts",
+    Properties: []odata.PropertyDefinition{
+        {Name: "ID", Type: odata.EdmInt64},
+        {Name: "Name", Type: odata.EdmString, Nullable: &required},
+        {Name: "Price", Type: odata.EdmDecimal},
+    },
+    Keys: []string{"ID"},
+    DisabledMethods: []string{
+        http.MethodPost,
+        http.MethodPatch,
+        http.MethodPut,
+        http.MethodDelete,
+    },
+}
+
+err := service.RegisterDynamicEntity(definition, &odata.EntityOverwrite{
+    GetCollection: func(ctx *odata.OverwriteContext) (*odata.CollectionResult, error) {
+        rows, total, err := externalAPI.Query(ctx.QueryOptions)
+        if err != nil {
+            return nil, err
+        }
+        return &odata.CollectionResult{Items: rows, Count: &total}, nil
+    },
+    GetEntity: func(ctx *odata.OverwriteContext) (interface{}, error) {
+        id := ctx.EntityKeyValues["ID"].(int64)
+        return externalAPI.Get(id)
+    },
+    GetCount: func(ctx *odata.OverwriteContext) (int64, error) {
+        return externalAPI.Count(ctx.QueryOptions)
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+Use the declared property names as keys in returned `map[string]interface{}` values. Collection handlers should return `[]map[string]interface{}`. Query options are parsed and validated by the service, but the callback is responsible for applying filtering, ordering, paging, selection, and search to its data source.
+
+Registration validates all enabled operations atomically. `GET` requires `GetCollection`, `GetEntity`, and `GetCount`; `POST` requires `Create`; `PATCH` and `PUT` require `Update`; and `DELETE` requires `Delete`. Add an operation to `DisabledMethods` when the dynamic entity does not support it.
+
+Runtime definitions currently support primitive structural properties and top-level CRUD. Navigation properties, streams, hooks, ETags, inheritance, caching, and change tracking require struct-backed entities.
+
 ## Registering a Virtual Entity
 
 To register a virtual entity, use the `RegisterVirtualEntity` method:

--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -182,7 +182,7 @@ func (h *EntityHandler) handlePostEntity(w http.ResponseWriter, r *http.Request)
 		h.writeEntityResponseWithETag(w, r, entity, "", http.StatusCreated, nil, nil)
 	} else {
 		SetODataHeader(w, HeaderODataEntityId, location)
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusCreated)
 	}
 }
 
@@ -651,6 +651,6 @@ func (h *EntityHandler) handlePostEntityOverwrite(w http.ResponseWriter, r *http
 		h.writeEntityResponseWithETag(w, r, result, "", http.StatusCreated, queryOptions.Expand, queryOptions.Select)
 	} else {
 		SetODataHeader(w, HeaderODataEntityId, location)
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusCreated)
 	}
 }

--- a/internal/handlers/collection_write.go
+++ b/internal/handlers/collection_write.go
@@ -181,9 +181,8 @@ func (h *EntityHandler) handlePostEntity(w http.ResponseWriter, r *http.Request)
 		SetODataHeader(w, HeaderODataEntityId, location)
 		h.writeEntityResponseWithETag(w, r, entity, "", http.StatusCreated, nil, nil)
 	} else {
-		// Per OData v4.01 spec, POST with return=minimal should return 201 Created with empty body
 		SetODataHeader(w, HeaderODataEntityId, location)
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 
@@ -552,12 +551,21 @@ func (h *EntityHandler) handlePostEntityOverwrite(w http.ResponseWriter, r *http
 	if err := validateContentType(w, r); err != nil {
 		return
 	}
+	queryOptions, err := h.parseModificationQueryOptions(r)
+	if err != nil {
+		h.writeRequestError(w, r, err, http.StatusBadRequest, ErrMsgInvalidQueryOptions)
+		return
+	}
 
 	pref := preference.ParsePrefer(r)
 
 	// Parse the request body
 	var requestData map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&requestData); err != nil {
+	decoder := json.NewDecoder(r.Body)
+	if h.isDynamicEntity() {
+		decoder.UseNumber()
+	}
+	if err := decoder.Decode(&requestData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
 			fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error()))
 		return
@@ -565,6 +573,10 @@ func (h *EntityHandler) handlePostEntityOverwrite(w http.ResponseWriter, r *http
 
 	if err := h.decodeBinaryPropertiesInPlace(requestData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error())
+		return
+	}
+	if err := h.normalizeDynamicPropertyValues(requestData, r); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
 		return
 	}
 	if err := h.validatePropertiesExistForCreate(requestData, w, r); err != nil {
@@ -583,24 +595,31 @@ func (h *EntityHandler) handlePostEntityOverwrite(w http.ResponseWriter, r *http
 		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
 		return
 	}
-
-	// Convert to entity for type-safe handling
-	entity := reflect.New(h.metadata.EntityType).Interface()
-	jsonData, err := json.Marshal(requestData)
-	if err != nil {
-		WriteError(w, r, http.StatusInternalServerError, "Failed to process request data", err.Error())
+	if err := h.validateDataTypes(requestData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
 		return
 	}
-	if err := json.Unmarshal(jsonData, entity); err != nil {
-		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
-			fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error()))
-		return
+
+	entity := interface{}(requestData)
+	if h.metadata.EntityType != nil {
+		// Convert struct-backed entities for type-safe overwrite handlers.
+		entity = reflect.New(h.metadata.EntityType).Interface()
+		jsonData, err := json.Marshal(requestData)
+		if err != nil {
+			WriteError(w, r, http.StatusInternalServerError, "Failed to process request data", err.Error())
+			return
+		}
+		if err := json.Unmarshal(jsonData, entity); err != nil {
+			WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
+				fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error()))
+			return
+		}
 	}
 
 	// Create overwrite context with empty query options (CREATE doesn't use query options,
 	// but we provide a consistent context interface across all operations)
 	ctx := &OverwriteContext{
-		QueryOptions: &query.QueryOptions{},
+		QueryOptions: queryOptions,
 		Request:      r,
 	}
 
@@ -626,10 +645,12 @@ func (h *EntityHandler) handlePostEntityOverwrite(w http.ResponseWriter, r *http
 
 	if pref.ShouldReturnContent(true) {
 		SetODataHeader(w, HeaderODataEntityId, location)
-		h.writeEntityResponseWithETag(w, r, result, "", http.StatusCreated, nil, nil)
+		if len(queryOptions.Select) > 0 {
+			result = query.ApplySelectToEntity(result, queryOptions.Select, h.metadata, queryOptions.Expand)
+		}
+		h.writeEntityResponseWithETag(w, r, result, "", http.StatusCreated, queryOptions.Expand, queryOptions.Select)
 	} else {
-		// Per OData v4.01 spec, POST with return=minimal should return 201 Created with empty body
 		SetODataHeader(w, HeaderODataEntityId, location)
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/handlers/entity_handler_test.go
+++ b/internal/handlers/entity_handler_test.go
@@ -353,9 +353,8 @@ func TestHandlePostEntity_WithPreferMinimal(t *testing.T) {
 
 	handler.HandleCollection(w, req)
 
-	// Per OData v4.01 spec, POST with return=minimal should return 201 Created with empty body
-	if w.Code != http.StatusCreated {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
 	}
 }
 

--- a/internal/handlers/entity_handler_test.go
+++ b/internal/handlers/entity_handler_test.go
@@ -353,8 +353,8 @@ func TestHandlePostEntity_WithPreferMinimal(t *testing.T) {
 
 	handler.HandleCollection(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
+	if w.Code != http.StatusCreated {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
 	}
 }
 

--- a/internal/handlers/entity_helpers.go
+++ b/internal/handlers/entity_helpers.go
@@ -132,6 +132,23 @@ func (h *EntityHandler) parseSingleEntityQueryOptions(r *http.Request) (*query.Q
 	return queryOptions, nil
 }
 
+func (h *EntityHandler) parseModificationQueryOptions(r *http.Request) (*query.QueryOptions, error) {
+	queryOptions, err := h.parseSingleEntityQueryOptions(r)
+	if err != nil {
+		return nil, err
+	}
+	if queryOptions.Filter != nil || len(queryOptions.OrderBy) > 0 || queryOptions.Count ||
+		queryOptions.Search != "" || len(queryOptions.Apply) > 0 || queryOptions.Compute != nil ||
+		queryOptions.SkipToken != nil || queryOptions.DeltaToken != nil {
+		return nil, &requestError{
+			StatusCode: http.StatusBadRequest,
+			ErrorCode:  ErrMsgInvalidQueryOptions,
+			Message:    "only $select and $expand are applicable to entity modification requests",
+		}
+	}
+	return queryOptions, nil
+}
+
 // fetchEntityByKey fetches an entity by its key with optional expand
 func (h *EntityHandler) fetchEntityByKey(ctx context.Context, entityKey string, queryOptions *query.QueryOptions, scopes []func(*gorm.DB) *gorm.DB) (interface{}, error) {
 	// Fast path: serve the key read from the in-memory snapshot cache. When the

--- a/internal/handlers/entity_read.go
+++ b/internal/handlers/entity_read.go
@@ -164,12 +164,17 @@ func (h *EntityHandler) handleGetEntityOverwrite(w http.ResponseWriter, r *http.
 		h.writeRequestError(w, r, err, http.StatusBadRequest, ErrMsgInvalidQueryOptions)
 		return
 	}
+	keyValues, err := h.parseOverwriteEntityKeyValues(entityKey)
+	if err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid entity key", err.Error())
+		return
+	}
 
 	// Create overwrite context
 	ctx := &OverwriteContext{
 		QueryOptions:    queryOptions,
 		EntityKey:       entityKey,
-		EntityKeyValues: parseEntityKeyValues(entityKey, h.metadata.KeyProperties),
+		EntityKeyValues: keyValues,
 		Request:         r,
 	}
 

--- a/internal/handlers/entity_write.go
+++ b/internal/handlers/entity_write.go
@@ -805,12 +805,17 @@ func (h *EntityHandler) preserveImmutableProperties(source, destination interfac
 
 // handleDeleteEntityOverwrite handles DELETE entity requests using the overwrite handler
 func (h *EntityHandler) handleDeleteEntityOverwrite(w http.ResponseWriter, r *http.Request, entityKey string) {
+	keyValues, err := h.parseOverwriteEntityKeyValues(entityKey)
+	if err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid entity key", err.Error())
+		return
+	}
 	// Create overwrite context with empty query options (DELETE doesn't use query options,
 	// but we provide a consistent context interface across all operations)
 	ctx := &OverwriteContext{
 		QueryOptions:    &query.QueryOptions{},
 		EntityKey:       entityKey,
-		EntityKeyValues: parseEntityKeyValues(entityKey, h.metadata.KeyProperties),
+		EntityKeyValues: keyValues,
 		Request:         r,
 	}
 
@@ -833,12 +838,21 @@ func (h *EntityHandler) handleUpdateEntityOverwrite(w http.ResponseWriter, r *ht
 	if err := validateContentType(w, r); err != nil {
 		return
 	}
+	queryOptions, err := h.parseModificationQueryOptions(r)
+	if err != nil {
+		h.writeRequestError(w, r, err, http.StatusBadRequest, ErrMsgInvalidQueryOptions)
+		return
+	}
 
 	pref := preference.ParsePrefer(r)
 
 	// Parse the request body
 	var updateData map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&updateData); err != nil {
+	decoder := json.NewDecoder(r.Body)
+	if h.isDynamicEntity() {
+		decoder.UseNumber()
+	}
+	if err := decoder.Decode(&updateData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody,
 			fmt.Sprintf(ErrDetailFailedToParseJSON, err.Error()))
 		return
@@ -846,6 +860,10 @@ func (h *EntityHandler) handleUpdateEntityOverwrite(w http.ResponseWriter, r *ht
 
 	if err := h.decodeBinaryPropertiesInPlace(updateData); err != nil {
 		WriteError(w, r, http.StatusBadRequest, ErrMsgInvalidRequestBody, err.Error())
+		return
+	}
+	if err := h.normalizeDynamicPropertyValues(updateData, r); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
 		return
 	}
 	if !isFullReplace {
@@ -870,12 +888,21 @@ func (h *EntityHandler) handleUpdateEntityOverwrite(w http.ResponseWriter, r *ht
 		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
 		return
 	}
+	if err := h.validateDataTypes(updateData); err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid property value", err.Error())
+		return
+	}
+	keyValues, err := h.parseOverwriteEntityKeyValues(entityKey)
+	if err != nil {
+		WriteError(w, r, http.StatusBadRequest, "Invalid entity key", err.Error())
+		return
+	}
 
 	// Create overwrite context
 	ctx := &OverwriteContext{
-		QueryOptions:    &query.QueryOptions{},
+		QueryOptions:    queryOptions,
 		EntityKey:       entityKey,
-		EntityKeyValues: parseEntityKeyValues(entityKey, h.metadata.KeyProperties),
+		EntityKeyValues: keyValues,
 		Request:         r,
 	}
 
@@ -898,7 +925,10 @@ func (h *EntityHandler) handleUpdateEntityOverwrite(w http.ResponseWriter, r *ht
 
 	if pref.ShouldReturnContent(false) {
 		if result != nil {
-			h.writeEntityResponseWithETag(w, r, result, "", http.StatusOK, nil, nil)
+			if len(queryOptions.Select) > 0 {
+				result = query.ApplySelectToEntity(result, queryOptions.Select, h.metadata, queryOptions.Expand)
+			}
+			h.writeEntityResponseWithETag(w, r, result, "", http.StatusOK, queryOptions.Expand, queryOptions.Select)
 		} else {
 			// If no result was returned but content was requested, return 204
 			w.WriteHeader(http.StatusNoContent)

--- a/internal/handlers/entity_write_comprehensive_test.go
+++ b/internal/handlers/entity_write_comprehensive_test.go
@@ -51,8 +51,8 @@ func TestHandleCollection_PostWithReturnMinimal(t *testing.T) {
 
 	handler.HandleCollection(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	if w.Code != http.StatusCreated {
+		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusCreated, w.Body.String())
 	}
 
 	// Should have Location header

--- a/internal/handlers/entity_write_comprehensive_test.go
+++ b/internal/handlers/entity_write_comprehensive_test.go
@@ -51,9 +51,8 @@ func TestHandleCollection_PostWithReturnMinimal(t *testing.T) {
 
 	handler.HandleCollection(w, req)
 
-	// Per OData v4.01 spec, POST with return=minimal should return 201 Created with empty body
-	if w.Code != http.StatusCreated {
-		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Status = %v, want %v. Body: %s", w.Code, http.StatusNoContent, w.Body.String())
 	}
 
 	// Should have Location header

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 
 	"github.com/nlstn/go-odata/internal/metadata"
@@ -52,6 +55,113 @@ func parseEntityKeyValues(entityKey string, keyProperties []metadata.PropertyMet
 	}
 
 	return keyValues
+}
+
+func (h *EntityHandler) parseOverwriteEntityKeyValues(entityKey string) (map[string]interface{}, error) {
+	if !h.isDynamicEntity() {
+		return parseEntityKeyValues(entityKey, h.metadata.KeyProperties), nil
+	}
+	return parseDynamicEntityKeyValues(entityKey, h.metadata.KeyProperties)
+}
+
+func parseDynamicEntityKeyValues(entityKey string, keyProperties []metadata.PropertyMetadata) (map[string]interface{}, error) {
+	if entityKey == "" {
+		return nil, nil
+	}
+	if len(keyProperties) == 0 {
+		return nil, fmt.Errorf("entity has no key metadata")
+	}
+
+	rawValues := make(map[string]string)
+	components := &response.ODataURLComponents{EntityKeyMap: make(map[string]string)}
+	if err := parseCompositeKey(entityKey, components); err == nil && len(components.EntityKeyMap) > 0 {
+		rawValues = components.EntityKeyMap
+	} else if len(keyProperties) == 1 {
+		rawValues[keyProperties[0].JsonName] = entityKey
+	} else {
+		return nil, fmt.Errorf("invalid composite key %q", entityKey)
+	}
+	if len(rawValues) != len(keyProperties) {
+		return nil, fmt.Errorf("key contains %d properties, expected %d", len(rawValues), len(keyProperties))
+	}
+
+	values := make(map[string]interface{}, len(keyProperties))
+	for _, property := range keyProperties {
+		rawValue, ok := rawValues[property.JsonName]
+		if !ok {
+			rawValue, ok = rawValues[property.Name]
+		}
+		if !ok {
+			return nil, fmt.Errorf("key property %q is missing", property.JsonName)
+		}
+		value, err := parseDynamicKeyValue(rawValue, property)
+		if err != nil {
+			return nil, fmt.Errorf("invalid key property %q: %w", property.JsonName, err)
+		}
+		values[property.JsonName] = value
+	}
+	return values, nil
+}
+
+var durationKeyPattern = regexp.MustCompile(`^-?P(?:\d+D(?:T(?:\d+H)?(?:\d+M)?(?:\d+(?:\.\d+)?S)?)?|T(?:\d+H(?:\d+M)?(?:\d+(?:\.\d+)?S)?|\d+M(?:\d+(?:\.\d+)?S)?|\d+(?:\.\d+)?S))$`)
+
+func parseDynamicKeyValue(value string, property metadata.PropertyMetadata) (interface{}, error) {
+	primitiveType, ok := property.EffectivePrimitiveType()
+	if !ok {
+		return nil, fmt.Errorf("missing EDM type")
+	}
+	switch primitiveType {
+	case metadata.PrimitiveTypeString:
+		return value, nil
+	case metadata.PrimitiveTypeBoolean:
+		if value != "true" && value != "false" {
+			return nil, fmt.Errorf("invalid Boolean literal %q", value)
+		}
+		return value == "true", nil
+	case metadata.PrimitiveTypeByte:
+		parsed, err := strconv.ParseUint(value, 10, 8)
+		return int64(parsed), err
+	case metadata.PrimitiveTypeSByte:
+		return strconv.ParseInt(value, 10, 8)
+	case metadata.PrimitiveTypeInt16:
+		return strconv.ParseInt(value, 10, 16)
+	case metadata.PrimitiveTypeInt32:
+		return strconv.ParseInt(value, 10, 32)
+	case metadata.PrimitiveTypeInt64:
+		return strconv.ParseInt(value, 10, 64)
+	case metadata.PrimitiveTypeDecimal:
+		return decimal.NewFromString(value)
+	case metadata.PrimitiveTypeGuid:
+		if _, err := uuid.Parse(value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	case metadata.PrimitiveTypeDate:
+		if _, err := time.Parse("2006-01-02", value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	case metadata.PrimitiveTypeDateTimeOffset:
+		if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	case metadata.PrimitiveTypeTimeOfDay:
+		if _, err := time.Parse("15:04:05.999999999", value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	case metadata.PrimitiveTypeDuration:
+		if strings.HasPrefix(value, "duration'") && strings.HasSuffix(value, "'") {
+			value = strings.TrimSuffix(strings.TrimPrefix(value, "duration'"), "'")
+		}
+		if !durationKeyPattern.MatchString(value) {
+			return nil, fmt.Errorf("invalid duration %q", value)
+		}
+		return value, nil
+	default:
+		return nil, fmt.Errorf("unsupported key type %s", primitiveType)
+	}
 }
 
 // convertKeyValue attempts to convert a string key value to the appropriate type

--- a/internal/handlers/helpers_test.go
+++ b/internal/handlers/helpers_test.go
@@ -453,6 +453,44 @@ func TestParseEntityKeyValues(t *testing.T) {
 	}
 }
 
+func TestParseDynamicEntityKeyValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		value         string
+		primitiveType metadata.PrimitiveType
+		want          interface{}
+		wantError     bool
+	}{
+		{name: "int64", value: "9223372036854775807", primitiveType: metadata.PrimitiveTypeInt64, want: int64(9223372036854775807)},
+		{name: "invalid int64", value: "not-an-integer", primitiveType: metadata.PrimitiveTypeInt64, wantError: true},
+		{name: "guid", value: "01234567-89ab-cdef-0123-456789abcdef", primitiveType: metadata.PrimitiveTypeGuid, want: "01234567-89ab-cdef-0123-456789abcdef"},
+		{name: "invalid guid", value: "invalid", primitiveType: metadata.PrimitiveTypeGuid, wantError: true},
+		{name: "date", value: "2026-08-30", primitiveType: metadata.PrimitiveTypeDate, want: "2026-08-30"},
+		{name: "duration", value: "duration'P1DT2H'", primitiveType: metadata.PrimitiveTypeDuration, want: "P1DT2H"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			properties := []metadata.PropertyMetadata{{Name: "ID", JsonName: "ID", EdmType: test.primitiveType}}
+			values, err := parseDynamicEntityKeyValues(test.value, properties)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("parseDynamicEntityKeyValues() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDynamicEntityKeyValues() error = %v", err)
+			}
+			if got := values["ID"]; got != test.want {
+				t.Fatalf("key value = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestConvertKeyValue(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/handlers/overwrite_coverage_test.go
+++ b/internal/handlers/overwrite_coverage_test.go
@@ -181,7 +181,7 @@ func TestHandleUpdateEntityOverwrite(t *testing.T) {
 			},
 		}
 
-		body := map[string]interface{}{"id": "123", "name": "Replaced"}
+		body := map[string]interface{}{"id": 123, "name": "Replaced"}
 		jsonBody, _ := json.Marshal(body)
 		req := httptest.NewRequest(http.MethodPut, "/Products(123)", bytes.NewReader(jsonBody))
 		req.Header.Set("Content-Type", "application/json")
@@ -288,6 +288,30 @@ func TestHandlePostEntityOverwrite(t *testing.T) {
 
 		if w.Code != http.StatusUnsupportedMediaType {
 			t.Errorf("Expected status 415, got %d", w.Code)
+		}
+	})
+
+	t.Run("map-backed entity", func(t *testing.T) {
+		handler := createTestHandlerWithMetadata()
+		handler.metadata.EntityType = nil
+		handler.overwrite = &entityOverwriteHandlers{
+			create: func(_ *OverwriteContext, entity interface{}) (interface{}, error) {
+				requestData, ok := entity.(map[string]interface{})
+				if !ok {
+					t.Fatalf("entity type = %T, want map[string]interface{}", entity)
+				}
+				return map[string]interface{}{"ID": 123, "Name": requestData["Name"]}, nil
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/Products", bytes.NewBufferString(`{"Name":"New Product"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		handler.handlePostEntityOverwrite(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusCreated)
 		}
 	})
 }

--- a/internal/handlers/validation.go
+++ b/internal/handlers/validation.go
@@ -2,14 +2,18 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"mime"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/nlstn/go-odata/internal/metadata"
 	"github.com/nlstn/go-odata/internal/response"
+	"github.com/shopspring/decimal"
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
 )
@@ -31,6 +35,15 @@ func (h *EntityHandler) validateDataTypes(updateData map[string]interface{}) err
 			continue
 		}
 
+		if propMeta.Type == nil {
+			if primitiveType, ok := propMeta.EffectivePrimitiveType(); ok {
+				if err := validatePrimitiveValueType(propValue, primitiveType, propMeta.JsonName); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
 		// Validate the type
 		if err := validateValueType(propValue, propMeta.Type, propMeta.JsonName); err != nil {
 			return err
@@ -38,6 +51,139 @@ func (h *EntityHandler) validateDataTypes(updateData map[string]interface{}) err
 	}
 
 	return nil
+}
+
+func validatePrimitiveValueType(value interface{}, primitiveType metadata.PrimitiveType, fieldName string) error {
+	valid := false
+	switch primitiveType {
+	case metadata.PrimitiveTypeUntyped:
+		valid = true
+	case metadata.PrimitiveTypeBoolean:
+		_, valid = value.(bool)
+	case metadata.PrimitiveTypeByte, metadata.PrimitiveTypeInt16, metadata.PrimitiveTypeInt32,
+		metadata.PrimitiveTypeInt64, metadata.PrimitiveTypeSByte:
+		_, valid = value.(int64)
+	case metadata.PrimitiveTypeDecimal:
+		_, valid = value.(decimal.Decimal)
+	case metadata.PrimitiveTypeDouble, metadata.PrimitiveTypeSingle:
+		_, valid = value.(float64)
+	case metadata.PrimitiveTypeBinary:
+		_, valid = value.([]byte)
+	case metadata.PrimitiveTypeDate, metadata.PrimitiveTypeDateTimeOffset, metadata.PrimitiveTypeDuration,
+		metadata.PrimitiveTypeGuid, metadata.PrimitiveTypeString, metadata.PrimitiveTypeTimeOfDay:
+		_, valid = value.(string)
+	case metadata.PrimitiveTypeGeography, metadata.PrimitiveTypeGeographyCollection,
+		metadata.PrimitiveTypeGeographyLineString, metadata.PrimitiveTypeGeographyMultiLineString,
+		metadata.PrimitiveTypeGeographyMultiPoint, metadata.PrimitiveTypeGeographyMultiPolygon,
+		metadata.PrimitiveTypeGeographyPoint, metadata.PrimitiveTypeGeographyPolygon,
+		metadata.PrimitiveTypeGeometry, metadata.PrimitiveTypeGeometryCollection,
+		metadata.PrimitiveTypeGeometryLineString, metadata.PrimitiveTypeGeometryMultiLineString,
+		metadata.PrimitiveTypeGeometryMultiPoint, metadata.PrimitiveTypeGeometryMultiPolygon,
+		metadata.PrimitiveTypeGeometryPoint, metadata.PrimitiveTypeGeometryPolygon:
+		_, valid = value.(map[string]interface{})
+	}
+	if !valid {
+		return fmt.Errorf("property '%s' expects type %s but got %T", fieldName, primitiveType, value)
+	}
+	return nil
+}
+
+func (h *EntityHandler) normalizeDynamicPropertyValues(data map[string]interface{}, r *http.Request) error {
+	if !h.isDynamicEntity() {
+		return nil
+	}
+	ieee754Compatible := requestIEEE754Compatible(r)
+	for propertyName, value := range data {
+		if value == nil {
+			continue
+		}
+		property := h.metadata.FindProperty(propertyName)
+		if property == nil {
+			continue
+		}
+		primitiveType, ok := property.EffectivePrimitiveType()
+		if !ok {
+			continue
+		}
+		normalized, err := normalizeDynamicPrimitiveValue(value, primitiveType, ieee754Compatible)
+		if err != nil {
+			return fmt.Errorf("property '%s' expects type %s: %w", property.JsonName, primitiveType, err)
+		}
+		data[propertyName] = normalized
+	}
+	return nil
+}
+
+func (h *EntityHandler) isDynamicEntity() bool {
+	return h.metadata != nil && h.metadata.IsVirtual && h.metadata.EntityType == nil
+}
+
+func normalizeDynamicPrimitiveValue(value interface{}, primitiveType metadata.PrimitiveType, ieee754Compatible bool) (interface{}, error) {
+	lexical, isNumber := "", false
+	switch typed := value.(type) {
+	case json.Number:
+		lexical, isNumber = typed.String(), true
+	case string:
+		if ieee754Compatible && (primitiveType == metadata.PrimitiveTypeInt64 || primitiveType == metadata.PrimitiveTypeDecimal) {
+			lexical, isNumber = typed, true
+		}
+	}
+
+	switch primitiveType {
+	case metadata.PrimitiveTypeByte:
+		parsed, err := strconv.ParseUint(lexical, 10, 8)
+		if !isNumber || err != nil {
+			return nil, fmt.Errorf("invalid integer value %q", lexical)
+		}
+		return int64(parsed), nil
+	case metadata.PrimitiveTypeSByte:
+		return parseDynamicInteger(lexical, isNumber, 8)
+	case metadata.PrimitiveTypeInt16:
+		return parseDynamicInteger(lexical, isNumber, 16)
+	case metadata.PrimitiveTypeInt32:
+		return parseDynamicInteger(lexical, isNumber, 32)
+	case metadata.PrimitiveTypeInt64:
+		return parseDynamicInteger(lexical, isNumber, 64)
+	case metadata.PrimitiveTypeDecimal:
+		if !isNumber {
+			return nil, fmt.Errorf("invalid decimal value")
+		}
+		parsed, err := decimal.NewFromString(lexical)
+		if err != nil {
+			return nil, fmt.Errorf("invalid decimal value %q", lexical)
+		}
+		return parsed, nil
+	case metadata.PrimitiveTypeSingle, metadata.PrimitiveTypeDouble:
+		if !isNumber {
+			return nil, fmt.Errorf("invalid floating-point value")
+		}
+		parsed, err := strconv.ParseFloat(lexical, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid floating-point value %q", lexical)
+		}
+		return parsed, nil
+	default:
+		return value, nil
+	}
+}
+
+func parseDynamicInteger(lexical string, isNumber bool, bitSize int) (interface{}, error) {
+	if !isNumber {
+		return nil, fmt.Errorf("invalid integer value")
+	}
+	parsed, err := strconv.ParseInt(lexical, 10, bitSize)
+	if err != nil {
+		return nil, fmt.Errorf("invalid integer value %q", lexical)
+	}
+	return parsed, nil
+}
+
+func requestIEEE754Compatible(r *http.Request) bool {
+	_, parameters, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parameters["ieee754compatible"], "true")
 }
 
 // validateValueType checks if a value matches the expected reflect.Type

--- a/internal/query/apply_select.go
+++ b/internal/query/apply_select.go
@@ -295,6 +295,19 @@ func ApplySelectToEntity(entity interface{}, selectedProperties []string, entity
 	if entityValue.Kind() == reflect.Ptr {
 		entityValue = entityValue.Elem()
 	}
+	if entityValue.IsValid() && entityValue.Kind() == reflect.Map {
+		filteredEntity := make(map[string]interface{})
+		for _, prop := range entityMetadata.Properties {
+			isSelected := selectedPropMap[prop.JsonName] || selectedPropMap[prop.Name]
+			if !isSelected && !prop.IsKey {
+				continue
+			}
+			if value, ok := metadata.ReadPropertyValue(entity, prop); ok {
+				filteredEntity[prop.JsonName] = value
+			}
+		}
+		return filteredEntity
+	}
 
 	filteredEntity := make(map[string]interface{})
 

--- a/internal/query/apply_select_test.go
+++ b/internal/query/apply_select_test.go
@@ -187,6 +187,26 @@ func TestApplySelectToEntity(t *testing.T) {
 		}
 	})
 
+	t.Run("Select specific properties on map entity", func(t *testing.T) {
+		entity := map[string]interface{}{
+			"ID":          1,
+			"name":        "Product1",
+			"price":       10.5,
+			"description": "Desc1",
+		}
+		result := ApplySelectToEntity(entity, []string{"name"}, meta, nil)
+		resultMap, ok := result.(map[string]interface{})
+		if !ok {
+			t.Fatal("expected result to be map[string]interface{}")
+		}
+		if resultMap["name"] != "Product1" || resultMap["ID"] != 1 {
+			t.Fatalf("selected map = %v, want name and key", resultMap)
+		}
+		if _, ok := resultMap["price"]; ok {
+			t.Fatal("expected 'price' to NOT be in result")
+		}
+	})
+
 	t.Run("Select with navigation property", func(t *testing.T) {
 		productWithNav := selectTestProduct{
 			ID:   1,

--- a/internal/response/format_helpers.go
+++ b/internal/response/format_helpers.go
@@ -52,12 +52,23 @@ func BuildEntityIDFromEntity(entitySetName string, entity interface{}, keyProper
 		}
 
 		if len(keyProperties) == 1 {
-			return fmt.Sprintf("%s(%s)", entitySetName, formatKeyValueLiteral(value))
+			return fmt.Sprintf("%s(%s)", entitySetName, formatPropertyKeyLiteral(value, keyProp))
 		}
-		keyParts = append(keyParts, fmt.Sprintf("%s=%s", keyProp.JsonName, formatKeyValueLiteral(value)))
+		keyParts = append(keyParts, fmt.Sprintf("%s=%s", keyProp.JsonName, formatPropertyKeyLiteral(value, keyProp)))
 	}
 
 	return fmt.Sprintf("%s(%s)", entitySetName, strings.Join(keyParts, ","))
+}
+
+func formatPropertyKeyLiteral(value interface{}, property metadata.PropertyMetadata) string {
+	primitiveType, ok := property.EffectivePrimitiveType()
+	if !ok || primitiveType == metadata.PrimitiveTypeString {
+		return formatKeyValueLiteral(value)
+	}
+	if primitiveType == metadata.PrimitiveTypeDuration {
+		return fmt.Sprintf("duration'%v'", value)
+	}
+	return fmt.Sprintf("%v", value)
 }
 
 func formatKeyValueLiteral(value interface{}) string {

--- a/internal/response/format_helpers_test.go
+++ b/internal/response/format_helpers_test.go
@@ -38,6 +38,33 @@ func TestBuildEntityIDStringWithQuotes(t *testing.T) {
 	}
 }
 
+func TestBuildEntityIDFromEntityUsesEDMKeyLiterals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		primitiveType metadata.PrimitiveType
+		value         interface{}
+		want          string
+	}{
+		{name: "string", primitiveType: metadata.PrimitiveTypeString, value: "O'Brien", want: "Items('O''Brien')"},
+		{name: "guid", primitiveType: metadata.PrimitiveTypeGuid, value: "01234567-89ab-cdef-0123-456789abcdef", want: "Items(01234567-89ab-cdef-0123-456789abcdef)"},
+		{name: "date", primitiveType: metadata.PrimitiveTypeDate, value: "2026-08-30", want: "Items(2026-08-30)"},
+		{name: "duration", primitiveType: metadata.PrimitiveTypeDuration, value: "P1D", want: "Items(duration'P1D')"},
+		{name: "int64", primitiveType: metadata.PrimitiveTypeInt64, value: int64(9223372036854775807), want: "Items(9223372036854775807)"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			property := metadata.PropertyMetadata{Name: "ID", JsonName: "ID", EdmType: test.primitiveType}
+			got := BuildEntityIDFromEntity("Items", map[string]interface{}{"ID": test.value}, []metadata.PropertyMetadata{property})
+			if got != test.want {
+				t.Fatalf("BuildEntityIDFromEntity() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestFormatKeyValueLiteral(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/odata.go
+++ b/odata.go
@@ -1304,6 +1304,104 @@ func (s *Service) RegisterVirtualEntity(entity interface{}) error {
 	return nil
 }
 
+// RegisterDynamicEntity registers a primitive, map-backed entity type at runtime.
+// Registration is intended to happen during service setup, before requests are served.
+func (s *Service) RegisterDynamicEntity(definition EntityDefinition, overwrite *EntityOverwrite) error {
+	entityMetadata, err := metadata.AnalyzeEntityDefinition(definition)
+	if err != nil {
+		return fmt.Errorf("failed to analyze dynamic entity: %w", err)
+	}
+
+	if _, exists := s.entities[entityMetadata.EntitySetName]; exists {
+		return fmt.Errorf("entity set '%s' is already registered", entityMetadata.EntitySetName)
+	}
+	if _, exists := s.handlers[entityMetadata.EntitySetName]; exists {
+		return fmt.Errorf("entity handler for '%s' is already registered", entityMetadata.EntitySetName)
+	}
+	if err := validateDynamicEntityOverwrite(entityMetadata, overwrite); err != nil {
+		return err
+	}
+
+	handler := handlers.NewEntityHandlerWithStore(s.store, entityMetadata, s.logger)
+	handler.SetNamespace(s.namespace)
+	handler.SetEntitiesMetadata(s.entities)
+	handler.SetFTSManager(s.ftsManager)
+	handler.SetPolicy(s.policy)
+	handler.SetKeyGeneratorResolver(func(name string) (func(context.Context) (interface{}, error), bool) {
+		generator, ok := s.resolveKeyGenerator(name)
+		if !ok {
+			return nil, false
+		}
+		return generator, true
+	})
+	if s.defaultMaxTop != nil {
+		handler.SetDefaultMaxTop(s.defaultMaxTop)
+	}
+	if s.observability != nil {
+		handler.SetObservability(s.observability)
+	}
+	handler.SetGeospatialEnabled(atomic.LoadInt32(&s.geospatialEnabled) == 1)
+	handler.SetMaxInClauseSize(s.maxInClauseSize)
+	handler.SetMaxExpandDepth(s.maxExpandDepth)
+	if s.schemaVersion != "" {
+		handler.SetSchemaVersion(s.schemaVersion)
+	}
+	handler.SetOverwrite(overwrite)
+
+	s.entities[entityMetadata.EntitySetName] = entityMetadata
+	entityMetadata.SetEntitiesRegistry(s.entities)
+	for _, registeredMetadata := range s.entities {
+		if registeredMetadata != entityMetadata {
+			registeredMetadata.AddEntityToRegistry(entityMetadata)
+		}
+	}
+	s.handlers[entityMetadata.EntitySetName] = handler
+	s.metadataHandler.ClearCache()
+	s.serviceDocumentHandler.ClearCache()
+
+	s.logger.Debug("Registered dynamic entity",
+		"entity", entityMetadata.EntityName,
+		"entitySet", entityMetadata.EntitySetName)
+	return nil
+}
+
+func validateDynamicEntityOverwrite(entityMetadata *metadata.EntityMetadata, overwrite *EntityOverwrite) error {
+	if overwrite == nil {
+		return fmt.Errorf("dynamic entity '%s' requires overwrite handlers", entityMetadata.EntitySetName)
+	}
+
+	require := func(method, handlerName string, handlerPresent bool) error {
+		if entityMetadata.DisabledMethods[method] || handlerPresent {
+			return nil
+		}
+		return fmt.Errorf("dynamic entity '%s' requires %s when %s is enabled", entityMetadata.EntitySetName, handlerName, method)
+	}
+
+	if err := require(http.MethodGet, "GetCollection", overwrite.GetCollection != nil); err != nil {
+		return err
+	}
+	if err := require(http.MethodGet, "GetEntity", overwrite.GetEntity != nil); err != nil {
+		return err
+	}
+	if err := require(http.MethodGet, "GetCount", overwrite.GetCount != nil); err != nil {
+		return err
+	}
+	if err := require(http.MethodPost, "Create", overwrite.Create != nil); err != nil {
+		return err
+	}
+	if err := require(http.MethodPatch, "Update", overwrite.Update != nil); err != nil {
+		return err
+	}
+	if err := require(http.MethodPut, "Update", overwrite.Update != nil); err != nil {
+		return err
+	}
+	if err := require(http.MethodDelete, "Delete", overwrite.Delete != nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Types for registering custom OData actions and functions.
 //
 // The following types are re-exported from internal/actions package to provide a public API

--- a/test/dynamic_entity_test.go
+++ b/test/dynamic_entity_test.go
@@ -1,0 +1,265 @@
+package odata_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	odata "github.com/nlstn/go-odata"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newDynamicEntityService(t *testing.T) *odata.Service {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open() error = %v", err)
+	}
+	service, err := odata.NewService(db)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	return service
+}
+
+func dynamicProductDefinition(disabledMethods ...string) odata.EntityDefinition {
+	nullable := false
+	return odata.EntityDefinition{
+		Name:          "DynamicProduct",
+		EntitySetName: "DynamicProducts",
+		Properties: []odata.PropertyDefinition{
+			{Name: "ID", Type: odata.EdmInt64},
+			{Name: "Name", Type: odata.EdmString, Nullable: &nullable},
+			{Name: "Price", Type: odata.EdmDecimal},
+		},
+		Keys:            []string{"ID"},
+		DisabledMethods: disabledMethods,
+	}
+}
+
+func performDynamicRequest(service *odata.Service, method, target, body string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, target, strings.NewReader(body))
+	if body != "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response := httptest.NewRecorder()
+	service.ServeHTTP(response, request)
+	return response
+}
+
+func TestRegisterDynamicEntityPublishesReadOnlyEntityAfterCacheWarmup(t *testing.T) {
+	service := newDynamicEntityService(t)
+	performDynamicRequest(service, http.MethodGet, "/", "")
+	performDynamicRequest(service, http.MethodGet, "/$metadata", "")
+
+	row := map[string]interface{}{"ID": int64(1), "Name": "Keyboard", "Price": 99.5}
+	var collectionCalled, entityCalled, countCalled bool
+	err := service.RegisterDynamicEntity(
+		dynamicProductDefinition(http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete),
+		&odata.EntityOverwrite{
+			GetCollection: func(ctx *odata.OverwriteContext) (*odata.CollectionResult, error) {
+				collectionCalled = true
+				if ctx.QueryOptions.Top == nil || *ctx.QueryOptions.Top != 1 || !ctx.QueryOptions.Count {
+					t.Errorf("query options = %+v, want $top=1 and $count=true", ctx.QueryOptions)
+				}
+				count := int64(1)
+				return &odata.CollectionResult{Items: []map[string]interface{}{row}, Count: &count}, nil
+			},
+			GetEntity: func(ctx *odata.OverwriteContext) (interface{}, error) {
+				entityCalled = true
+				if got, ok := ctx.EntityKeyValues["ID"].(int64); !ok || got != 1 {
+					t.Errorf("ID key = %#v, want int64(1)", ctx.EntityKeyValues["ID"])
+				}
+				return row, nil
+			},
+			GetCount: func(*odata.OverwriteContext) (int64, error) {
+				countCalled = true
+				return 1, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("RegisterDynamicEntity() error = %v", err)
+	}
+
+	serviceDocument := performDynamicRequest(service, http.MethodGet, "/", "")
+	if serviceDocument.Code != http.StatusOK || !strings.Contains(serviceDocument.Body.String(), `"name":"DynamicProducts"`) {
+		t.Fatalf("service document status/body = %d %s", serviceDocument.Code, serviceDocument.Body.String())
+	}
+	metadataDocument := performDynamicRequest(service, http.MethodGet, "/$metadata", "")
+	metadataBody := metadataDocument.Body.String()
+	for _, expected := range []string{
+		`EntityType Name="DynamicProduct"`,
+		`PropertyRef Name="ID"`,
+		`Property Name="ID" Type="Edm.Int64" Nullable="false"`,
+		`Property Name="Name" Type="Edm.String" Nullable="false"`,
+		`EntitySet Name="DynamicProducts"`,
+	} {
+		if !strings.Contains(metadataBody, expected) {
+			t.Errorf("metadata does not contain %q: %s", expected, metadataBody)
+		}
+	}
+
+	collection := performDynamicRequest(service, http.MethodGet, "/DynamicProducts?$top=1&$count=true", "")
+	if collection.Code != http.StatusOK || !collectionCalled {
+		t.Fatalf("collection status = %d, called = %t, body = %s", collection.Code, collectionCalled, collection.Body.String())
+	}
+	if !strings.Contains(collection.Body.String(), `"@odata.id":"http://example.com/DynamicProducts(1)"`) {
+		t.Fatalf("collection body lacks entity ID: %s", collection.Body.String())
+	}
+
+	entity := performDynamicRequest(service, http.MethodGet, "/DynamicProducts(1)", "")
+	if entity.Code != http.StatusOK || !entityCalled {
+		t.Fatalf("entity status = %d, called = %t, body = %s", entity.Code, entityCalled, entity.Body.String())
+	}
+	count := performDynamicRequest(service, http.MethodGet, "/DynamicProducts/$count", "")
+	if count.Code != http.StatusOK || strings.TrimSpace(count.Body.String()) != "1" || !countCalled {
+		t.Fatalf("count status/body/called = %d %q %t", count.Code, count.Body.String(), countCalled)
+	}
+	entityCalled = false
+	invalidKey := performDynamicRequest(service, http.MethodGet, "/DynamicProducts(not-an-integer)", "")
+	if invalidKey.Code != http.StatusBadRequest || entityCalled {
+		t.Fatalf("invalid key status/called = %d %t, body = %s", invalidKey.Code, entityCalled, invalidKey.Body.String())
+	}
+}
+
+func TestRegisterDynamicEntitySupportsMapBackedMutations(t *testing.T) {
+	service := newDynamicEntityService(t)
+	created := false
+	updates := make([]bool, 0, 2)
+	selectSeen := false
+	deleted := false
+
+	err := service.RegisterDynamicEntity(dynamicProductDefinition(http.MethodGet), &odata.EntityOverwrite{
+		Create: func(_ *odata.OverwriteContext, entity interface{}) (interface{}, error) {
+			payload, ok := entity.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("create payload type %T", entity)
+			}
+			created = true
+			return payload, nil
+		},
+		Update: func(ctx *odata.OverwriteContext, updateData map[string]interface{}, fullReplace bool) (interface{}, error) {
+			updates = append(updates, fullReplace)
+			selectSeen = len(ctx.QueryOptions.Select) == 1 && ctx.QueryOptions.Select[0] == "Name"
+			return map[string]interface{}{"ID": int64(1), "Name": updateData["Name"], "Price": 10.5}, nil
+		},
+		Delete: func(*odata.OverwriteContext) error {
+			deleted = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterDynamicEntity() error = %v", err)
+	}
+
+	invalidCreate := performDynamicRequest(service, http.MethodPost, "/DynamicProducts", `{"ID":"invalid","Name":"Keyboard"}`)
+	if invalidCreate.Code != http.StatusBadRequest || created {
+		t.Fatalf("invalid create status/called = %d %t, body = %s", invalidCreate.Code, created, invalidCreate.Body.String())
+	}
+
+	create := performDynamicRequest(service, http.MethodPost, "/DynamicProducts", `{"ID":1,"Name":"Keyboard"}`)
+	if create.Code != http.StatusCreated || !created {
+		t.Fatalf("create status/called = %d %t, body = %s", create.Code, created, create.Body.String())
+	}
+	invalidUpdate := performDynamicRequest(service, http.MethodPatch, "/DynamicProducts(1)", `{"Price":"invalid"}`)
+	if invalidUpdate.Code != http.StatusBadRequest || len(updates) != 0 {
+		t.Fatalf("invalid update status/calls = %d %v, body = %s", invalidUpdate.Code, updates, invalidUpdate.Body.String())
+	}
+	patchRequest := httptest.NewRequest(http.MethodPatch, "/DynamicProducts(1)?$select=Name", strings.NewReader(`{"Name":"Mouse"}`))
+	patchRequest.Header.Set("Content-Type", "application/json")
+	patchRequest.Header.Set("Prefer", "return=representation")
+	patchResponse := httptest.NewRecorder()
+	service.ServeHTTP(patchResponse, patchRequest)
+	if patchResponse.Code != http.StatusOK || !selectSeen || strings.Contains(patchResponse.Body.String(), `"Price"`) {
+		t.Fatalf("projected PATCH status/select/body = %d %t %s", patchResponse.Code, selectSeen, patchResponse.Body.String())
+	}
+
+	invalidOption := performDynamicRequest(service, http.MethodPatch, "/DynamicProducts(1)?$filter=Name%20eq%20'Mouse'", `{"Name":"Mouse"}`)
+	if invalidOption.Code != http.StatusBadRequest || len(updates) != 1 {
+		t.Fatalf("invalid option status/calls = %d %v", invalidOption.Code, updates)
+	}
+
+	putResponse := performDynamicRequest(service, http.MethodPut, "/DynamicProducts(1)", `{"ID":1,"Name":"Mouse"}`)
+	if putResponse.Code != http.StatusOK && putResponse.Code != http.StatusNoContent {
+		t.Fatalf("PUT status = %d, body = %s", putResponse.Code, putResponse.Body.String())
+	}
+	if len(updates) != 2 || updates[0] || !updates[1] {
+		t.Fatalf("update full-replace flags = %v, want [false true]", updates)
+	}
+	deleteResponse := performDynamicRequest(service, http.MethodDelete, "/DynamicProducts(1)", "")
+	if deleteResponse.Code != http.StatusNoContent || !deleted {
+		t.Fatalf("delete status/called = %d %t", deleteResponse.Code, deleted)
+	}
+}
+
+func TestRegisterDynamicEntityPreservesNumericPayloads(t *testing.T) {
+	service := newDynamicEntityService(t)
+	var captured map[string]interface{}
+	err := service.RegisterDynamicEntity(dynamicProductDefinition(http.MethodGet, http.MethodPatch, http.MethodPut, http.MethodDelete), &odata.EntityOverwrite{
+		Create: func(_ *odata.OverwriteContext, entity interface{}) (interface{}, error) {
+			captured = entity.(map[string]interface{})
+			return captured, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterDynamicEntity() error = %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/DynamicProducts", strings.NewReader(`{"ID":"9223372036854775807","Name":"Keyboard","Price":"1234567890.123456789"}`))
+	request.Header.Set("Content-Type", "application/json;IEEE754Compatible=true")
+	response := httptest.NewRecorder()
+	service.ServeHTTP(response, request)
+
+	if response.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if id, ok := captured["ID"].(int64); !ok || id != int64(9223372036854775807) {
+		t.Fatalf("ID = %#v, want exact max int64", captured["ID"])
+	}
+	if got := fmt.Sprint(captured["Price"]); got != "1234567890.123456789" {
+		t.Fatalf("Price = %q, want exact decimal", got)
+	}
+	if got := response.Header().Get("Location"); got != "http://example.com/DynamicProducts(9223372036854775807)" {
+		t.Fatalf("Location = %q", got)
+	}
+
+	invalid := performDynamicRequest(service, http.MethodPost, "/DynamicProducts", `{"ID":1.5,"Name":"Keyboard"}`)
+	if invalid.Code != http.StatusBadRequest {
+		t.Fatalf("fractional Int64 status = %d, want %d", invalid.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRegisterDynamicEntityRejectsIncompleteCallbacksAtomically(t *testing.T) {
+	service := newDynamicEntityService(t)
+	err := service.RegisterDynamicEntity(
+		dynamicProductDefinition(http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete),
+		&odata.EntityOverwrite{
+			GetCollection: func(*odata.OverwriteContext) (*odata.CollectionResult, error) {
+				return &odata.CollectionResult{Items: []map[string]interface{}{}}, nil
+			},
+			GetEntity: func(*odata.OverwriteContext) (interface{}, error) { return nil, nil },
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "requires GetCount") {
+		t.Fatalf("RegisterDynamicEntity() error = %v, want missing GetCount", err)
+	}
+
+	response := performDynamicRequest(service, http.MethodGet, "/DynamicProducts", "")
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("failed registration route status = %d, want %d", response.Code, http.StatusNotFound)
+	}
+	serviceDocument := performDynamicRequest(service, http.MethodGet, "/", "")
+	body, readErr := io.ReadAll(serviceDocument.Body)
+	if readErr != nil {
+		t.Fatalf("ReadAll() error = %v", readErr)
+	}
+	if bytes.Contains(body, []byte("DynamicProducts")) {
+		t.Fatalf("failed registration leaked into service document: %s", body)
+	}
+}

--- a/test/odata_entityid_header_test.go
+++ b/test/odata_entityid_header_test.go
@@ -87,9 +87,8 @@ func TestODataEntityIdHeader_POST(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	// Per OData v4.01 spec, POST with return=minimal should return 201 Created with empty body
-	if w.Code != http.StatusCreated {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
 	}
 
 	// Check OData-EntityId header is present
@@ -132,9 +131,8 @@ func TestODataEntityIdHeader_POST_CompositeKey(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	// Per OData v4.01 spec, POST with return=minimal should return 201 Created with empty body
-	if w.Code != http.StatusCreated {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
 	}
 
 	// Check OData-EntityId header is present

--- a/test/odata_entityid_header_test.go
+++ b/test/odata_entityid_header_test.go
@@ -87,8 +87,8 @@ func TestODataEntityIdHeader_POST(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
+	if w.Code != http.StatusCreated {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
 	}
 
 	// Check OData-EntityId header is present
@@ -131,8 +131,8 @@ func TestODataEntityIdHeader_POST_CompositeKey(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
+	if w.Code != http.StatusCreated {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
 	}
 
 	// Check OData-EntityId header is present

--- a/test/odata_header_capitalization_test.go
+++ b/test/odata_header_capitalization_test.go
@@ -107,7 +107,7 @@ func TestODataHeaderExactCapitalization(t *testing.T) {
 			path:           "/HeaderCapTestProducts",
 			body:           map[string]interface{}{"name": "New Product", "price": 49.99},
 			headers:        map[string]string{"Prefer": "return=minimal"},
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusNoContent,
 			checkVersion:   true,
 			checkEntityId:  true,
 		},

--- a/test/odata_header_capitalization_test.go
+++ b/test/odata_header_capitalization_test.go
@@ -107,7 +107,7 @@ func TestODataHeaderExactCapitalization(t *testing.T) {
 			path:           "/HeaderCapTestProducts",
 			body:           map[string]interface{}{"name": "New Product", "price": 49.99},
 			headers:        map[string]string{"Prefer": "return=minimal"},
-			expectedStatus: http.StatusNoContent,
+			expectedStatus: http.StatusCreated,
 			checkVersion:   true,
 			checkEntityId:  true,
 		},

--- a/test/prefer_test.go
+++ b/test/prefer_test.go
@@ -110,8 +110,8 @@ func TestPostEntity_PreferReturnMinimal(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
+	if w.Code != http.StatusCreated {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
 	}
 
 	// Verify Preference-Applied header is present
@@ -396,8 +396,8 @@ func TestPreferHeader_CaseInsensitive(t *testing.T) {
 
 		service.ServeHTTP(w, req)
 
-		if w.Code != http.StatusNoContent {
-			t.Errorf("For Prefer header '%s', Status = %v, want %v", preferValue, w.Code, http.StatusNoContent)
+		if w.Code != http.StatusCreated {
+			t.Errorf("For Prefer header '%s', Status = %v, want %v", preferValue, w.Code, http.StatusCreated)
 		}
 	}
 }
@@ -452,8 +452,8 @@ func TestPreferHeader_MultiplePreferences(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
+	if w.Code != http.StatusCreated {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
 	}
 
 	preferenceApplied := w.Header().Get("Preference-Applied")

--- a/test/prefer_test.go
+++ b/test/prefer_test.go
@@ -110,9 +110,8 @@ func TestPostEntity_PreferReturnMinimal(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	// Per OData v4.01 spec, POST with return=minimal should return 201 Created with empty body
-	if w.Code != http.StatusCreated {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
 	}
 
 	// Verify Preference-Applied header is present
@@ -397,9 +396,8 @@ func TestPreferHeader_CaseInsensitive(t *testing.T) {
 
 		service.ServeHTTP(w, req)
 
-		// Per OData v4.01 spec, POST with return=minimal should return 201 Created
-		if w.Code != http.StatusCreated {
-			t.Errorf("For Prefer header '%s', Status = %v, want %v", preferValue, w.Code, http.StatusCreated)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("For Prefer header '%s', Status = %v, want %v", preferValue, w.Code, http.StatusNoContent)
 		}
 	}
 }
@@ -454,9 +452,8 @@ func TestPreferHeader_MultiplePreferences(t *testing.T) {
 
 	service.ServeHTTP(w, req)
 
-	// Per OData v4.01 spec, POST with return=minimal should return 201 Created
-	if w.Code != http.StatusCreated {
-		t.Errorf("Status = %v, want %v", w.Code, http.StatusCreated)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Status = %v, want %v", w.Code, http.StatusNoContent)
 	}
 
 	preferenceApplied := w.Header().Get("Preference-Applied")


### PR DESCRIPTION
Implement startup-time registration of primitive OData entity schemas without static Go structs.

- add atomic `Service.RegisterDynamicEntity` registration backed by existing overwrite callbacks
- require callbacks for each enabled HTTP operation and avoid publishing incomplete entities
- expose dynamic entities through the service document, CSDL metadata, routing, query parsing, authorization, and top-level CRUD
- preserve exact `Edm.Int64` and `Edm.Decimal` request values, including `IEEE754Compatible=true`
- validate typed payloads and URI keys before callbacks run
- generate canonical IDs using declared EDM key types and preserve composite-key order
- support `$select` projection for map-backed modification responses
- correct POST `return=minimal` responses to OData-required `204 No Content`
- document the startup-only API, callback contract, and current feature boundaries

Closes #892.